### PR TITLE
feat: add launcher check stubs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,10 +92,28 @@ jobs:
       - uses: actions/checkout@v4
       - name: chmod scripts
         run: |
-          chmod +x scripts/check.sh
-          [ -f scripts/launch-stub.sh ] && chmod +x scripts/launch-stub.sh || true
+          for f in scripts/check.sh \
+                   scripts/check-device-stub.sh \
+                   scripts/install-stub.sh \
+                   scripts/launch-stub.sh; do
+            [ -f "$f" ] && chmod +x "$f" || true
+          done
       - name: run scripts/check.sh
         run: ./scripts/check.sh
+      - name: run scripts/check-device-stub.sh
+        run: |
+          if [ -x scripts/check-device-stub.sh ]; then
+            ./scripts/check-device-stub.sh
+          else
+            echo "scripts/check-device-stub.sh not present; skipping"
+          fi
+      - name: run scripts/install-stub.sh (preview only)
+        run: |
+          if [ -x scripts/install-stub.sh ]; then
+            ./scripts/install-stub.sh
+          else
+            echo "scripts/install-stub.sh not present; skipping"
+          fi
       - name: run scripts/launch-stub.sh (preview only)
         run: |
           if [ -x scripts/launch-stub.sh ]; then

--- a/README.md
+++ b/README.md
@@ -72,27 +72,30 @@ evidence lands.
 - No kernel development requirement for normal users.
 - This repo is not labelled as stable or as ready for unattended use.
 
-## Quick check
+## Usage
 
-A minimal probe script lives at [`scripts/check.sh`](./scripts/check.sh).
-It reports host info, available tooling, and any edge-device hints from
-`/proc/device-tree/model`. It does **not** attempt to run inference and
-does not claim that the launcher path is wired up — it is a probe.
+The current scripts are all **probe / preview** helpers — none of them
+runs inference, contacts a remote device, or installs anything. They
+exist so contributors can see the planned shape of the launcher flow
+and verify host-side prerequisites before the real engine lands.
+
+| Script | What it does |
+|---|---|
+| [`scripts/check.sh`](./scripts/check.sh) | Probe host info, tooling availability, edge-device hints. |
+| [`scripts/check-device-stub.sh`](./scripts/check-device-stub.sh) | Narrowly scoped device-tree / FPGA-node probe (KV260 / Kria detection only). |
+| [`scripts/install-stub.sh`](./scripts/install-stub.sh) | Preview of the planned install flow; reports which host runtime pieces are present, lists device-side pieces as future deliverables. |
+| [`scripts/launch-stub.sh`](./scripts/launch-stub.sh) | Dry-run preview of the intended launch sequence (host check → device bind → model pick → handoff → diagnostics). |
 
 ```bash
 bash scripts/check.sh
-```
-
-A second helper, [`scripts/launch-stub.sh`](./scripts/launch-stub.sh),
-prints a dry-run preview of the *intended* launch sequence (host check,
-target binding, model selection, log surfacing). It does **not** run
-inference, does **not** open a model, and does **not** contact a target
-device — it is a planning preview that will be replaced when the real
-launch path is wired up after the PCCX FPGA bring-up evidence lands.
-
-```bash
+bash scripts/check-device-stub.sh
+bash scripts/install-stub.sh
 bash scripts/launch-stub.sh
 ```
+
+All four are exit-0 by design. They will be replaced by real
+implementations only after `pccxai/pccx-FPGA-NPU-LLM-kv260` publishes
+verified bring-up evidence.
 
 The legacy launcher scripts from the `llm-lite` era are preserved
 read-only under [`scripts/legacy/`](./scripts/legacy/) as historical

--- a/scripts/check-device-stub.sh
+++ b/scripts/check-device-stub.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# scripts/check-device-stub.sh — narrowly-scoped device probe.
+#
+# A focused complement to scripts/check.sh: this stub only inspects what
+# is reachable from the host and prints which target-device facts would
+# matter once the launcher engine is wired up. It does NOT contact a
+# remote device, does NOT flash anything, and does NOT claim that any
+# device path is functional.
+#
+# KV260 / Kria detection is best-effort; on x86_64 hosts the device-tree
+# model file is usually missing and that is expected.
+#
+# Always exits 0 (probe-only).
+
+set -u
+
+INFO()  { printf '[INFO]  %s\n' "$*"; }
+NOTE()  { printf '[NOTE]  %s\n' "$*"; }
+HEAD()  { printf '\n=== %s ===\n' "$*"; }
+
+HEAD "device-tree probe"
+if [ -r /proc/device-tree/model ]; then
+    MODEL="$(tr -d '\0' < /proc/device-tree/model 2>/dev/null || true)"
+    INFO "model           : ${MODEL:-unknown}"
+    case "$MODEL" in
+        *KV260*|*Kria*)
+            INFO "platform class  : Kria-class (matches the planned target)"
+            ;;
+        *)
+            NOTE "platform class  : not a Kria-class device"
+            ;;
+    esac
+else
+    NOTE "model           : /proc/device-tree/model not readable (expected on most x86_64 hosts)"
+fi
+
+HEAD "FPGA / accel hints"
+for path in /dev/xdma0 /dev/xdma /dev/zynqmp /sys/class/fpga_manager; do
+    if [ -e "$path" ]; then
+        INFO "$path : present"
+    else
+        NOTE "$path : absent (expected on a non-target host)"
+    fi
+done
+
+HEAD "summary"
+NOTE "this script is a probe; it does not configure or contact any device"
+NOTE "KV260 bring-up evidence comes from pccxai/pccx-FPGA-NPU-LLM-kv260"
+exit 0

--- a/scripts/install-stub.sh
+++ b/scripts/install-stub.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# scripts/install-stub.sh — preview of the *intended* install flow.
+#
+# This script does NOT install anything. It only describes which package
+# / runtime / device pieces the eventual launcher install path will need
+# and reports which of them are already available on the current host.
+#
+# Real installation is gated on KV260 bring-up evidence from
+# pccxai/pccx-FPGA-NPU-LLM-kv260. Until that lands, we keep the install
+# path honest as a preview.
+#
+# Always exits 0 (preview-only).
+
+set -u
+
+INFO()  { printf '[INFO]  %s\n' "$*"; }
+NOTE()  { printf '[NOTE]  %s\n' "$*"; }
+HEAD()  { printf '\n=== %s ===\n' "$*"; }
+
+HEAD "host runtime requirements (planned)"
+have_count=0
+miss_count=0
+for cmd in bash python3 git curl tar; do
+    if command -v "$cmd" >/dev/null 2>&1; then
+        INFO "$cmd : present ($(command -v "$cmd"))"
+        have_count=$((have_count + 1))
+    else
+        NOTE "$cmd : missing — install via the host package manager before launcher work"
+        miss_count=$((miss_count + 1))
+    fi
+done
+
+HEAD "device-side requirements (target / future)"
+NOTE "KV260 bitstream / overlay : provided later by pccxai/pccx-FPGA-NPU-LLM-kv260"
+NOTE "kernel / driver           : provided later by pccxai/pccx-FPGA-NPU-LLM-kv260"
+NOTE "model artifact            : Gemma 3N E4B is a target, not bundled here"
+
+HEAD "pccx-lab integration (target / future)"
+NOTE "diagnostics integration   : depends on pccx-lab CLI / core boundary"
+NOTE "trace surfacing           : same dependency"
+
+HEAD "summary"
+INFO "host runtime present : ${have_count}"
+INFO "host runtime missing : ${miss_count}"
+NOTE "this script is a preview; it has not installed anything"
+exit 0


### PR DESCRIPTION
## Summary

- Add two narrowly-scoped probe / preview stubs that cover the device-side and install-side gaps in the existing scripts:
  - `scripts/check-device-stub.sh` — focused device-tree / FPGA-node probe (KV260 / Kria detection only). Probe-only.
  - `scripts/install-stub.sh` — preview of the planned install flow; reports host runtime presence and lists device-side pieces as future deliverables.
- Replace the README's *Quick check* prose with a *Usage* table covering all four scripts (`check`, `check-device-stub`, `install-stub`, `launch-stub`) so contributors see the planned shape at a glance.
- Wire the two new stubs into `check-script-runs` CI alongside the existing `check.sh` and `launch-stub.sh`.

All four scripts remain probe / preview only — none of them runs inference, contacts a remote device, or installs anything. The launcher engine is still gated on KV260 bring-up evidence from `pccxai/pccx-FPGA-NPU-LLM-kv260`.

## Test plan

- [x] `bash scripts/check-device-stub.sh` runs locally and exits 0.
- [x] `bash scripts/install-stub.sh` runs locally and exits 0.
- [x] `bash -n` syntax check passes on both new scripts.
- [x] Local pre-flight of the `claim-scan` regex — 0 violations.
- [ ] CI: `shell-lint`, `claim-scan`, and `check-script-runs` green on this PR.