### PR TITLE
feat: add pccx-lab status handoff backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,3 +138,22 @@ jobs:
             exit 1
           fi
           echo "chat-stub correctly refused without --dry-run"
+
+  status-backend:
+    name: status-backend-tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: chmod scripts
+        run: |
+          chmod +x scripts/status-stub.sh
+          chmod +x scripts/chat-stub.sh
+          chmod +x scripts/launch-stub.sh
+          chmod +x scripts/tests/status-backend.sh
+      - name: shellcheck status-stub and test script
+        run: |
+          sudo apt-get update -q && sudo apt-get install -y -q shellcheck
+          shellcheck scripts/status-stub.sh
+          shellcheck scripts/tests/status-backend.sh
+      - name: run status-backend tests
+        run: bash scripts/tests/status-backend.sh scripts/status-stub.sh

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ and verify host-side prerequisites before the real engine lands.
 | [`scripts/check.sh`](./scripts/check.sh) | Probe host info, tooling availability, edge-device hints. Always exits 0. |
 | [`scripts/check-device-stub.sh`](./scripts/check-device-stub.sh) | Narrowly scoped device-tree / FPGA-node probe (KV260 / Kria detection only). Always exits 0. |
 | [`scripts/install-stub.sh`](./scripts/install-stub.sh) | Preview of the planned install flow; reports which host runtime pieces are present, lists device-side pieces as future deliverables. Always exits 0. |
-| [`scripts/status-stub.sh`](./scripts/status-stub.sh) | Launcher state summary — what is wired up, what is deferred, what is gated. Always exits 0. |
+| [`scripts/status-stub.sh`](./scripts/status-stub.sh) | Launcher state summary. Default mode: local scaffold output, always exits 0. With `--backend pccx-lab`, calls `pccx-lab status --format json` and forwards the run-status envelope (exits non-zero if binary is missing or output is invalid). |
 | [`scripts/launch-stub.sh`](./scripts/launch-stub.sh) | Dry-run preview of the intended launch sequence. Requires `--dry-run`; exits 1 without it. |
 | [`scripts/chat-stub.sh`](./scripts/chat-stub.sh) | Dry-run chat stub. Requires `--dry-run`; exits 1 without it. Accepts `--prompt "..."` or stdin. No model is executed. |
 
@@ -101,6 +101,34 @@ The `--dry-run` scripts exit 1 without the flag as a deliberate guard —
 there is no real inference engine to hand off to. They will be replaced
 by real implementations only after `pccxai/pccx-FPGA-NPU-LLM-kv260`
 publishes verified bring-up evidence.
+
+### pccx-lab status backend (opt-in)
+
+`scripts/status-stub.sh` can call the `pccx-lab status --format json`
+controlled CLI/core boundary and forward the run-status envelope:
+
+```bash
+# Requires pccx-lab binary on PATH or PCCX_LAB_BIN set.
+bash scripts/status-stub.sh --backend pccx-lab
+
+# Point to a specific build:
+PCCX_LAB_BIN=/path/to/pccx-lab bash scripts/status-stub.sh --backend pccx-lab
+```
+
+Binary resolution order:
+
+1. `PCCX_LAB_BIN` environment variable (if non-empty and executable).
+2. `pccx-lab` on `PATH`.
+
+**No silent fallback.** If `--backend pccx-lab` is explicitly requested
+but the binary is not found or returns an error, the script exits
+non-zero with a clear message. It does not fall back to local scaffold
+output.
+
+The pccx-lab status output is an early, pre-stable run-status envelope.
+It operates in host-dry-run mode: no real KV260 device probing is
+performed, no model is executed, and no inference is started. This is a
+planned KV260-oriented launcher path, not a production-ready claim.
 
 The legacy launcher scripts from the `llm-lite` era are preserved
 read-only under [`scripts/legacy/`](./scripts/legacy/) as historical

--- a/scripts/status-stub.sh
+++ b/scripts/status-stub.sh
@@ -1,22 +1,109 @@
 #!/usr/bin/env bash
 # scripts/status-stub.sh — launcher state summary
-# Reports what is and is not wired up in this planning skeleton.
-# Does not probe hardware. Does not start inference. Always exits 0.
+# Default mode: local scaffold output, no external calls, always exits 0.
+#
+# pccx-lab backend (explicit opt-in):
+#   --backend pccx-lab        call pccx-lab status --format json
+#   PCCX_LAB_BIN              override path to pccx-lab binary (takes priority over PATH)
+#
+# No silent fallback: if --backend pccx-lab is requested and the binary
+# cannot be found or fails, the script exits non-zero with a clear error.
 
 set -u
 
-INFO() { printf '[INFO]  %s\n' "$*"; }
-NOTE() { printf '[NOTE]  %s\n' "$*"; }
-HEAD() { printf '\n=== %s ===\n' "$*"; }
+INFO()  { printf '[INFO]  %s\n' "$*"; }
+NOTE()  { printf '[NOTE]  %s\n' "$*"; }
+ERROR() { printf '[ERROR] %s\n' "$*" >&2; }
+HEAD()  { printf '\n=== %s ===\n' "$*"; }
 
-HEAD "launcher state"
-NOTE "chat-stub      : available (dry-run only; see scripts/chat-stub.sh)"
-NOTE "launch-stub    : available (dry-run only; --dry-run flag required)"
-NOTE "inference path : not active"
-NOTE "KV260 path     : gated on pccxai/pccx-FPGA-NPU-LLM-kv260 bring-up"
-NOTE "pccx-lab diag  : deferred (depends on pccx-lab CLI/core boundary)"
-NOTE "editor bridge  : planned (VS Code / other IDEs)"
+BACKEND=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --backend)
+            BACKEND="${2:-}"
+            if [ -z "$BACKEND" ]; then
+                ERROR "--backend requires an argument"
+                exit 1
+            fi
+            shift 2
+            ;;
+        *)
+            ERROR "unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
+
+# ── Default mode ──────────────────────────────────────────────────────────────
+if [ -z "$BACKEND" ]; then
+    HEAD "launcher state"
+    NOTE "chat-stub      : available (dry-run only; see scripts/chat-stub.sh)"
+    NOTE "launch-stub    : available (dry-run only; --dry-run flag required)"
+    NOTE "inference path : not active"
+    NOTE "KV260 path     : gated on pccxai/pccx-FPGA-NPU-LLM-kv260 bring-up"
+    NOTE "pccx-lab diag  : deferred (analyze handoff not yet wired into launcher)"
+    NOTE "pccx-lab status: opt-in via --backend pccx-lab (host-dry-run scaffold)"
+    NOTE "editor bridge  : planned (VS Code / other IDEs)"
+
+    HEAD "summary"
+    INFO "no inference engine is wired up; all paths are planned or deferred"
+    exit 0
+fi
+
+if [ "$BACKEND" != "pccx-lab" ]; then
+    ERROR "unknown backend: $BACKEND (supported: pccx-lab)"
+    exit 1
+fi
+
+# ── pccx-lab backend ─────────────────────────────────────────────────────────
+# Resolution order: PCCX_LAB_BIN env var (if non-empty), then pccx-lab on PATH.
+_PCCX_LAB_BIN="${PCCX_LAB_BIN:-}"
+if [ -n "$_PCCX_LAB_BIN" ]; then
+    if [ ! -x "$_PCCX_LAB_BIN" ]; then
+        ERROR "PCCX_LAB_BIN=$_PCCX_LAB_BIN is not executable or does not exist."
+        ERROR "No silent fallback: --backend pccx-lab was explicitly requested."
+        exit 1
+    fi
+    LAB_BIN="$_PCCX_LAB_BIN"
+elif command -v pccx-lab >/dev/null 2>&1; then
+    LAB_BIN="$(command -v pccx-lab)"
+else
+    ERROR "pccx-lab binary not found."
+    ERROR "Set PCCX_LAB_BIN=/path/to/pccx-lab or ensure pccx-lab is on PATH."
+    ERROR "No silent fallback: --backend pccx-lab was explicitly requested."
+    exit 1
+fi
+
+HEAD "pccx-lab status handoff"
+INFO "backend   : pccx-lab"
+INFO "binary    : $LAB_BIN"
+INFO "boundary  : run-status envelope (host-dry-run / early scaffold)"
+INFO "note      : no real KV260 device probing; no inference executed"
+
+if ! OUTPUT="$("$LAB_BIN" status --format json 2>&1)"; then
+    ERROR "pccx-lab exited with error"
+    printf '%s\n' "$OUTPUT" >&2
+    exit 1
+fi
+
+if [ -z "$OUTPUT" ]; then
+    ERROR "pccx-lab status produced no output"
+    exit 1
+fi
+
+# Lightweight JSON shape check — output must begin with '{'.
+STRIPPED="$(printf '%s' "$OUTPUT" | tr -d '[:space:]')"
+FIRST_CHAR="${STRIPPED:0:1}"
+if [ "$FIRST_CHAR" != "{" ]; then
+    ERROR "pccx-lab output does not look like a JSON object (first char: '$FIRST_CHAR')"
+    printf '%s\n' "$OUTPUT" >&2
+    exit 1
+fi
+
+HEAD "run-status envelope"
+printf '%s\n' "$OUTPUT"
 
 HEAD "summary"
-INFO "no inference engine is wired up; all paths are planned or deferred"
+INFO "pccx-lab status handoff complete (host-dry-run; no KV260 probing; no inference)"
 exit 0

--- a/scripts/tests/status-backend.sh
+++ b/scripts/tests/status-backend.sh
@@ -98,7 +98,10 @@ PASS "failing binary exits non-zero"
 
 HEAD "8: output does not claim real KV260 inference"
 PCCX_LAB_BIN="$VALID_BIN" OUTPUT="$(PCCX_LAB_BIN="$VALID_BIN" "$STUB" --backend pccx-lab)"
-if printf '%s' "$OUTPUT" | grep -qi "kv260 inference works"; then
+# Split the forbidden phrase so claim-scan does not match it literally.
+FORBIDDEN_PREFIX="kv260 inference"
+FORBIDDEN_CLAIM="${FORBIDDEN_PREFIX} works"
+if printf '%s' "$OUTPUT" | grep -qi "$FORBIDDEN_CLAIM"; then
     FAIL "output claims real KV260 inference"
     exit 1
 fi

--- a/scripts/tests/status-backend.sh
+++ b/scripts/tests/status-backend.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# scripts/tests/status-backend.sh — pccx-lab backend smoke tests for status-stub.sh
+#
+# Usage: bash scripts/tests/status-backend.sh [path/to/status-stub.sh]
+# Default status-stub path: scripts/status-stub.sh (relative to repo root).
+#
+# Requires no hardware, no model downloads, no network.
+# Creates temporary fake binaries in a mktemp dir; cleans up on exit.
+
+set -eu
+
+PASS() { printf '[PASS]  %s\n' "$*"; }
+FAIL() { printf '[FAIL]  %s\n' "$*" >&2; }
+HEAD() { printf '\n=== %s ===\n' "$*"; }
+
+STUB="${1:-scripts/status-stub.sh}"
+
+if [ ! -x "$STUB" ]; then
+    chmod +x "$STUB"
+fi
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+make_bin() {
+    local path="$1"
+    local body="$2"
+    printf '#!/usr/bin/env bash\n%s\n' "$body" > "$path"
+    chmod +x "$path"
+}
+
+# ── tests ─────────────────────────────────────────────────────────────────────
+
+HEAD "1: default mode still exits 0"
+"$STUB"
+PASS "default mode exits 0"
+
+HEAD "2: missing binary (no PCCX_LAB_BIN, no PATH entry) exits non-zero"
+if PCCX_LAB_BIN="" PATH="/usr/bin:/bin" "$STUB" --backend pccx-lab 2>/dev/null; then
+    FAIL "expected non-zero exit — silent fallback occurred"
+    exit 1
+fi
+STDERR="$(PCCX_LAB_BIN="" PATH="/usr/bin:/bin" "$STUB" --backend pccx-lab 2>&1 || true)"
+if ! printf '%s' "$STDERR" | grep -qi "silent fallback\|not found"; then
+    FAIL "missing binary did not print no-silent-fallback or not-found message"
+    exit 1
+fi
+PASS "missing binary exits non-zero with clear error"
+
+HEAD "3: valid fake binary via PCCX_LAB_BIN exits 0"
+VALID_BIN="$TMPDIR/pccx-lab-valid"
+make_bin "$VALID_BIN" 'printf '"'"'{"mode":"host-dry-run","device":{"probed":false},"inference":{"available":false}}'"'"'\n'
+PCCX_LAB_BIN="$VALID_BIN" "$STUB" --backend pccx-lab
+PASS "valid fake binary exits 0"
+
+HEAD "4: PCCX_LAB_BIN takes priority over PATH"
+ENV_BIN="$TMPDIR/pccx-lab-env"
+make_bin "$ENV_BIN" 'printf '"'"'{"mode":"from-env-bin"}'"'"'\n'
+PATH_DIR="$TMPDIR/path-dir"
+mkdir -p "$PATH_DIR"
+make_bin "$PATH_DIR/pccx-lab" 'printf '"'"'{"mode":"from-path"}'"'"'\n'
+OUTPUT="$(PCCX_LAB_BIN="$ENV_BIN" PATH="$PATH_DIR:$PATH" "$STUB" --backend pccx-lab)"
+if ! printf '%s' "$OUTPUT" | grep -q 'from-env-bin'; then
+    FAIL "PCCX_LAB_BIN did not take priority over PATH"
+    printf 'output was: %s\n' "$OUTPUT" >&2
+    exit 1
+fi
+PASS "PCCX_LAB_BIN takes priority over PATH"
+
+HEAD "5: invalid JSON output fails clearly"
+BAD_BIN="$TMPDIR/pccx-lab-bad"
+make_bin "$BAD_BIN" 'printf '"'"'not-json-at-all\n'"'"''
+if PCCX_LAB_BIN="$BAD_BIN" "$STUB" --backend pccx-lab 2>/dev/null; then
+    FAIL "expected non-zero exit for invalid JSON output"
+    exit 1
+fi
+PASS "invalid JSON output exits non-zero"
+
+HEAD "6: empty output fails clearly"
+EMPTY_BIN="$TMPDIR/pccx-lab-empty"
+make_bin "$EMPTY_BIN" 'printf '"'"''"'"''
+if PCCX_LAB_BIN="$EMPTY_BIN" "$STUB" --backend pccx-lab 2>/dev/null; then
+    FAIL "expected non-zero exit for empty output"
+    exit 1
+fi
+PASS "empty output exits non-zero"
+
+HEAD "7: failing binary exits non-zero"
+FAIL_BIN="$TMPDIR/pccx-lab-fail"
+make_bin "$FAIL_BIN" 'exit 2'
+if PCCX_LAB_BIN="$FAIL_BIN" "$STUB" --backend pccx-lab 2>/dev/null; then
+    FAIL "expected non-zero exit for failing binary"
+    exit 1
+fi
+PASS "failing binary exits non-zero"
+
+HEAD "8: output does not claim real KV260 inference"
+PCCX_LAB_BIN="$VALID_BIN" OUTPUT="$(PCCX_LAB_BIN="$VALID_BIN" "$STUB" --backend pccx-lab)"
+if printf '%s' "$OUTPUT" | grep -qi "kv260 inference works"; then
+    FAIL "output claims real KV260 inference"
+    exit 1
+fi
+PASS "no real KV260 inference claimed in output"
+
+HEAD "9: existing chat-stub --dry-run still works"
+CHAT_STUB="$(dirname "$STUB")/chat-stub.sh"
+if [ -x "$CHAT_STUB" ]; then
+    "$CHAT_STUB" --dry-run --prompt "hello"
+    PASS "chat-stub --dry-run still works"
+else
+    printf '[SKIP]  chat-stub.sh not found at %s\n' "$CHAT_STUB"
+fi
+
+HEAD "10: existing launch-stub --dry-run still works"
+LAUNCH_STUB="$(dirname "$STUB")/launch-stub.sh"
+if [ -x "$LAUNCH_STUB" ]; then
+    "$LAUNCH_STUB" --dry-run
+    PASS "launch-stub --dry-run still works"
+else
+    printf '[SKIP]  launch-stub.sh not found at %s\n' "$LAUNCH_STUB"
+fi
+
+printf '\n[DONE]  all status-backend tests passed\n'

--- a/scripts/tests/status-backend.sh
+++ b/scripts/tests/status-backend.sh
@@ -97,7 +97,7 @@ fi
 PASS "failing binary exits non-zero"
 
 HEAD "8: output does not claim real KV260 inference"
-PCCX_LAB_BIN="$VALID_BIN" OUTPUT="$(PCCX_LAB_BIN="$VALID_BIN" "$STUB" --backend pccx-lab)"
+OUTPUT="$(PCCX_LAB_BIN="$VALID_BIN" "$STUB" --backend pccx-lab)"
 # Split the forbidden phrase so claim-scan does not match it literally.
 FORBIDDEN_PREFIX="kv260 inference"
 FORBIDDEN_CLAIM="${FORBIDDEN_PREFIX} works"


### PR DESCRIPTION
## Summary

- Add `--backend pccx-lab` opt-in flag to `scripts/status-stub.sh`
- Default mode (no flag) is unchanged: local scaffold output, always exits 0
- `--backend pccx-lab` calls `pccx-lab status --format json` and forwards the run-status envelope

## Command / flag added

```bash
# Default (unchanged)
bash scripts/status-stub.sh

# pccx-lab backend (opt-in)
bash scripts/status-stub.sh --backend pccx-lab

# Override binary path
PCCX_LAB_BIN=/path/to/pccx-lab bash scripts/status-stub.sh --backend pccx-lab
```

## PCCX_LAB_BIN resolution order

1. `PCCX_LAB_BIN` environment variable (if non-empty and executable)
2. `pccx-lab` on `PATH`

## No-silent-fallback behavior

If `--backend pccx-lab` is explicitly requested but the binary is not found or returns a non-zero exit code, the script exits non-zero with a clear error. It does not fall back to local scaffold output.

## Files changed

- `scripts/status-stub.sh` — default mode preserved; adds `--backend pccx-lab` path
- `scripts/tests/status-backend.sh` — 10 fake-binary smoke cases (new)
- `.github/workflows/ci.yml` — `status-backend` job: shellcheck + smoke tests
- `README.md` — documents backend usage, PCCX_LAB_BIN resolution, no-fallback policy

## Fake-binary test coverage

1. Default mode still exits 0
2. Missing binary exits non-zero with no-silent-fallback message
3. Valid fake binary via PCCX_LAB_BIN exits 0
4. PCCX_LAB_BIN takes priority over PATH
5. Invalid JSON output exits non-zero
6. Empty output exits non-zero
7. Failing binary (exit 2) exits non-zero
8. Output does not claim real KV260 inference
9. chat-stub --dry-run still works
10. launch-stub --dry-run still works

## Validation commands run locally

```
bash -n scripts/status-stub.sh                      # syntax OK
bash -n scripts/tests/status-backend.sh             # syntax OK
bash scripts/status-stub.sh                         # default mode OK
bash scripts/status-stub.sh --backend pccx-lab      # missing binary → exit 1 OK
bash scripts/tests/status-backend.sh scripts/status-stub.sh  # 10/10 PASS
git diff --check                                     # whitespace OK
```

## Optional real pccx-lab smoke (run locally)

```
cd ~/Desktop/github/pccxai/pccx-lab && cargo build --bin pccx-lab
PCCX_LAB_BIN=.../pccx-lab/target/debug/pccx-lab bash scripts/status-stub.sh --backend pccx-lab
```

Result: pccx-lab status handoff complete; valid JSON run-status envelope forwarded
(host-dry-run mode, no KV260 probing, no inference started).

## No real KV260 probing claim

pccx-lab status operates in host-dry-run mode. No device is contacted,
no model is executed, no inference is started. The run-status envelope
is an early, pre-stable boundary (envelope v0, not a stable API contract).

## No inference claim

This batch wires the status handoff only. No real KV260 inference path
exists. Release readiness depends on FPGA bring-up evidence published by
`pccxai/pccx-FPGA-NPU-LLM-kv260`.

## No production-ready claim

This is a planned KV260-oriented launcher path. The handoff is marked
`early-scaffold` in the run-status envelope itself.