### PR TITLE
feat: add launcher IDE status contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,13 @@ jobs:
           import os, re, sys
           PATTERN = re.compile(
               r"(?:\bis\s+|\bnow\s+|\balready\s+|\bcurrently\s+)?"
-              r"(production[- ]ready|timing[- ]closed|fully verified|"
-              r"kv260 inference (?:works|works now|is working|is functional))",
+              r"(production[- ]ready|marketplace[- ]ready|"
+              r"(?<!pre-)stable\s+(?:api|abi|lsp)|"
+              r"mcp\s+ready|ai\s+provider\s+ready|"
+              r"kv260 inference (?:works|works now|is working|is functional)|"
+              r"20\s*tok/s\s+achieved|timing[- ]closed|fully verified|"
+              r"vibe coding|autonomous coding|"
+              r"(?:claude|gpt)\s+directly\s+controls)",
               re.IGNORECASE,
           )
           # A line is only flagged if the matched phrase is *asserted*.
@@ -53,7 +58,7 @@ jobs:
               r"|does not|is not|are not)\b",
               re.IGNORECASE,
           )
-          SCAN_EXTS = {".md", ".sh", ".yml", ".yaml"}
+          SCAN_EXTS = {".md", ".sh", ".yml", ".yaml", ".json"}
           SKIP_DIRS = {".git", "scripts/legacy"}
           SKIP_FILES = {".github/workflows/ci.yml"}
           violations = []
@@ -71,9 +76,14 @@ jobs:
                   if "scripts/legacy/" in rel:
                       continue
                   with open(rel, encoding="utf-8", errors="replace") as fh:
-                      for i, line in enumerate(fh, 1):
-                          if PATTERN.search(line) and not NEGATION.search(line):
-                              violations.append(f"{rel}:{i}: {line.rstrip()}")
+                      lines = fh.read().splitlines()
+                      for index, line in enumerate(lines):
+                          context = " ".join(
+                              lines[i]
+                              for i in range(max(0, index - 2), min(len(lines), index + 2))
+                          )
+                          if PATTERN.search(line) and not NEGATION.search(context):
+                              violations.append(f"{rel}:{index + 1}: {line}")
           if violations:
               print("Forbidden positive claims detected:")
               for v in violations:
@@ -138,6 +148,8 @@ jobs:
             exit 1
           fi
           echo "chat-stub correctly refused without --dry-run"
+      - name: run launcher/IDE contract tests
+        run: python3 scripts/tests/launcher_ide_contract_test.py
 
   status-backend:
     name: status-backend-tests

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ publishes a verified end-to-end path.
 ## Roadmap
 
 - Coding-assistant mode (AI-assisted local workflow with a controlled
-  MCP-style interface).
+  tool boundary).
 - VS Code extension bridge for guided launches and log inspection.
 - Additional target models beyond Gemma 3N E4B.
 - Additional edge devices beyond KV260.
@@ -125,10 +125,29 @@ but the binary is not found or returns an error, the script exits
 non-zero with a clear message. It does not fall back to local scaffold
 output.
 
-The pccx-lab status output is an early, pre-stable run-status envelope.
+The pccx-lab status output is an early, pre-compatibility run-status envelope.
 It operates in host-dry-run mode: no real KV260 device probing is
 performed, no model is executed, and no inference is started. This is a
-planned KV260-oriented launcher path, not a production-ready claim.
+planned KV260-oriented launcher path, not a readiness claim.
+
+### Launcher / IDE bridge contract (planned)
+
+The launcher now has a small data-only status contract for future editor
+consumers:
+
+```bash
+python3 contracts/launcher_ide_status_contract.py
+python3 scripts/tests/launcher_ide_contract_test.py
+```
+
+The contract reports conservative placeholder state: configured target,
+availability, runtime/model/evidence status, supported future operations,
+safety flags, and a planned read-only pccx-lab diagnostics handoff.
+
+It does not execute the launcher, call a provider, contact hardware,
+load a model, implement an editor bridge, or make a compatibility
+promise. See
+[docs/LAUNCHER_IDE_BRIDGE_CONTRACT.md](./docs/LAUNCHER_IDE_BRIDGE_CONTRACT.md).
 
 The legacy launcher scripts from the `llm-lite` era are preserved
 read-only under [`scripts/legacy/`](./scripts/legacy/) as historical

--- a/contracts/fixtures/launcher-ide-status.placeholder.json
+++ b/contracts/fixtures/launcher-ide-status.placeholder.json
@@ -1,0 +1,104 @@
+{
+  "availabilityState": "unavailable",
+  "configuredTarget": {
+    "id": "not_configured",
+    "label": "not_configured",
+    "source": "default_placeholder"
+  },
+  "diagnosticsHandoff": {
+    "automaticUpload": false,
+    "lowerBoundary": "pccx-lab CLI/core",
+    "mode": "read_only_handoff",
+    "rawLogsIncluded": false,
+    "state": "planned",
+    "writeBack": false
+  },
+  "evidenceState": "evidence_required",
+  "futureConsumers": [
+    "pccx-systemverilog-ide",
+    "future editor integration consumer",
+    "local coding-assistant mode, planned"
+  ],
+  "issueRefs": [
+    "pccxai/pccx-llm-launcher#4",
+    "pccxai/pccx-llm-launcher#3",
+    "pccxai/pccx-llm-launcher#5",
+    "pccxai/pccx-llm-launcher#12"
+  ],
+  "launcherMode": "placeholder",
+  "limitations": [
+    "No launcher runtime call is performed by this contract.",
+    "No KV260 run is claimed by this contract.",
+    "No AI provider integration is implemented by this contract.",
+    "No MCP, LSP, packaging, or marketplace flow is implemented by this contract.",
+    "Evidence is required before hardware or performance claims.",
+    "The contract shape may change before a versioned compatibility commitment."
+  ],
+  "modelState": "not_configured",
+  "runtimeState": "planned",
+  "safetyFlags": {
+    "dataOnly": true,
+    "disabledByDefault": true,
+    "executesLauncher": false,
+    "kv260Access": false,
+    "lspImplemented": false,
+    "marketplaceFlow": false,
+    "mcpServerImplemented": false,
+    "modelExecution": false,
+    "modelWeightPathsIncluded": false,
+    "networkCalls": false,
+    "privatePathsIncluded": false,
+    "providerCalls": false,
+    "rawLogsIncluded": false,
+    "secretsIncluded": false,
+    "shellExecution": false,
+    "touchesHardware": false
+  },
+  "schemaVersion": "pccx.launcherIdeStatus.v0",
+  "supportedOperations": [
+    {
+      "execution": "data_only",
+      "futureConsumerCommand": "pccxLauncher.showStatus",
+      "id": "launcher.status.local",
+      "label": "local launcher status",
+      "state": "placeholder"
+    },
+    {
+      "execution": "data_only",
+      "futureConsumerCommand": "pccxLauncher.showModelRuntimeDescriptor",
+      "id": "model.runtime.descriptor",
+      "label": "model/runtime descriptor availability",
+      "state": "planned"
+    },
+    {
+      "execution": "data_only",
+      "futureConsumerCommand": "pccxLauncher.showDeviceSessionStatus",
+      "id": "device.session.status",
+      "label": "device/session status placeholder",
+      "state": "placeholder"
+    },
+    {
+      "futureConsumerCommand": "pccxLauncher.exportDiagnosticsForLab",
+      "handoffMode": "read_only_handoff",
+      "id": "pccxlab.diagnostics.handoff",
+      "label": "pccx-lab diagnostics handoff placeholder",
+      "lowerBoundary": "pccx-lab CLI/core",
+      "state": "planned"
+    },
+    {
+      "execution": "data_only",
+      "futureConsumerCommand": "pccxLauncher.prepareEditorBridgeStatus",
+      "id": "editor.bridge.consumer",
+      "label": "future editor bridge consumer",
+      "state": "planned"
+    },
+    {
+      "execution": "disabled_by_default",
+      "futureConsumerCommand": "pccxLauncher.prepareLocalCodingAssistantStatus",
+      "id": "local.coding.assistant.consumer",
+      "label": "local coding-assistant mode consumer",
+      "state": "planned"
+    }
+  ],
+  "targetKind": "not_configured"
+}

--- a/contracts/launcher_ide_status_contract.py
+++ b/contracts/launcher_ide_status_contract.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Data-only launcher/IDE status contract placeholder.
+
+The contract is intentionally static. It describes planned boundaries for
+future editor consumers without starting a launcher, probing hardware, or
+reading local user configuration.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import sys
+
+
+SCHEMA_VERSION = "pccx.launcherIdeStatus.v0"
+
+_CONTRACT = {
+    "schemaVersion": SCHEMA_VERSION,
+    "launcherMode": "placeholder",
+    "configuredTarget": {
+        "id": "not_configured",
+        "label": "not_configured",
+        "source": "default_placeholder",
+    },
+    "targetKind": "not_configured",
+    "availabilityState": "unavailable",
+    "runtimeState": "planned",
+    "modelState": "not_configured",
+    "evidenceState": "evidence_required",
+    "supportedOperations": [
+        {
+            "id": "launcher.status.local",
+            "label": "local launcher status",
+            "state": "placeholder",
+            "execution": "data_only",
+            "futureConsumerCommand": "pccxLauncher.showStatus",
+        },
+        {
+            "id": "model.runtime.descriptor",
+            "label": "model/runtime descriptor availability",
+            "state": "planned",
+            "execution": "data_only",
+            "futureConsumerCommand": "pccxLauncher.showModelRuntimeDescriptor",
+        },
+        {
+            "id": "device.session.status",
+            "label": "device/session status placeholder",
+            "state": "placeholder",
+            "execution": "data_only",
+            "futureConsumerCommand": "pccxLauncher.showDeviceSessionStatus",
+        },
+        {
+            "id": "pccxlab.diagnostics.handoff",
+            "label": "pccx-lab diagnostics handoff placeholder",
+            "state": "planned",
+            "handoffMode": "read_only_handoff",
+            "lowerBoundary": "pccx-lab CLI/core",
+            "futureConsumerCommand": "pccxLauncher.exportDiagnosticsForLab",
+        },
+        {
+            "id": "editor.bridge.consumer",
+            "label": "future editor bridge consumer",
+            "state": "planned",
+            "execution": "data_only",
+            "futureConsumerCommand": "pccxLauncher.prepareEditorBridgeStatus",
+        },
+        {
+            "id": "local.coding.assistant.consumer",
+            "label": "local coding-assistant mode consumer",
+            "state": "planned",
+            "execution": "disabled_by_default",
+            "futureConsumerCommand": "pccxLauncher.prepareLocalCodingAssistantStatus",
+        },
+    ],
+    "safetyFlags": {
+        "dataOnly": True,
+        "disabledByDefault": True,
+        "executesLauncher": False,
+        "touchesHardware": False,
+        "kv260Access": False,
+        "modelExecution": False,
+        "networkCalls": False,
+        "providerCalls": False,
+        "mcpServerImplemented": False,
+        "lspImplemented": False,
+        "marketplaceFlow": False,
+        "shellExecution": False,
+        "rawLogsIncluded": False,
+        "privatePathsIncluded": False,
+        "secretsIncluded": False,
+        "modelWeightPathsIncluded": False,
+    },
+    "diagnosticsHandoff": {
+        "state": "planned",
+        "mode": "read_only_handoff",
+        "lowerBoundary": "pccx-lab CLI/core",
+        "automaticUpload": False,
+        "writeBack": False,
+        "rawLogsIncluded": False,
+    },
+    "futureConsumers": [
+        "pccx-systemverilog-ide",
+        "future editor integration consumer",
+        "local coding-assistant mode, planned",
+    ],
+    "limitations": [
+        "No launcher runtime call is performed by this contract.",
+        "No KV260 run is claimed by this contract.",
+        "No AI provider integration is implemented by this contract.",
+        "No MCP, LSP, packaging, or marketplace flow is implemented by this contract.",
+        "Evidence is required before hardware or performance claims.",
+        "The contract shape may change before a versioned compatibility commitment.",
+    ],
+    "issueRefs": [
+        "pccxai/pccx-llm-launcher#4",
+        "pccxai/pccx-llm-launcher#3",
+        "pccxai/pccx-llm-launcher#5",
+        "pccxai/pccx-llm-launcher#12",
+    ],
+}
+
+
+def create_launcher_ide_status_contract() -> dict:
+    """Return a defensive copy of the placeholder contract."""
+    return copy.deepcopy(_CONTRACT)
+
+
+def contract_json(contract: dict | None = None) -> str:
+    """Render a deterministic JSON representation."""
+    return json.dumps(
+        contract if contract is not None else create_launcher_ide_status_contract(),
+        indent=2,
+        sort_keys=True,
+    ) + "\n"
+
+
+def main() -> int:
+    sys.stdout.write(contract_json())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/LAUNCHER_IDE_BRIDGE_CONTRACT.md
+++ b/docs/LAUNCHER_IDE_BRIDGE_CONTRACT.md
@@ -1,0 +1,87 @@
+# Launcher / IDE Bridge Contract
+
+This note describes the first launcher-side contract for future editor
+integrations. It is a data-only status boundary. It does not start the
+launcher, inspect a device, load a model, call a provider, or connect to
+an editor.
+
+The contract lives in:
+
+- `contracts/launcher_ide_status_contract.py`
+- `contracts/fixtures/launcher-ide-status.placeholder.json`
+
+The fixture is the checked example for the current placeholder status.
+It is deterministic and intentionally small enough to review in a pull
+request.
+
+## What Is Implemented
+
+The contract reports a placeholder summary with:
+
+- schema version
+- launcher mode
+- configured target
+- target kind
+- availability, runtime, model, and evidence states
+- supported future operations
+- safety flags
+- pccx-lab diagnostics handoff status
+- future consumers and limitations
+
+All values are conservative. The default state is not configured or
+planned unless there is checked evidence for something stronger.
+
+## Planned Consumers
+
+Future editor integrations may read this status before presenting
+launcher actions to a user. `pccx-systemverilog-ide` is one possible
+consumer, but this repository does not implement that integration in
+this PR.
+
+The planned mapping is:
+
+| Contract operation | Future consumer action |
+|---|---|
+| `launcher.status.local` | Show local launcher status. |
+| `model.runtime.descriptor` | Show model/runtime descriptor availability. |
+| `device.session.status` | Show device/session status placeholder. |
+| `pccxlab.diagnostics.handoff` | Prepare read-only diagnostics handoff for pccx-lab. |
+| `editor.bridge.consumer` | Prepare editor bridge status. |
+| `local.coding.assistant.consumer` | Prepare local coding-assistant status, disabled by default. |
+
+These names are a draft bridge sketch, not a compatibility guarantee.
+The shape may change before a versioned interface is declared.
+
+## pccx-lab Boundary
+
+pccx-lab remains the CLI/core lower boundary. Launcher and editor flows
+should not bypass pccx-lab analysis behavior or create a separate logic
+island.
+
+Diagnostics handoff is planned as read-only first:
+
+- no automatic upload
+- no write-back
+- no raw hardware log in this contract
+- no user data
+- no model weight path
+
+## Safety Notes
+
+This contract does not claim a KV260 run. It does not report throughput,
+timing closure, or hardware readiness. Evidence is required before
+hardware or performance claims.
+
+This PR also does not add:
+
+- launcher runtime execution
+- AI provider calls
+- network calls
+- MCP implementation
+- LSP implementation
+- editor extension implementation
+- packaging or publisher flow
+- model weights or generated blobs
+
+The purpose is to make future integration work easier to review by
+starting with a small, testable data boundary.

--- a/scripts/tests/launcher_ide_contract_test.py
+++ b/scripts/tests/launcher_ide_contract_test.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Fixture tests for the launcher/IDE status contract."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "contracts" / "launcher_ide_status_contract.py"
+FIXTURE_PATH = ROOT / "contracts" / "fixtures" / "launcher-ide-status.placeholder.json"
+DOC_PATH = ROOT / "docs" / "LAUNCHER_IDE_BRIDGE_CONTRACT.md"
+README_PATH = ROOT / "README.md"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("launcher_ide_status_contract", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def flatten(value) -> str:
+    return json.dumps(value, sort_keys=True)
+
+
+def assert_no_private_or_generated_data(text: str) -> None:
+    forbidden_patterns = [
+        r"/home/[^\s\"']+",
+        r"/Users/[^\s\"']+",
+        r"[A-Za-z]:\\Users\\",
+        r"\b(?:api[_-]?key|authorization|bearer|client[_-]?secret|password|private[_-]?key|secret|token)\b\s*[:=]",
+        r"\.(?:gguf|safetensors|ckpt|pt|pth|onnx)\b",
+        r"(?:weights|model_weights|model-cache)/(?:[^\"'\s]+)",
+    ]
+    for pattern in forbidden_patterns:
+        assert not re.search(pattern, text, re.IGNORECASE), pattern
+
+
+def assert_no_runtime_implementation_terms(source: str) -> None:
+    forbidden = [
+        "subprocess",
+        "os.system",
+        "popen",
+        "socket",
+        "urllib",
+        "requests",
+        "http.client",
+        "openai",
+        "anthropic",
+        "gemini",
+        "modelcontextprotocol",
+        "vscode-languageclient",
+        "vsce",
+    ]
+    lowered = source.lower()
+    for term in forbidden:
+        assert term not in lowered, term
+
+
+def assert_no_unsupported_claims(text: str) -> None:
+    literal_claims = [
+        "production-ready",
+        "marketplace-ready",
+        "stable API",
+        "stable ABI",
+        "KV260 inference works",
+        "20 tok/s achieved",
+        "timing closed",
+        "vibe coding",
+        "autonomous coding",
+        "Claude directly controls",
+        "GPT directly controls",
+    ]
+    lowered = text.lower()
+    for claim in literal_claims:
+        assert claim.lower() not in lowered, claim
+
+    asserted_claim_patterns = [
+        r"\bMCP\s+(?:server|client)\s+(?:is\s+)?implemented\b",
+        r"\bLSP\s+(?:server|client)\s+(?:is\s+)?implemented\b",
+        r"\bAI\s+provider\s+(?:is\s+)?implemented\b",
+    ]
+    for pattern in asserted_claim_patterns:
+        assert not re.search(pattern, text, re.IGNORECASE), pattern
+
+
+def test_contract_matches_fixture_and_is_deterministic() -> None:
+    module = load_module()
+    generated = module.create_launcher_ide_status_contract()
+    fixture = json.loads(read_text(FIXTURE_PATH))
+
+    assert generated == fixture
+    assert module.contract_json(generated) == module.contract_json(generated)
+    assert module.contract_json(generated).endswith("\n")
+    assert json.loads(module.contract_json(generated)) == fixture
+
+
+def test_contract_shape_and_status_values() -> None:
+    module = load_module()
+    contract = module.create_launcher_ide_status_contract()
+
+    assert contract["schemaVersion"] == "pccx.launcherIdeStatus.v0"
+    assert contract["launcherMode"] == "placeholder"
+    assert contract["configuredTarget"]["id"] == "not_configured"
+    assert contract["targetKind"] == "not_configured"
+    assert contract["availabilityState"] == "unavailable"
+    assert contract["runtimeState"] == "planned"
+    assert contract["modelState"] == "not_configured"
+    assert contract["evidenceState"] == "evidence_required"
+    assert contract["diagnosticsHandoff"]["mode"] == "read_only_handoff"
+    assert contract["diagnosticsHandoff"]["lowerBoundary"] == "pccx-lab CLI/core"
+
+    operation_labels = {operation["label"] for operation in contract["supportedOperations"]}
+    assert "local launcher status" in operation_labels
+    assert "model/runtime descriptor availability" in operation_labels
+    assert "device/session status placeholder" in operation_labels
+    assert "pccx-lab diagnostics handoff placeholder" in operation_labels
+    assert "future editor bridge consumer" in operation_labels
+    assert "local coding-assistant mode consumer" in operation_labels
+
+    operation_states = {operation["state"] for operation in contract["supportedOperations"]}
+    assert operation_states <= {"planned", "placeholder"}
+    assert any(operation.get("execution") == "disabled_by_default" for operation in contract["supportedOperations"])
+
+
+def test_safety_flags_are_boundary_only() -> None:
+    contract = load_module().create_launcher_ide_status_contract()
+    flags = contract["safetyFlags"]
+
+    assert flags["dataOnly"] is True
+    assert flags["disabledByDefault"] is True
+    for name in [
+        "executesLauncher",
+        "touchesHardware",
+        "kv260Access",
+        "modelExecution",
+        "networkCalls",
+        "providerCalls",
+        "mcpServerImplemented",
+        "lspImplemented",
+        "marketplaceFlow",
+        "shellExecution",
+        "rawLogsIncluded",
+        "privatePathsIncluded",
+        "secretsIncluded",
+        "modelWeightPathsIncluded",
+    ]:
+        assert flags[name] is False, name
+
+
+def test_no_private_data_runtime_calls_or_overclaims() -> None:
+    module_source = read_text(MODULE_PATH)
+    contract = load_module().create_launcher_ide_status_contract()
+    contract_text = flatten(contract)
+    docs_text = "\n".join([
+        read_text(DOC_PATH),
+        read_text(README_PATH),
+        contract_text,
+        module_source,
+        read_text(FIXTURE_PATH),
+    ])
+
+    assert_no_private_or_generated_data(docs_text)
+    assert_no_runtime_implementation_terms(module_source)
+    assert_no_unsupported_claims(docs_text)
+    assert "future editor integration consumer" in contract_text
+    assert "planned" in contract_text
+    assert "placeholder" in contract_text
+    assert "evidence_required" in contract_text
+
+
+test_contract_matches_fixture_and_is_deterministic()
+test_contract_shape_and_status_values()
+test_safety_flags_are_boundary_only()
+test_no_private_data_runtime_calls_or_overclaims()
+
+print("launcher/IDE status contract tests ok")


### PR DESCRIPTION
## Summary
- add a data-only launcher/IDE status contract module and checked placeholder fixture
- document the planned editor bridge and pccx-lab diagnostics handoff boundary
- add fixture-based tests and wire them into CI
- expand claim-scan coverage for public docs and checked JSON fixtures

## Scope
- contract module: contracts/launcher_ide_status_contract.py
- fixture: contracts/fixtures/launcher-ide-status.placeholder.json
- docs: docs/LAUNCHER_IDE_BRIDGE_CONTRACT.md and README link/usage note
- tests: scripts/tests/launcher_ide_contract_test.py
- CI: run the contract test and scan JSON fixtures for unsupported positive claims

## Non-goals
- no real VS Code bridge implementation
- no launcher runtime execution
- no KV260 access or hardware probing
- no model execution or model weights
- no AI provider calls or network calls
- no MCP or LSP implementation
- no marketplace, packaging, publisher, release, or tag work
- no systemverilog-ide changes
- no FPGA repo or hkimw/llm-bottleneck-lab access or edits

## Validation
- git status --short --branch
- python3 contracts/launcher_ide_status_contract.py | python3 -m json.tool
- python3 scripts/tests/launcher_ide_contract_test.py
- python3 -m pytest -q
- bash scripts/check.sh
- bash scripts/check-device-stub.sh
- bash scripts/install-stub.sh
- bash scripts/launch-stub.sh --dry-run
- launch-stub refusal without --dry-run
- bash scripts/status-stub.sh
- bash scripts/chat-stub.sh --dry-run --prompt hello
- chat-stub refusal without --dry-run
- bash scripts/tests/status-backend.sh scripts/status-stub.sh
- local claim-scan reproduction
- git diff --check
- npm test skipped: no package.json present
- local shellcheck skipped: shellcheck not installed locally; CI installs it

## Safety notes
- contract is deterministic and data-only
- safety flags explicitly mark launcher execution, hardware access, model execution, provider calls, network calls, MCP/LSP implementation, marketplace flow, raw logs, private paths, secrets, and model weight paths as absent
- pccx-lab remains the CLI/core lower boundary
- future editor consumers are described without runtime integration
- no release or tag created

## Related issues
- Closes #4
- Related #3
- Related #5
- Related #12