### PR TITLE
docs: link provenance doc to org-level engineering discipline

### DIFF
--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -70,3 +70,9 @@ bring-up and verification work that is happening in
 `pccxai/pccx-FPGA-NPU-LLM-kv260`. No release of this repository should
 claim KV260 inference until that repository publishes a verified
 end-to-end path (RTL bring-up, simulation evidence, timing closure).
+
+---
+
+*See also*:
+[AI-assisted engineering discipline](https://github.com/pccxai/pccxai/blob/main/docs/AI_ASSISTED_ENGINEERING.md) —
+org-level evidence-first release rules that apply to launcher and device bridge work.


### PR DESCRIPTION
## Summary

- Adds a "See also" cross-reference at the end of `docs/PROVENANCE.md` pointing to the org-level AI-assisted engineering discipline, specifically the evidence-first release rules that apply to launcher and device bridge work.

## Type of change

- [x] Documentation

## Verification

`git diff --check` clean. One-line addition only.

## Linked issues

(none)