### PR TITLE
Define model/runtime descriptor boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,8 @@ jobs:
           echo "chat-stub correctly refused without --dry-run"
       - name: run launcher/IDE contract tests
         run: python3 scripts/tests/launcher_ide_contract_test.py
+      - name: run model/runtime descriptor tests
+        run: python3 scripts/tests/model_runtime_descriptor_test.py
 
   status-backend:
     name: status-backend-tests

--- a/README.md
+++ b/README.md
@@ -149,6 +149,25 @@ load a model, implement an editor bridge, or make a compatibility
 promise. See
 [docs/LAUNCHER_IDE_BRIDGE_CONTRACT.md](./docs/LAUNCHER_IDE_BRIDGE_CONTRACT.md).
 
+### Model / runtime descriptor boundary (planned)
+
+The launcher also has a small data-only model/runtime descriptor boundary:
+
+```bash
+python3 contracts/model_runtime_descriptor_contract.py
+python3 scripts/tests/model_runtime_descriptor_test.py
+```
+
+The checked fixture covers Gemma 3N E4B as a descriptor target and a
+KV260 PCCX runtime placeholder. Model assets are external/user-provided
+and not bundled. The runtime path is planned, unavailable, and not
+configured, so compatibility remains provisional until evidence exists.
+
+This boundary does not load weights, execute a runtime, call a provider,
+touch KV260 hardware, report performance, implement MCP/LSP, or make an
+API/ABI compatibility commitment. See
+[docs/MODEL_RUNTIME_DESCRIPTOR_BOUNDARY.md](./docs/MODEL_RUNTIME_DESCRIPTOR_BOUNDARY.md).
+
 The legacy launcher scripts from the `llm-lite` era are preserved
 read-only under [`scripts/legacy/`](./scripts/legacy/) as historical
 reference (see that directory's README for status).

--- a/contracts/fixtures/model-runtime-descriptor.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/model-runtime-descriptor.gemma3n-e4b-kv260-placeholder.json
@@ -1,0 +1,195 @@
+{
+  "compatibility": {
+    "compatibilityState": "provisional",
+    "compatible": false,
+    "missingArtifacts": [
+      "external_user_provided_model_assets",
+      "model_assets",
+      "runtime_adapter",
+      "kv260_hardware_evidence",
+      "measurement_evidence"
+    ],
+    "modelId": "gemma3n_e4b_placeholder",
+    "nextActionKind": "collect_evidence_before_runtime_claim",
+    "reason": "descriptor_match_evidence_required",
+    "requiredEvidence": [
+      "model_descriptor_evidence",
+      "measurement_evidence",
+      "external_user_provided_model_assets",
+      "runtime_adapter_integration_evidence",
+      "kv260_hardware_evidence"
+    ],
+    "runtimeId": "kv260_pccx_placeholder",
+    "schemaVersion": "pccx.modelRuntimeCompatibility.v0",
+    "warnings": [
+      "descriptor_only",
+      "no_runtime_execution",
+      "no_hardware_access",
+      "no_performance_measurement",
+      "compatibility_is_provisional"
+    ]
+  },
+  "exampleId": "gemma3n_e4b_kv260_pccx_placeholder",
+  "issueRefs": [
+    "pccxai/pccx-llm-launcher#3",
+    "pccxai/pccx-llm-launcher#5",
+    "pccxai/pccx-llm-launcher#12"
+  ],
+  "launcherIdeStatusReference": {
+    "compatibilityState": "provisional",
+    "coupling": "data_reference_only",
+    "evidenceState": "evidence_required",
+    "executesRuntime": false,
+    "modelId": "gemma3n_e4b_placeholder",
+    "operationId": "model.runtime.descriptor",
+    "referenceKind": "descriptor_only",
+    "runtimeId": "kv260_pccx_placeholder",
+    "schemaVersion": "pccx.modelRuntimeDescriptorExample.v0",
+    "touchesHardware": false
+  },
+  "modelDescriptor": {
+    "evidenceState": "evidence_required",
+    "expectedRuntimeKinds": [
+      "kv260_pccx_placeholder",
+      "cpu_reference_placeholder"
+    ],
+    "limitations": [
+      "Descriptor only; no model assets are bundled.",
+      "Model assets are expected to be external/user-provided.",
+      "No model load or runtime execution is performed.",
+      "Performance and hardware evidence are required before stronger claims."
+    ],
+    "loadState": "not_loaded",
+    "measurementState": "not_measured",
+    "modelFamily": "gemma3n",
+    "modelId": "gemma3n_e4b_placeholder",
+    "modelVariant": "e4b",
+    "parameterScale": "e4b",
+    "quantization": {
+      "execution": "descriptor_only",
+      "kind": "planned",
+      "state": "not_measured"
+    },
+    "safetyFlags": {
+      "dataOnly": true,
+      "descriptorOnly": true,
+      "modelExecution": false,
+      "modelLoaded": false,
+      "modelWeightPathsIncluded": false,
+      "networkCalls": false,
+      "privatePathsIncluded": false,
+      "providerCalls": false,
+      "secretsIncluded": false,
+      "weightsBundled": false
+    },
+    "schemaVersion": "pccx.modelDescriptor.v0",
+    "tokenizerKind": "gemma3n_placeholder",
+    "weightFormat": "external_user_provided",
+    "weightLocationKind": "external_user_provided",
+    "weightPresence": "not_bundled"
+  },
+  "runtimeDescriptor": {
+    "acceleratorKind": "planned",
+    "availabilityState": "unavailable",
+    "compatibilityNotes": [
+      "Gemma 3N E4B is represented as a descriptor target only.",
+      "The KV260 PCCX runtime path is planned and not configured.",
+      "Compatibility is provisional until evidence exists."
+    ],
+    "configurationState": "not_configured",
+    "evidenceRequirements": [
+      "external_user_provided_model_assets",
+      "runtime_adapter_integration_evidence",
+      "kv260_hardware_evidence",
+      "measurement_evidence"
+    ],
+    "lifecycleStates": [
+      {
+        "execution": "descriptor_only",
+        "state": "load",
+        "supportState": "planned"
+      },
+      {
+        "execution": "descriptor_only",
+        "state": "warm",
+        "supportState": "planned"
+      },
+      {
+        "execution": "descriptor_only",
+        "state": "run",
+        "supportState": "planned"
+      },
+      {
+        "execution": "descriptor_only",
+        "state": "unload",
+        "supportState": "planned"
+      }
+    ],
+    "requiredArtifacts": [
+      {
+        "artifactKind": "model_assets",
+        "locationKind": "external_user_provided",
+        "presence": "not_bundled"
+      },
+      {
+        "artifactKind": "runtime_adapter",
+        "locationKind": "future_launcher_runtime_integration",
+        "presence": "planned"
+      },
+      {
+        "artifactKind": "kv260_hardware_evidence",
+        "locationKind": "future_pccx_lab_or_core_handoff",
+        "presence": "evidence_required"
+      },
+      {
+        "artifactKind": "measurement_evidence",
+        "locationKind": "future_pccx_lab_or_core_handoff",
+        "presence": "not_measured"
+      }
+    ],
+    "runtimeId": "kv260_pccx_placeholder",
+    "runtimeKind": "kv260_pccx_placeholder",
+    "safetyFlags": {
+      "dataOnly": true,
+      "descriptorOnly": true,
+      "kv260Access": false,
+      "modelExecution": false,
+      "modelWeightPathsIncluded": false,
+      "networkCalls": false,
+      "privatePathsIncluded": false,
+      "providerCalls": false,
+      "runtimeExecution": false,
+      "secretsIncluded": false,
+      "shellExecution": false,
+      "touchesHardware": false
+    },
+    "schemaVersion": "pccx.runtimeDescriptor.v0",
+    "statusChecks": [
+      {
+        "checkId": "target_configuration",
+        "execution": "descriptor_only",
+        "state": "not_configured"
+      },
+      {
+        "checkId": "hardware_access",
+        "execution": "no_hardware_access",
+        "state": "unavailable"
+      },
+      {
+        "checkId": "runtime_execution",
+        "execution": "no_runtime_execution",
+        "state": "unavailable"
+      }
+    ],
+    "supportedModelFamilies": [
+      "gemma3n"
+    ],
+    "targetDevice": {
+      "configurationState": "not_configured",
+      "id": "kv260_pccx_placeholder",
+      "label": "KV260 PCCX placeholder"
+    },
+    "targetKind": "kv260"
+  },
+  "schemaVersion": "pccx.modelRuntimeDescriptorExample.v0"
+}

--- a/contracts/model_runtime_descriptor_contract.py
+++ b/contracts/model_runtime_descriptor_contract.py
@@ -1,0 +1,417 @@
+#!/usr/bin/env python3
+"""Data-only model/runtime descriptor contract placeholder.
+
+The contract describes model and runtime vocabulary for future launcher
+integration work. It does not load model assets, inspect devices, execute
+runtime commands, read local paths, or call providers.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import sys
+
+
+MODEL_SCHEMA_VERSION = "pccx.modelDescriptor.v0"
+RUNTIME_SCHEMA_VERSION = "pccx.runtimeDescriptor.v0"
+COMPATIBILITY_SCHEMA_VERSION = "pccx.modelRuntimeCompatibility.v0"
+EXAMPLE_SCHEMA_VERSION = "pccx.modelRuntimeDescriptorExample.v0"
+
+MODEL_DESCRIPTOR_FIELDS = (
+    "schemaVersion",
+    "modelId",
+    "modelFamily",
+    "modelVariant",
+    "parameterScale",
+    "tokenizerKind",
+    "weightFormat",
+    "weightLocationKind",
+    "weightPresence",
+    "loadState",
+    "quantization",
+    "expectedRuntimeKinds",
+    "measurementState",
+    "evidenceState",
+    "limitations",
+    "safetyFlags",
+)
+
+RUNTIME_DESCRIPTOR_FIELDS = (
+    "schemaVersion",
+    "runtimeId",
+    "runtimeKind",
+    "targetKind",
+    "targetDevice",
+    "acceleratorKind",
+    "availabilityState",
+    "configurationState",
+    "lifecycleStates",
+    "supportedModelFamilies",
+    "requiredArtifacts",
+    "statusChecks",
+    "evidenceRequirements",
+    "compatibilityNotes",
+    "safetyFlags",
+)
+
+COMPATIBILITY_RESULT_FIELDS = (
+    "schemaVersion",
+    "modelId",
+    "runtimeId",
+    "compatible",
+    "compatibilityState",
+    "reason",
+    "requiredEvidence",
+    "missingArtifacts",
+    "warnings",
+    "nextActionKind",
+)
+
+_GEMMA3N_E4B_MODEL_DESCRIPTOR = {
+    "schemaVersion": MODEL_SCHEMA_VERSION,
+    "modelId": "gemma3n_e4b_placeholder",
+    "modelFamily": "gemma3n",
+    "modelVariant": "e4b",
+    "parameterScale": "e4b",
+    "tokenizerKind": "gemma3n_placeholder",
+    "weightFormat": "external_user_provided",
+    "weightLocationKind": "external_user_provided",
+    "weightPresence": "not_bundled",
+    "loadState": "not_loaded",
+    "quantization": {
+        "kind": "planned",
+        "state": "not_measured",
+        "execution": "descriptor_only",
+    },
+    "expectedRuntimeKinds": [
+        "kv260_pccx_placeholder",
+        "cpu_reference_placeholder",
+    ],
+    "measurementState": "not_measured",
+    "evidenceState": "evidence_required",
+    "limitations": [
+        "Descriptor only; no model assets are bundled.",
+        "Model assets are expected to be external/user-provided.",
+        "No model load or runtime execution is performed.",
+        "Performance and hardware evidence are required before stronger claims.",
+    ],
+    "safetyFlags": {
+        "dataOnly": True,
+        "descriptorOnly": True,
+        "weightsBundled": False,
+        "modelLoaded": False,
+        "modelExecution": False,
+        "modelWeightPathsIncluded": False,
+        "privatePathsIncluded": False,
+        "secretsIncluded": False,
+        "providerCalls": False,
+        "networkCalls": False,
+    },
+}
+
+_KV260_PCCX_RUNTIME_DESCRIPTOR = {
+    "schemaVersion": RUNTIME_SCHEMA_VERSION,
+    "runtimeId": "kv260_pccx_placeholder",
+    "runtimeKind": "kv260_pccx_placeholder",
+    "targetKind": "kv260",
+    "targetDevice": {
+        "id": "kv260_pccx_placeholder",
+        "label": "KV260 PCCX placeholder",
+        "configurationState": "not_configured",
+    },
+    "acceleratorKind": "planned",
+    "availabilityState": "unavailable",
+    "configurationState": "not_configured",
+    "lifecycleStates": [
+        {
+            "state": "load",
+            "supportState": "planned",
+            "execution": "descriptor_only",
+        },
+        {
+            "state": "warm",
+            "supportState": "planned",
+            "execution": "descriptor_only",
+        },
+        {
+            "state": "run",
+            "supportState": "planned",
+            "execution": "descriptor_only",
+        },
+        {
+            "state": "unload",
+            "supportState": "planned",
+            "execution": "descriptor_only",
+        },
+    ],
+    "supportedModelFamilies": [
+        "gemma3n",
+    ],
+    "requiredArtifacts": [
+        {
+            "artifactKind": "model_assets",
+            "locationKind": "external_user_provided",
+            "presence": "not_bundled",
+        },
+        {
+            "artifactKind": "runtime_adapter",
+            "locationKind": "future_launcher_runtime_integration",
+            "presence": "planned",
+        },
+        {
+            "artifactKind": "kv260_hardware_evidence",
+            "locationKind": "future_pccx_lab_or_core_handoff",
+            "presence": "evidence_required",
+        },
+        {
+            "artifactKind": "measurement_evidence",
+            "locationKind": "future_pccx_lab_or_core_handoff",
+            "presence": "not_measured",
+        },
+    ],
+    "statusChecks": [
+        {
+            "checkId": "target_configuration",
+            "state": "not_configured",
+            "execution": "descriptor_only",
+        },
+        {
+            "checkId": "hardware_access",
+            "state": "unavailable",
+            "execution": "no_hardware_access",
+        },
+        {
+            "checkId": "runtime_execution",
+            "state": "unavailable",
+            "execution": "no_runtime_execution",
+        },
+    ],
+    "evidenceRequirements": [
+        "external_user_provided_model_assets",
+        "runtime_adapter_integration_evidence",
+        "kv260_hardware_evidence",
+        "measurement_evidence",
+    ],
+    "compatibilityNotes": [
+        "Gemma 3N E4B is represented as a descriptor target only.",
+        "The KV260 PCCX runtime path is planned and not configured.",
+        "Compatibility is provisional until evidence exists.",
+    ],
+    "safetyFlags": {
+        "dataOnly": True,
+        "descriptorOnly": True,
+        "touchesHardware": False,
+        "kv260Access": False,
+        "runtimeExecution": False,
+        "modelExecution": False,
+        "providerCalls": False,
+        "networkCalls": False,
+        "shellExecution": False,
+        "privatePathsIncluded": False,
+        "secretsIncluded": False,
+        "modelWeightPathsIncluded": False,
+    },
+}
+
+
+def create_gemma3n_e4b_model_descriptor() -> dict:
+    """Return a defensive copy of the Gemma 3N E4B placeholder descriptor."""
+    return copy.deepcopy(_GEMMA3N_E4B_MODEL_DESCRIPTOR)
+
+
+def create_kv260_pccx_runtime_descriptor() -> dict:
+    """Return a defensive copy of the KV260 PCCX placeholder descriptor."""
+    return copy.deepcopy(_KV260_PCCX_RUNTIME_DESCRIPTOR)
+
+
+def _unique_ordered(values: list[str]) -> list[str]:
+    seen = set()
+    result = []
+    for value in values:
+        if value not in seen:
+            seen.add(value)
+            result.append(value)
+    return result
+
+
+def _artifact_is_missing(artifact: dict) -> bool:
+    return artifact.get("presence") in {
+        "not_bundled",
+        "not_loaded",
+        "not_measured",
+        "planned",
+        "evidence_required",
+        "not_configured",
+        "unavailable",
+    }
+
+
+def _missing_artifacts(model_descriptor: dict, runtime_descriptor: dict) -> list[str]:
+    missing = []
+    if model_descriptor.get("weightPresence") in {"not_bundled", "not_loaded"}:
+        missing.append("external_user_provided_model_assets")
+
+    for artifact in runtime_descriptor.get("requiredArtifacts", []):
+        if _artifact_is_missing(artifact):
+            missing.append(str(artifact.get("artifactKind", "unknown_artifact")))
+
+    return _unique_ordered(missing)
+
+
+def _required_evidence(model_descriptor: dict, runtime_descriptor: dict) -> list[str]:
+    required = []
+    if model_descriptor.get("evidenceState") == "evidence_required":
+        required.append("model_descriptor_evidence")
+    if model_descriptor.get("measurementState") == "not_measured":
+        required.append("measurement_evidence")
+    required.extend(
+        str(item) for item in runtime_descriptor.get("evidenceRequirements", [])
+    )
+    return _unique_ordered(required)
+
+
+def resolve_model_runtime_compatibility(
+    model_descriptor: dict,
+    runtime_descriptor: dict,
+) -> dict:
+    """Return a deterministic, data-only compatibility sketch.
+
+    The resolver only compares descriptor values supplied by the caller.
+    It does not inspect hardware, paths, model files, commands, networks,
+    provider settings, or generated caches.
+    """
+    model_family = model_descriptor.get("modelFamily")
+    runtime_kind = runtime_descriptor.get("runtimeKind")
+    runtime_id = runtime_descriptor.get("runtimeId")
+    expected_runtime_kinds = set(model_descriptor.get("expectedRuntimeKinds", []))
+    supported_model_families = set(runtime_descriptor.get("supportedModelFamilies", []))
+
+    family_match = model_family in supported_model_families
+    runtime_match = runtime_kind in expected_runtime_kinds or runtime_id in expected_runtime_kinds
+    missing_artifacts = _missing_artifacts(model_descriptor, runtime_descriptor)
+    required_evidence = _required_evidence(model_descriptor, runtime_descriptor)
+
+    unavailable = runtime_descriptor.get("availabilityState") != "available"
+    not_configured = runtime_descriptor.get("configurationState") != "configured"
+    not_measured = model_descriptor.get("measurementState") == "not_measured"
+    evidence_required = bool(required_evidence)
+
+    if not family_match:
+        compatibility_state = "not_compatible"
+        reason = "model_family_not_supported"
+        next_action_kind = "choose_matching_descriptor"
+    elif not runtime_match:
+        compatibility_state = "not_compatible"
+        reason = "runtime_kind_not_expected"
+        next_action_kind = "choose_matching_descriptor"
+    elif missing_artifacts or unavailable or not_configured or not_measured or evidence_required:
+        compatibility_state = "provisional"
+        reason = "descriptor_match_evidence_required"
+        next_action_kind = "collect_evidence_before_runtime_claim"
+    else:
+        compatibility_state = "compatible"
+        reason = "descriptor_match_with_evidence"
+        next_action_kind = "ready_for_future_runtime_integration"
+
+    compatible = compatibility_state == "compatible"
+    warnings = [
+        "descriptor_only",
+        "no_runtime_execution",
+        "no_hardware_access",
+        "no_performance_measurement",
+    ]
+    if compatibility_state == "provisional":
+        warnings.append("compatibility_is_provisional")
+
+    return {
+        "schemaVersion": COMPATIBILITY_SCHEMA_VERSION,
+        "modelId": model_descriptor.get("modelId", "unknown_model"),
+        "runtimeId": runtime_descriptor.get("runtimeId", "unknown_runtime"),
+        "compatible": compatible,
+        "compatibilityState": compatibility_state,
+        "reason": reason,
+        "requiredEvidence": required_evidence,
+        "missingArtifacts": missing_artifacts,
+        "warnings": warnings,
+        "nextActionKind": next_action_kind,
+    }
+
+
+def create_launcher_ide_status_descriptor_reference(
+    model_descriptor: dict | None = None,
+    runtime_descriptor: dict | None = None,
+    compatibility_result: dict | None = None,
+) -> dict:
+    """Return a data-only reference usable by the launcher/IDE status contract."""
+    model = (
+        model_descriptor
+        if model_descriptor is not None
+        else create_gemma3n_e4b_model_descriptor()
+    )
+    runtime = (
+        runtime_descriptor
+        if runtime_descriptor is not None
+        else create_kv260_pccx_runtime_descriptor()
+    )
+    compatibility = (
+        compatibility_result
+        if compatibility_result is not None
+        else resolve_model_runtime_compatibility(model, runtime)
+    )
+
+    return {
+        "operationId": "model.runtime.descriptor",
+        "referenceKind": "descriptor_only",
+        "schemaVersion": EXAMPLE_SCHEMA_VERSION,
+        "modelId": model["modelId"],
+        "runtimeId": runtime["runtimeId"],
+        "compatibilityState": compatibility["compatibilityState"],
+        "evidenceState": model["evidenceState"],
+        "coupling": "data_reference_only",
+        "executesRuntime": False,
+        "touchesHardware": False,
+    }
+
+
+def create_gemma3n_e4b_kv260_placeholder_example() -> dict:
+    """Return the checked Gemma 3N E4B + KV260 descriptor example."""
+    model = create_gemma3n_e4b_model_descriptor()
+    runtime = create_kv260_pccx_runtime_descriptor()
+    compatibility = resolve_model_runtime_compatibility(model, runtime)
+
+    return {
+        "schemaVersion": EXAMPLE_SCHEMA_VERSION,
+        "exampleId": "gemma3n_e4b_kv260_pccx_placeholder",
+        "modelDescriptor": model,
+        "runtimeDescriptor": runtime,
+        "compatibility": compatibility,
+        "launcherIdeStatusReference": create_launcher_ide_status_descriptor_reference(
+            model,
+            runtime,
+            compatibility,
+        ),
+        "issueRefs": [
+            "pccxai/pccx-llm-launcher#3",
+            "pccxai/pccx-llm-launcher#5",
+            "pccxai/pccx-llm-launcher#12",
+        ],
+    }
+
+
+def descriptor_json(descriptor: dict | None = None) -> str:
+    """Render a deterministic JSON representation."""
+    return json.dumps(
+        descriptor if descriptor is not None else create_gemma3n_e4b_kv260_placeholder_example(),
+        indent=2,
+        sort_keys=True,
+    ) + "\n"
+
+
+def main() -> int:
+    sys.stdout.write(descriptor_json())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/LAUNCHER_IDE_BRIDGE_CONTRACT.md
+++ b/docs/LAUNCHER_IDE_BRIDGE_CONTRACT.md
@@ -52,6 +52,19 @@ The planned mapping is:
 These names are a draft bridge sketch, not a compatibility guarantee.
 The shape may change before a versioned interface is declared.
 
+## Model / Runtime Descriptor Reference
+
+`model.runtime.descriptor` is backed by a separate data-only descriptor
+boundary in
+[`MODEL_RUNTIME_DESCRIPTOR_BOUNDARY.md`](./MODEL_RUNTIME_DESCRIPTOR_BOUNDARY.md).
+That boundary names model and runtime descriptors, target placeholders,
+lifecycle vocabulary, and a compatibility sketch without adding runtime
+logic to this status contract.
+
+The status contract remains a status summary. Future consumers may use
+the operation id as a reference, but this module does not import the
+descriptor module or execute model/runtime code.
+
 ## pccx-lab Boundary
 
 pccx-lab remains the CLI/core lower boundary. Launcher and editor flows

--- a/docs/MODEL_RUNTIME_DESCRIPTOR_BOUNDARY.md
+++ b/docs/MODEL_RUNTIME_DESCRIPTOR_BOUNDARY.md
@@ -1,0 +1,189 @@
+# Model / Runtime Descriptor Boundary
+
+This note defines the launcher-side descriptor boundary for future model
+and runtime integration. It is a data-only contract. It describes how the
+launcher can name models, runtimes, target devices, compatibility, and
+lifecycle states before any real runtime path is wired in.
+
+The implementation lives in:
+
+- `contracts/model_runtime_descriptor_contract.py`
+- `contracts/fixtures/model-runtime-descriptor.gemma3n-e4b-kv260-placeholder.json`
+- `scripts/tests/model_runtime_descriptor_test.py`
+
+## What Is Implemented
+
+The contract currently provides:
+
+- a model descriptor schema
+- a runtime descriptor schema
+- a deterministic compatibility sketch
+- a checked Gemma 3N E4B plus KV260 PCCX placeholder example
+- fixture tests that scan for private paths, bundled assets, secrets,
+  provider configuration, runtime execution, hardware access, and
+  unsupported claims
+
+The descriptors are deliberately conservative. They are meant to give the
+launcher, future editor consumers, and pccx-lab handoff code one shared
+vocabulary without making the launcher a separate logic island.
+
+## Model Descriptor
+
+The model descriptor records model identity and asset status:
+
+- `schemaVersion`
+- `modelId`
+- `modelFamily`
+- `modelVariant`
+- `parameterScale`
+- `tokenizerKind`
+- `weightFormat`
+- `weightLocationKind`
+- `weightPresence`
+- `loadState`
+- `quantization`
+- `expectedRuntimeKinds`
+- `measurementState`
+- `evidenceState`
+- `limitations`
+- `safetyFlags`
+
+The checked placeholder uses `gemma3n_e4b_placeholder`. Its assets are
+external/user-provided, not bundled, and not loaded. Measurement and
+evidence states remain `not_measured` and `evidence_required`.
+
+## Runtime Descriptor
+
+The runtime descriptor records the planned runtime path and target state:
+
+- `schemaVersion`
+- `runtimeId`
+- `runtimeKind`
+- `targetKind`
+- `targetDevice`
+- `acceleratorKind`
+- `availabilityState`
+- `configurationState`
+- `lifecycleStates`
+- `supportedModelFamilies`
+- `requiredArtifacts`
+- `statusChecks`
+- `evidenceRequirements`
+- `compatibilityNotes`
+- `safetyFlags`
+
+The checked KV260 runtime uses `kv260_pccx_placeholder`. It is planned,
+unavailable, and not configured. Status checks are descriptor-only and
+explicitly record no hardware access and no runtime execution.
+
+The model descriptor also names `cpu_reference_placeholder` as an
+expected future runtime kind. That is vocabulary only; this PR does not
+add a CPU runtime descriptor or execution path.
+
+## Lifecycle Vocabulary
+
+The descriptor names the future lifecycle states:
+
+- `load`
+- `warm`
+- `run`
+- `unload`
+
+All four are marked `planned` and `descriptor_only`. No lifecycle state
+starts a process, loads model assets, touches a target device, or calls a
+provider.
+
+## Compatibility Sketch
+
+`resolve_model_runtime_compatibility(model, runtime)` compares only the
+data supplied in the descriptors.
+
+It checks:
+
+- whether the runtime kind is listed by the model descriptor
+- whether the model family is listed by the runtime descriptor
+- whether required artifacts and evidence are still missing
+- whether the runtime is unavailable or not configured
+- whether the model remains not measured
+
+The result contains:
+
+- `compatible`
+- `compatibilityState`
+- `reason`
+- `requiredEvidence`
+- `missingArtifacts`
+- `warnings`
+- `nextActionKind`
+
+For the Gemma 3N E4B plus KV260 placeholder, the resolver returns
+`compatible: false` with `compatibilityState: provisional`. The descriptor
+match is visible, but evidence is required before the launcher can make a
+runtime claim.
+
+The resolver does not inspect hardware, inspect model directories,
+execute commands, call network APIs, call providers, read private paths,
+or look for generated caches.
+
+## Placeholder Example
+
+The checked example shows:
+
+- model identity: `gemma3n_e4b_placeholder`
+- runtime identity: `kv260_pccx_placeholder`
+- model assets: external/user-provided and not bundled
+- model load state: `not_loaded`
+- runtime state: planned, unavailable, and not configured
+- compatibility: provisional
+- evidence: required before runtime claims
+- performance: not measured
+- launcher/IDE reference: data-only through `model.runtime.descriptor`
+
+There is no bundled weight file, no provider configuration, no KV260
+hardware access, no runtime execution, no throughput claim, and no
+versioned API or ABI commitment in this descriptor boundary.
+
+## Launcher / IDE Status Relationship
+
+The existing launcher/IDE status contract already exposes the planned
+operation `model.runtime.descriptor`. The descriptor example includes a
+small reference to that operation:
+
+- `operationId: model.runtime.descriptor`
+- `referenceKind: descriptor_only`
+- `coupling: data_reference_only`
+- `executesRuntime: false`
+- `touchesHardware: false`
+
+The status contract does not import this descriptor module. Future editor
+or launcher code can read both contracts without turning the status
+boundary into runtime logic.
+
+## pccx-lab Boundary
+
+pccx-lab remains CLI-first and core-first. Future diagnostics handoff
+should use pccx-lab/core contracts for evidence and analysis. This
+launcher descriptor boundary only names the model/runtime vocabulary that
+future launcher runtime integration can refer to.
+
+Issue #5 diagnostics integration should wait until this descriptor shape
+has settled enough to avoid inventing a second model/runtime vocabulary.
+
+## Non-Goals
+
+This descriptor boundary does not add:
+
+- model weight loading
+- bundled or copied weights
+- model runtime execution
+- KV260 device access
+- hardware probing
+- provider or network calls
+- MCP implementation
+- LSP implementation
+- marketplace or publisher flow
+- release or tag behavior
+- API or ABI stability commitment
+
+Evidence from the lower runtime, device, and pccx-lab/core layers is
+required before any future runtime support or performance claim.

--- a/scripts/tests/model_runtime_descriptor_test.py
+++ b/scripts/tests/model_runtime_descriptor_test.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Fixture tests for the model/runtime descriptor boundary."""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "contracts" / "model_runtime_descriptor_contract.py"
+STATUS_MODULE_PATH = ROOT / "contracts" / "launcher_ide_status_contract.py"
+FIXTURE_PATH = (
+    ROOT
+    / "contracts"
+    / "fixtures"
+    / "model-runtime-descriptor.gemma3n-e4b-kv260-placeholder.json"
+)
+DOC_PATH = ROOT / "docs" / "MODEL_RUNTIME_DESCRIPTOR_BOUNDARY.md"
+README_PATH = ROOT / "README.md"
+
+
+def load_module(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def flatten(value) -> str:
+    return json.dumps(value, sort_keys=True)
+
+
+def iter_keys(value):
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            yield key
+            yield from iter_keys(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            yield from iter_keys(nested)
+
+
+def assert_no_private_or_generated_data(text: str) -> None:
+    forbidden_patterns = [
+        r"/home/[^\s\"']+",
+        r"/Users/[^\s\"']+",
+        r"[A-Za-z]:\\Users\\",
+        r"\b(?:api[_-]?key|authorization|bearer|client[_-]?secret|password|private[_-]?key|secret|token)\b\s*[:=]",
+        r"\.(?:gguf|safetensors|ckpt|pt|pth|onnx)\b",
+        r"(?:weights|model_weights|model-cache)/(?:[^\"'\s]+)",
+    ]
+    for pattern in forbidden_patterns:
+        assert not re.search(pattern, text, re.IGNORECASE), pattern
+
+
+def assert_no_runtime_implementation_terms(source: str) -> None:
+    forbidden = [
+        "subprocess",
+        "os.system",
+        "popen",
+        "socket",
+        "urllib",
+        "requests",
+        "http.client",
+        "openai",
+        "anthropic",
+        "gemini",
+        "modelcontextprotocol",
+        "vscode-languageclient",
+        "vsce",
+        "/proc/device-tree",
+        "xrt",
+        "xbutil",
+    ]
+    lowered = source.lower()
+    for term in forbidden:
+        assert term not in lowered, term
+
+
+def assert_no_provider_configs(value) -> None:
+    forbidden_keys = {
+        "apiKey",
+        "accessToken",
+        "refreshToken",
+        "authorization",
+        "bearerToken",
+        "provider",
+        "providers",
+        "providerConfig",
+        "providerConfigs",
+    }
+    for key in iter_keys(value):
+        assert key not in forbidden_keys, key
+
+
+def assert_no_unsupported_claims(text: str) -> None:
+    literal_claims = [
+        "production-ready",
+        "marketplace-ready",
+        "stable API",
+        "stable ABI",
+        "KV260 inference works",
+        "20 tok/s achieved",
+        "timing closed",
+        "vibe coding",
+        "autonomous coding",
+        "model support completed",
+    ]
+    lowered = text.lower()
+    for claim in literal_claims:
+        assert claim.lower() not in lowered, claim
+
+    asserted_claim_patterns = [
+        r"\bMCP\s+(?:server|client)\s+(?:is\s+)?implemented\b",
+        r"\bLSP\s+(?:server|client)\s+(?:is\s+)?implemented\b",
+        r"\bAI\s+provider\s+(?:is\s+)?implemented\b",
+        r"\bKV260\s+run\s+(?:is\s+)?claimed\b",
+    ]
+    for pattern in asserted_claim_patterns:
+        assert not re.search(pattern, text, re.IGNORECASE), pattern
+
+
+def test_descriptor_matches_fixture_and_is_deterministic() -> None:
+    module = load_module(MODULE_PATH, "model_runtime_descriptor_contract")
+    generated = module.create_gemma3n_e4b_kv260_placeholder_example()
+    fixture = json.loads(read_text(FIXTURE_PATH))
+
+    assert generated == fixture
+    assert module.descriptor_json(generated) == module.descriptor_json(generated)
+    assert module.descriptor_json(generated).endswith("\n")
+    assert json.loads(module.descriptor_json(generated)) == fixture
+
+
+def test_model_descriptor_schema_shape() -> None:
+    module = load_module(MODULE_PATH, "model_runtime_descriptor_contract")
+    descriptor = module.create_gemma3n_e4b_model_descriptor()
+
+    assert tuple(descriptor.keys()) == module.MODEL_DESCRIPTOR_FIELDS
+    assert descriptor["schemaVersion"] == "pccx.modelDescriptor.v0"
+    assert descriptor["modelId"] == "gemma3n_e4b_placeholder"
+    assert descriptor["modelFamily"] == "gemma3n"
+    assert descriptor["modelVariant"] == "e4b"
+    assert descriptor["parameterScale"] == "e4b"
+    assert descriptor["tokenizerKind"] == "gemma3n_placeholder"
+    assert descriptor["weightFormat"] == "external_user_provided"
+    assert descriptor["weightLocationKind"] == "external_user_provided"
+    assert descriptor["weightPresence"] == "not_bundled"
+    assert descriptor["loadState"] == "not_loaded"
+    assert descriptor["measurementState"] == "not_measured"
+    assert descriptor["evidenceState"] == "evidence_required"
+    assert descriptor["quantization"]["state"] == "not_measured"
+    assert descriptor["quantization"]["execution"] == "descriptor_only"
+    assert "kv260_pccx_placeholder" in descriptor["expectedRuntimeKinds"]
+    assert "cpu_reference_placeholder" in descriptor["expectedRuntimeKinds"]
+
+
+def test_runtime_descriptor_schema_shape() -> None:
+    module = load_module(MODULE_PATH, "model_runtime_descriptor_contract")
+    descriptor = module.create_kv260_pccx_runtime_descriptor()
+
+    assert tuple(descriptor.keys()) == module.RUNTIME_DESCRIPTOR_FIELDS
+    assert descriptor["schemaVersion"] == "pccx.runtimeDescriptor.v0"
+    assert descriptor["runtimeId"] == "kv260_pccx_placeholder"
+    assert descriptor["runtimeKind"] == "kv260_pccx_placeholder"
+    assert descriptor["targetKind"] == "kv260"
+    assert descriptor["targetDevice"]["id"] == "kv260_pccx_placeholder"
+    assert descriptor["targetDevice"]["configurationState"] == "not_configured"
+    assert descriptor["acceleratorKind"] == "planned"
+    assert descriptor["availabilityState"] == "unavailable"
+    assert descriptor["configurationState"] == "not_configured"
+    assert descriptor["supportedModelFamilies"] == ["gemma3n"]
+
+    lifecycle = descriptor["lifecycleStates"]
+    assert [state["state"] for state in lifecycle] == ["load", "warm", "run", "unload"]
+    assert {state["supportState"] for state in lifecycle} == {"planned"}
+    assert {state["execution"] for state in lifecycle} == {"descriptor_only"}
+
+    status_checks = {check["checkId"]: check for check in descriptor["statusChecks"]}
+    assert status_checks["hardware_access"]["execution"] == "no_hardware_access"
+    assert status_checks["runtime_execution"]["execution"] == "no_runtime_execution"
+
+
+def test_resolver_compatibility_result() -> None:
+    module = load_module(MODULE_PATH, "model_runtime_descriptor_contract")
+    model = module.create_gemma3n_e4b_model_descriptor()
+    runtime = module.create_kv260_pccx_runtime_descriptor()
+    result = module.resolve_model_runtime_compatibility(model, runtime)
+
+    assert tuple(result.keys()) == module.COMPATIBILITY_RESULT_FIELDS
+    assert result == module.resolve_model_runtime_compatibility(model, runtime)
+    assert result["schemaVersion"] == "pccx.modelRuntimeCompatibility.v0"
+    assert result["compatible"] is False
+    assert result["compatibilityState"] == "provisional"
+    assert result["reason"] == "descriptor_match_evidence_required"
+    assert result["nextActionKind"] == "collect_evidence_before_runtime_claim"
+    assert "external_user_provided_model_assets" in result["missingArtifacts"]
+    assert "runtime_adapter" in result["missingArtifacts"]
+    assert "kv260_hardware_evidence" in result["missingArtifacts"]
+    assert "measurement_evidence" in result["missingArtifacts"]
+    assert "descriptor_only" in result["warnings"]
+    assert "no_runtime_execution" in result["warnings"]
+    assert "no_hardware_access" in result["warnings"]
+    assert "compatibility_is_provisional" in result["warnings"]
+
+    mismatch = copy.deepcopy(runtime)
+    mismatch["supportedModelFamilies"] = ["other_family"]
+    mismatch_result = module.resolve_model_runtime_compatibility(model, mismatch)
+    assert mismatch_result["compatible"] is False
+    assert mismatch_result["compatibilityState"] == "not_compatible"
+    assert mismatch_result["reason"] == "model_family_not_supported"
+
+
+def test_no_bundled_weights_private_paths_secrets_or_provider_configs() -> None:
+    module = load_module(MODULE_PATH, "model_runtime_descriptor_contract")
+    example = module.create_gemma3n_e4b_kv260_placeholder_example()
+    fixture_text = read_text(FIXTURE_PATH)
+    source_text = read_text(MODULE_PATH)
+
+    model = example["modelDescriptor"]
+    runtime = example["runtimeDescriptor"]
+    assert model["weightLocationKind"] == "external_user_provided"
+    assert model["weightPresence"] == "not_bundled"
+    assert model["loadState"] == "not_loaded"
+    assert model["safetyFlags"]["weightsBundled"] is False
+    assert model["safetyFlags"]["modelWeightPathsIncluded"] is False
+    assert runtime["requiredArtifacts"][0]["locationKind"] == "external_user_provided"
+    assert runtime["requiredArtifacts"][0]["presence"] == "not_bundled"
+    assert runtime["safetyFlags"]["modelWeightPathsIncluded"] is False
+
+    assert_no_private_or_generated_data("\n".join([fixture_text, source_text]))
+    assert_no_provider_configs(example)
+
+
+def test_no_runtime_execution_hardware_access_or_unsupported_claims() -> None:
+    module = load_module(MODULE_PATH, "model_runtime_descriptor_contract")
+    example = module.create_gemma3n_e4b_kv260_placeholder_example()
+    source_text = read_text(MODULE_PATH)
+    scan_text = "\n".join([
+        read_text(FIXTURE_PATH),
+        read_text(DOC_PATH),
+        read_text(README_PATH),
+        flatten(example),
+        source_text,
+    ])
+
+    assert_no_runtime_implementation_terms(source_text)
+    assert_no_private_or_generated_data(scan_text)
+    assert_no_unsupported_claims(scan_text)
+
+    model_flags = example["modelDescriptor"]["safetyFlags"]
+    runtime_flags = example["runtimeDescriptor"]["safetyFlags"]
+    reference = example["launcherIdeStatusReference"]
+    assert model_flags["modelExecution"] is False
+    assert runtime_flags["runtimeExecution"] is False
+    assert runtime_flags["touchesHardware"] is False
+    assert runtime_flags["kv260Access"] is False
+    assert runtime_flags["shellExecution"] is False
+    assert runtime_flags["providerCalls"] is False
+    assert runtime_flags["networkCalls"] is False
+    assert reference["executesRuntime"] is False
+    assert reference["touchesHardware"] is False
+
+
+def test_gemma3n_e4b_kv260_placeholder_is_not_measured() -> None:
+    module = load_module(MODULE_PATH, "model_runtime_descriptor_contract")
+    example = module.create_gemma3n_e4b_kv260_placeholder_example()
+
+    assert example["modelDescriptor"]["modelId"] == "gemma3n_e4b_placeholder"
+    assert example["runtimeDescriptor"]["runtimeId"] == "kv260_pccx_placeholder"
+    assert example["modelDescriptor"]["measurementState"] == "not_measured"
+    assert example["modelDescriptor"]["quantization"]["state"] == "not_measured"
+    assert example["runtimeDescriptor"]["availabilityState"] == "unavailable"
+    assert example["runtimeDescriptor"]["configurationState"] == "not_configured"
+    assert example["compatibility"]["compatible"] is False
+    assert example["compatibility"]["compatibilityState"] == "provisional"
+    assert "no_performance_measurement" in example["compatibility"]["warnings"]
+
+
+def test_descriptor_reference_matches_launcher_ide_status_without_coupling() -> None:
+    descriptor_module = load_module(MODULE_PATH, "model_runtime_descriptor_contract")
+    status_module = load_module(STATUS_MODULE_PATH, "launcher_ide_status_contract")
+    status_contract = status_module.create_launcher_ide_status_contract()
+    reference = descriptor_module.create_gemma3n_e4b_kv260_placeholder_example()[
+        "launcherIdeStatusReference"
+    ]
+
+    operation_ids = {operation["id"] for operation in status_contract["supportedOperations"]}
+    assert reference["operationId"] == "model.runtime.descriptor"
+    assert reference["operationId"] in operation_ids
+    assert reference["coupling"] == "data_reference_only"
+    assert reference["referenceKind"] == "descriptor_only"
+    assert reference["executesRuntime"] is False
+    assert reference["touchesHardware"] is False
+
+    status_source = read_text(STATUS_MODULE_PATH)
+    assert "model_runtime_descriptor_contract" not in status_source
+    assert status_contract["safetyFlags"]["modelExecution"] is False
+    assert status_contract["safetyFlags"]["touchesHardware"] is False
+
+
+test_descriptor_matches_fixture_and_is_deterministic()
+test_model_descriptor_schema_shape()
+test_runtime_descriptor_schema_shape()
+test_resolver_compatibility_result()
+test_no_bundled_weights_private_paths_secrets_or_provider_configs()
+test_no_runtime_execution_hardware_access_or_unsupported_claims()
+test_gemma3n_e4b_kv260_placeholder_is_not_measured()
+test_descriptor_reference_matches_launcher_ide_status_without_coupling()
+
+print("model/runtime descriptor tests ok")


### PR DESCRIPTION
## Summary

- add data-only model/runtime descriptor boundary
- add Gemma 3N E4B + KV260 placeholder fixture
- add compatibility resolver sketch and tests
- document descriptor-only scope and evidence requirements

## Scope

- contracts and fixtures
- tests
- docs
- CI wiring for the descriptor test

## Non-goals

- no runtime execution
- no model weight loading
- no KV260 access
- no provider/network calls
- no MCP/LSP/marketplace flow
- no release/tag
- no stable API/ABI claim

## Validation

- `git status --short --branch`
- `git diff --check`
- `git diff --cached --check`
- `python3 scripts/tests/launcher_ide_contract_test.py`
- `python3 scripts/tests/model_runtime_descriptor_test.py`
- `python3 -m pytest -q`
- `bash scripts/check.sh`
- `bash scripts/check-device-stub.sh`
- `bash scripts/install-stub.sh`
- `bash scripts/launch-stub.sh --dry-run`
- `bash scripts/status-stub.sh`
- `bash scripts/chat-stub.sh --dry-run --prompt hello`
- `bash scripts/tests/status-backend.sh scripts/status-stub.sh`
- claim-scan simulation: clean
- `npm test` skipped locally: no `package.json`
- `shellcheck` skipped locally: not installed; CI installs shellcheck

## Safety notes

- descriptors are placeholder/data-only
- weights are external/user-provided and not bundled
- compatibility is provisional until evidence exists
- no 20 tok/s or KV260 inference claim
- no real runtime, model, provider, KV260, MCP, LSP, or marketplace flow added

## Related issues

Closes #3.

Context only: #5, #12.
