### PR TITLE
feat(scripts): add launch-stub.sh dry-run preview

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: chmod scripts/check.sh
-        run: chmod +x scripts/check.sh
+      - name: chmod scripts
+        run: |
+          chmod +x scripts/check.sh
+          [ -f scripts/launch-stub.sh ] && chmod +x scripts/launch-stub.sh || true
       - name: run scripts/check.sh
         run: ./scripts/check.sh
+      - name: run scripts/launch-stub.sh (preview only)
+        run: |
+          if [ -x scripts/launch-stub.sh ]; then
+            ./scripts/launch-stub.sh
+          else
+            echo "scripts/launch-stub.sh not present; skipping"
+          fi

--- a/README.md
+++ b/README.md
@@ -83,6 +83,17 @@ does not claim that the launcher path is wired up — it is a probe.
 bash scripts/check.sh
 ```
 
+A second helper, [`scripts/launch-stub.sh`](./scripts/launch-stub.sh),
+prints a dry-run preview of the *intended* launch sequence (host check,
+target binding, model selection, log surfacing). It does **not** run
+inference, does **not** open a model, and does **not** contact a target
+device — it is a planning preview that will be replaced when the real
+launch path is wired up after the PCCX FPGA bring-up evidence lands.
+
+```bash
+bash scripts/launch-stub.sh
+```
+
 The legacy launcher scripts from the `llm-lite` era are preserved
 read-only under [`scripts/legacy/`](./scripts/legacy/) as historical
 reference (see that directory's README for status).

--- a/scripts/launch-stub.sh
+++ b/scripts/launch-stub.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# scripts/launch-stub.sh — dry-run preview of the *intended* launcher
+# sequence. This script does NOT run inference, does NOT open a model,
+# and does NOT talk to a target device. It only describes what the
+# launcher will eventually do, in order, so contributors can see the
+# planned shape before any of it is wired up.
+#
+# Hardware readiness (KV260 / Gemma 3N E4B) is gated on
+# pccxai/pccx-FPGA-NPU-LLM-kv260 publishing verified bring-up
+# evidence. Until that lands, this stub stays as a description.
+#
+# Always exits 0 (preview-only).
+
+set -u
+
+INFO()  { printf '[INFO]  %s\n' "$*"; }
+NOTE()  { printf '[NOTE]  %s\n' "$*"; }
+HEAD()  { printf '\n=== %s ===\n' "$*"; }
+
+HEAD "host"
+INFO "uname -s : $(uname -s)"
+INFO "uname -m : $(uname -m)"
+if [ -r /etc/os-release ]; then
+    INFO "$(grep -E '^(NAME|VERSION)=' /etc/os-release | tr '\n' ' ')"
+fi
+
+HEAD "tooling availability"
+for cmd in bash python3 cmake g++ git curl; do
+    if command -v "$cmd" >/dev/null 2>&1; then
+        INFO "$cmd : $(command -v "$cmd")"
+    else
+        NOTE "$cmd : not installed (the eventual launcher may need this)"
+    fi
+done
+
+HEAD "target / device hint"
+INFO "target platform (planned) : Xilinx Kria KV260"
+INFO "target model (planned)    : Gemma 3N E4B"
+if [ -r /proc/device-tree/model ]; then
+    MODEL="$(tr -d '\0' < /proc/device-tree/model 2>/dev/null || true)"
+    INFO "device-tree model        : ${MODEL:-unknown}"
+else
+    NOTE "device-tree model        : not readable on this host"
+fi
+
+HEAD "planned launch sequence (preview only)"
+cat <<'STEPS'
+The launcher, once a real engine is wired up, is intended to perform:
+
+  1. Verify host / device prerequisites.
+  2. Bind to the target device (via the verified bring-up path supplied
+     by pccxai/pccx-FPGA-NPU-LLM-kv260, after that work lands).
+  3. Pick a target model (initially Gemma 3N E4B) and a precision mode.
+  4. Hand control to a launch backend that drives the actual inference.
+  5. Surface logs and diagnostics via pccx-lab integration so device /
+     kernel state is visible from the launcher UI.
+
+None of these steps are executed by this script.
+STEPS
+
+HEAD "gating dependencies"
+NOTE "Step 2 (device binding)    requires pccx-FPGA bring-up evidence."
+NOTE "Step 4 (launch backend)    requires that bring-up plus a launcher engine."
+NOTE "Step 5 (diagnostics)       requires pccx-lab CLI / core boundary integration."
+
+HEAD "summary"
+INFO "preview complete; no inference was started, no device was contacted"
+exit 0


### PR DESCRIPTION
## Goal

Add a preview-only \`launch-stub.sh\` so contributors can see the shape
of the intended launch sequence, without claiming any of it is wired up.

## What changes

**scripts/launch-stub.sh** (new, executable)
- Reports host / tooling / device-tree hints (same probe surface as
  \`scripts/check.sh\`).
- Prints the *planned* 5-step launch sequence: host check, device
  binding, model selection, launch backend, diagnostics surfacing.
- Lists the gating dependencies (pccx-FPGA bring-up evidence,
  launcher engine, pccx-lab CLI / core boundary integration).
- Always exits 0. Does **not** run inference, does **not** open a
  model, does **not** contact a target device.

**.github/workflows/ci.yml**
- \`check-script-runs\` job now also executes \`scripts/launch-stub.sh\`
  to make sure it stays runnable and honest.
- \`shell-lint\` already covers any new \`scripts/*.sh\` that isn't a
  \`.snapshot\`, so the new stub is linted automatically.

**README.md**
- Adds a short Quick check note pointing at \`launch-stub.sh\` with the
  same planning-preview framing used elsewhere in the repo.

## What this PR does NOT do

- No real launcher engine, no model loading, no device interaction.
- No release / tag.
- No staging repo activity.
- KV260 / Gemma 3N E4B remain *target* paths, not current capabilities.
- Hardware readiness still gated on
  \`pccxai/pccx-FPGA-NPU-LLM-kv260\` bring-up evidence.

## Validation

- Local \`bash scripts/launch-stub.sh\` run: clean output, exit 0.
- Negation-aware claim scan: clean.
- shellcheck PASS expected once CI runs.