### PR TITLE
feat(scripts): add status-stub, chat-stub, guard launch-stub with --dry-run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,9 @@ jobs:
           for f in scripts/check.sh \
                    scripts/check-device-stub.sh \
                    scripts/install-stub.sh \
-                   scripts/launch-stub.sh; do
+                   scripts/launch-stub.sh \
+                   scripts/status-stub.sh \
+                   scripts/chat-stub.sh; do
             [ -f "$f" ] && chmod +x "$f" || true
           done
       - name: run scripts/check.sh
@@ -114,10 +116,25 @@ jobs:
           else
             echo "scripts/install-stub.sh not present; skipping"
           fi
-      - name: run scripts/launch-stub.sh (preview only)
+      - name: run scripts/launch-stub.sh (dry-run)
+        run: ./scripts/launch-stub.sh --dry-run
+      - name: launch-stub refuses without --dry-run
         run: |
-          if [ -x scripts/launch-stub.sh ]; then
-            ./scripts/launch-stub.sh
-          else
-            echo "scripts/launch-stub.sh not present; skipping"
+          set -e
+          if ./scripts/launch-stub.sh; then
+            echo "::error::expected non-zero exit without --dry-run"
+            exit 1
           fi
+          echo "launch-stub correctly refused without --dry-run"
+      - name: run scripts/status-stub.sh
+        run: ./scripts/status-stub.sh
+      - name: run scripts/chat-stub.sh --dry-run
+        run: ./scripts/chat-stub.sh --dry-run --prompt "hello"
+      - name: chat-stub refuses without --dry-run
+        run: |
+          set -e
+          if ./scripts/chat-stub.sh --prompt "hello"; then
+            echo "::error::expected non-zero exit without --dry-run"
+            exit 1
+          fi
+          echo "chat-stub correctly refused without --dry-run"

--- a/README.md
+++ b/README.md
@@ -81,21 +81,26 @@ and verify host-side prerequisites before the real engine lands.
 
 | Script | What it does |
 |---|---|
-| [`scripts/check.sh`](./scripts/check.sh) | Probe host info, tooling availability, edge-device hints. |
-| [`scripts/check-device-stub.sh`](./scripts/check-device-stub.sh) | Narrowly scoped device-tree / FPGA-node probe (KV260 / Kria detection only). |
-| [`scripts/install-stub.sh`](./scripts/install-stub.sh) | Preview of the planned install flow; reports which host runtime pieces are present, lists device-side pieces as future deliverables. |
-| [`scripts/launch-stub.sh`](./scripts/launch-stub.sh) | Dry-run preview of the intended launch sequence (host check → device bind → model pick → handoff → diagnostics). |
+| [`scripts/check.sh`](./scripts/check.sh) | Probe host info, tooling availability, edge-device hints. Always exits 0. |
+| [`scripts/check-device-stub.sh`](./scripts/check-device-stub.sh) | Narrowly scoped device-tree / FPGA-node probe (KV260 / Kria detection only). Always exits 0. |
+| [`scripts/install-stub.sh`](./scripts/install-stub.sh) | Preview of the planned install flow; reports which host runtime pieces are present, lists device-side pieces as future deliverables. Always exits 0. |
+| [`scripts/status-stub.sh`](./scripts/status-stub.sh) | Launcher state summary — what is wired up, what is deferred, what is gated. Always exits 0. |
+| [`scripts/launch-stub.sh`](./scripts/launch-stub.sh) | Dry-run preview of the intended launch sequence. Requires `--dry-run`; exits 1 without it. |
+| [`scripts/chat-stub.sh`](./scripts/chat-stub.sh) | Dry-run chat stub. Requires `--dry-run`; exits 1 without it. Accepts `--prompt "..."` or stdin. No model is executed. |
 
 ```bash
 bash scripts/check.sh
 bash scripts/check-device-stub.sh
 bash scripts/install-stub.sh
-bash scripts/launch-stub.sh
+bash scripts/status-stub.sh
+bash scripts/launch-stub.sh --dry-run
+bash scripts/chat-stub.sh --dry-run --prompt "hello"
 ```
 
-All four are exit-0 by design. They will be replaced by real
-implementations only after `pccxai/pccx-FPGA-NPU-LLM-kv260` publishes
-verified bring-up evidence.
+The `--dry-run` scripts exit 1 without the flag as a deliberate guard —
+there is no real inference engine to hand off to. They will be replaced
+by real implementations only after `pccxai/pccx-FPGA-NPU-LLM-kv260`
+publishes verified bring-up evidence.
 
 The legacy launcher scripts from the `llm-lite` era are preserved
 read-only under [`scripts/legacy/`](./scripts/legacy/) as historical

--- a/scripts/chat-stub.sh
+++ b/scripts/chat-stub.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# scripts/chat-stub.sh — dry-run chat stub
+# Requires --dry-run. No model is executed. No network call is made.
+# Accepts a prompt via --prompt "..." or stdin.
+
+set -u
+
+INFO() { printf '[INFO]  %s\n' "$*"; }
+NOTE() { printf '[NOTE]  %s\n' "$*"; }
+HEAD() { printf '\n=== %s ===\n' "$*"; }
+
+DRY_RUN=0
+PROMPT=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --dry-run)
+            DRY_RUN=1
+            shift
+            ;;
+        --prompt)
+            PROMPT="$2"
+            shift 2
+            ;;
+        *)
+            printf '[ERROR] unknown option: %s\n' "$1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [ "$DRY_RUN" -eq 0 ]; then
+    printf '[ERROR] --dry-run is required. No model is available for execution.\n' >&2
+    printf '        Real chat requires pccx-FPGA verified bring-up.\n' >&2
+    exit 1
+fi
+
+if [ -z "$PROMPT" ] && [ -t 0 ]; then
+    printf '[ERROR] provide --prompt "..." or pipe input via stdin.\n' >&2
+    exit 1
+fi
+
+if [ -z "$PROMPT" ]; then
+    PROMPT="$(cat)"
+fi
+
+HEAD "pccx-launcher chat-stub | dry-run"
+INFO "prompt   : ${PROMPT}"
+NOTE "no model executed"
+NOTE "no network call made"
+NOTE "response : [placeholder — real inference requires pccx-FPGA bring-up evidence]"
+exit 0

--- a/scripts/launch-stub.sh
+++ b/scripts/launch-stub.sh
@@ -9,13 +9,27 @@
 # pccxai/pccx-FPGA-NPU-LLM-kv260 publishing verified bring-up
 # evidence. Until that lands, this stub stays as a description.
 #
-# Always exits 0 (preview-only).
+# Requires --dry-run. Exits 1 without it.
 
 set -u
 
 INFO()  { printf '[INFO]  %s\n' "$*"; }
 NOTE()  { printf '[NOTE]  %s\n' "$*"; }
 HEAD()  { printf '\n=== %s ===\n' "$*"; }
+
+DRY_RUN=0
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --dry-run) DRY_RUN=1; shift ;;
+        *) printf '[ERROR] unknown option: %s\n' "$1" >&2; exit 1 ;;
+    esac
+done
+
+if [ "$DRY_RUN" -eq 0 ]; then
+    printf '[ERROR] --dry-run is required. This stub does not execute a real launch.\n' >&2
+    printf '        Pass --dry-run to see the planned launch sequence preview.\n' >&2
+    exit 1
+fi
 
 HEAD "host"
 INFO "uname -s : $(uname -s)"
@@ -64,5 +78,5 @@ NOTE "Step 4 (launch backend)    requires that bring-up plus a launcher engine."
 NOTE "Step 5 (diagnostics)       requires pccx-lab CLI / core boundary integration."
 
 HEAD "summary"
-INFO "preview complete; no inference was started, no device was contacted"
+INFO "dry-run preview complete; no inference was started, no device was contacted"
 exit 0

--- a/scripts/status-stub.sh
+++ b/scripts/status-stub.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# scripts/status-stub.sh — launcher state summary
+# Reports what is and is not wired up in this planning skeleton.
+# Does not probe hardware. Does not start inference. Always exits 0.
+
+set -u
+
+INFO() { printf '[INFO]  %s\n' "$*"; }
+NOTE() { printf '[NOTE]  %s\n' "$*"; }
+HEAD() { printf '\n=== %s ===\n' "$*"; }
+
+HEAD "launcher state"
+NOTE "chat-stub      : available (dry-run only; see scripts/chat-stub.sh)"
+NOTE "launch-stub    : available (dry-run only; --dry-run flag required)"
+NOTE "inference path : not active"
+NOTE "KV260 path     : gated on pccxai/pccx-FPGA-NPU-LLM-kv260 bring-up"
+NOTE "pccx-lab diag  : deferred (depends on pccx-lab CLI/core boundary)"
+NOTE "editor bridge  : planned (VS Code / other IDEs)"
+
+HEAD "summary"
+INFO "no inference engine is wired up; all paths are planned or deferred"
+exit 0


### PR DESCRIPTION
## Summary

- Add `scripts/status-stub.sh` — launcher state summary (exits 0, no hardware probe)
- Add `scripts/chat-stub.sh` — deterministic placeholder chat; requires `--dry-run`, exits 1 without it; accepts `--prompt "..."` or stdin
- `scripts/launch-stub.sh` now requires `--dry-run`; exits 1 with a clear message otherwise

## CI changes

- `launch-stub` CI step updated to pass `--dry-run`
- New refusal-test step verifies `launch-stub` exits 1 without the flag
- New steps smoke-run `status-stub` and `chat-stub --dry-run`
- New refusal-test step verifies `chat-stub` exits 1 without `--dry-run`

## Test plan

- [ ] CI passes (shell-lint, claim-scan, check-script-runs)
- [ ] `launch-stub` refusal step exits non-zero without `--dry-run`
- [ ] `chat-stub` refusal step exits non-zero without `--dry-run`
- [ ] `status-stub` smoke step exits 0