### PR TITLE
Add read-only diagnostics handoff contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,27 @@ touch KV260 hardware, report performance, implement MCP/LSP, or make an
 API/ABI compatibility commitment. See
 [docs/MODEL_RUNTIME_DESCRIPTOR_BOUNDARY.md](./docs/MODEL_RUNTIME_DESCRIPTOR_BOUNDARY.md).
 
+### Diagnostics handoff boundary (planned)
+
+The launcher has a read-only diagnostics handoff contract for future
+pccx-lab consumers:
+
+```bash
+python3 contracts/diagnostics_handoff_contract.py
+python3 scripts/tests/diagnostics_handoff_contract_test.py
+```
+
+The checked fixture references the launcher/IDE status contract and the
+model/runtime descriptor fixture by id. It summarizes blocked or
+not-configured placeholder state without raw logs, private paths, user
+prompts, source code, secrets, tokens, provider configuration, model
+weight paths, telemetry, automatic upload, or write-back.
+
+This boundary does not execute pccx-lab, invoke launcher runtime code,
+touch KV260 hardware, call providers, implement MCP/LSP, or add a
+marketplace flow. See
+[docs/DIAGNOSTICS_HANDOFF_CONTRACT.md](./docs/DIAGNOSTICS_HANDOFF_CONTRACT.md).
+
 The legacy launcher scripts from the `llm-lite` era are preserved
 read-only under [`scripts/legacy/`](./scripts/legacy/) as historical
 reference (see that directory's README for status).

--- a/contracts/diagnostics_handoff_contract.py
+++ b/contracts/diagnostics_handoff_contract.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""Data-only diagnostics handoff contract placeholder.
+
+The contract describes a future read-only handoff from pccx-llm-launcher
+to pccx-lab. It does not execute pccx-lab, start launcher runtime code,
+probe hardware, load models, call providers, or write artifacts.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import sys
+
+
+SCHEMA_VERSION = "pccx.diagnosticsHandoff.v0"
+
+HANDOFF_FIELDS = (
+    "schemaVersion",
+    "handoffId",
+    "handoffKind",
+    "producer",
+    "consumer",
+    "createdAt",
+    "sessionId",
+    "launcherStatusRef",
+    "modelDescriptorRef",
+    "runtimeDescriptorRef",
+    "targetKind",
+    "targetDevice",
+    "diagnostics",
+    "evidenceRefs",
+    "artifactRefs",
+    "privacyFlags",
+    "safetyFlags",
+    "transport",
+    "limitations",
+    "issueRefs",
+)
+
+DIAGNOSTIC_ITEM_FIELDS = (
+    "diagnosticId",
+    "severity",
+    "category",
+    "source",
+    "title",
+    "summary",
+    "relatedContractRefs",
+    "suggestedNextAction",
+    "evidenceState",
+    "redactionState",
+)
+
+SEVERITY_VALUES = (
+    "info",
+    "warning",
+    "blocked",
+    "error",
+)
+
+CATEGORY_VALUES = (
+    "configuration",
+    "model_descriptor",
+    "runtime_descriptor",
+    "target_device",
+    "evidence",
+    "safety",
+    "diagnostics_handoff",
+)
+
+_DIAGNOSTICS_HANDOFF = {
+    "schemaVersion": SCHEMA_VERSION,
+    "handoffId": "launcher_diagnostics_handoff_gemma3n_e4b_kv260_placeholder",
+    "handoffKind": "read_only_handoff",
+    "producer": {
+        "id": "pccx-llm-launcher",
+        "role": "launcher_generated_summary",
+        "execution": "data_only",
+    },
+    "consumer": {
+        "id": "pccx-lab",
+        "role": "pccx_lab_future_consumer",
+        "boundary": "cli_core_future_consumer",
+        "state": "planned",
+    },
+    "createdAt": "1970-01-01T00:00:00Z",
+    "sessionId": "placeholder_session",
+    "launcherStatusRef": {
+        "schemaVersion": "pccx.launcherIdeStatus.v0",
+        "fixture": "contracts/fixtures/launcher-ide-status.placeholder.json",
+        "operationId": "pccxlab.diagnostics.handoff",
+        "referenceKind": "descriptor_ref_only",
+        "coupling": "data_reference_only",
+    },
+    "modelDescriptorRef": {
+        "schemaVersion": "pccx.modelDescriptor.v0",
+        "fixture": "contracts/fixtures/model-runtime-descriptor.gemma3n-e4b-kv260-placeholder.json",
+        "modelId": "gemma3n_e4b_placeholder",
+        "referenceKind": "descriptor_ref_only",
+    },
+    "runtimeDescriptorRef": {
+        "schemaVersion": "pccx.runtimeDescriptor.v0",
+        "fixture": "contracts/fixtures/model-runtime-descriptor.gemma3n-e4b-kv260-placeholder.json",
+        "runtimeId": "kv260_pccx_placeholder",
+        "referenceKind": "descriptor_ref_only",
+    },
+    "targetKind": "kv260",
+    "targetDevice": {
+        "id": "kv260_pccx_placeholder",
+        "label": "KV260 PCCX placeholder",
+        "configurationState": "not_configured",
+        "accessState": "no_hardware_access",
+    },
+    "diagnostics": [
+        {
+            "diagnosticId": "launcher_target_not_configured",
+            "severity": "warning",
+            "category": "configuration",
+            "source": "pccx-llm-launcher",
+            "title": "Launcher target is not configured",
+            "summary": "The handoff records a placeholder target state only.",
+            "relatedContractRefs": [
+                "pccx.launcherIdeStatus.v0",
+            ],
+            "suggestedNextAction": "Keep the handoff read-only until target configuration evidence exists.",
+            "evidenceState": "evidence_required",
+            "redactionState": "sanitized_summary",
+        },
+        {
+            "diagnosticId": "gemma3n_e4b_descriptor_reference_only",
+            "severity": "info",
+            "category": "model_descriptor",
+            "source": "pccx-llm-launcher",
+            "title": "Model descriptor is referenced by id",
+            "summary": "Gemma 3N E4B is represented as descriptor_ref_only with no bundled assets.",
+            "relatedContractRefs": [
+                "pccx.modelDescriptor.v0",
+            ],
+            "suggestedNextAction": "Collect descriptor and asset evidence before runtime claims.",
+            "evidenceState": "evidence_required",
+            "redactionState": "sanitized_summary",
+        },
+        {
+            "diagnosticId": "kv260_runtime_placeholder_not_configured",
+            "severity": "blocked",
+            "category": "runtime_descriptor",
+            "source": "pccx-llm-launcher",
+            "title": "KV260 runtime remains placeholder",
+            "summary": "The runtime descriptor is planned, unavailable, and not configured.",
+            "relatedContractRefs": [
+                "pccx.runtimeDescriptor.v0",
+                "pccx.modelRuntimeCompatibility.v0",
+            ],
+            "suggestedNextAction": "Require pccx-lab/core evidence before enabling runtime integration.",
+            "evidenceState": "evidence_required",
+            "redactionState": "sanitized_summary",
+        },
+        {
+            "diagnosticId": "hardware_and_measurement_evidence_missing",
+            "severity": "blocked",
+            "category": "evidence",
+            "source": "pccx-llm-launcher",
+            "title": "Hardware and measurement evidence are missing",
+            "summary": "Compatibility stays provisional until checked evidence exists.",
+            "relatedContractRefs": [
+                "pccx.modelRuntimeCompatibility.v0",
+            ],
+            "suggestedNextAction": "Treat all hardware and performance claims as not measured.",
+            "evidenceState": "not_measured",
+            "redactionState": "sanitized_summary",
+        },
+        {
+            "diagnosticId": "read_only_privacy_boundary",
+            "severity": "info",
+            "category": "safety",
+            "source": "pccx-llm-launcher",
+            "title": "Read-only privacy boundary is active",
+            "summary": "The fixture carries no telemetry, upload, write-back, raw logs, prompts, or private paths.",
+            "relatedContractRefs": [
+                "pccx.diagnosticsHandoff.v0",
+            ],
+            "suggestedNextAction": "Keep future consumer behavior explicit and opt-in.",
+            "evidenceState": "placeholder",
+            "redactionState": "sanitized_summary",
+        },
+    ],
+    "evidenceRefs": [
+        {
+            "evidenceId": "model_descriptor_evidence",
+            "state": "evidence_required",
+            "referenceKind": "descriptor_ref_only",
+        },
+        {
+            "evidenceId": "kv260_hardware_evidence",
+            "state": "evidence_required",
+            "referenceKind": "descriptor_ref_only",
+        },
+        {
+            "evidenceId": "measurement_evidence",
+            "state": "not_measured",
+            "referenceKind": "descriptor_ref_only",
+        },
+    ],
+    "artifactRefs": [
+        {
+            "artifactId": "launcher_status_contract_fixture",
+            "artifactKind": "json_fixture",
+            "reference": "contracts/fixtures/launcher-ide-status.placeholder.json",
+            "referenceKind": "read_only_local_artifact_reference",
+        },
+        {
+            "artifactId": "model_runtime_descriptor_fixture",
+            "artifactKind": "json_fixture",
+            "reference": "contracts/fixtures/model-runtime-descriptor.gemma3n-e4b-kv260-placeholder.json",
+            "referenceKind": "read_only_local_artifact_reference",
+        },
+    ],
+    "privacyFlags": {
+        "uploadPolicy": "no_user_data_upload",
+        "telemetryPolicy": "no_telemetry",
+        "automaticUpload": False,
+        "rawFullLogsIncluded": False,
+        "userPromptsIncluded": False,
+        "userSourceCodeIncluded": False,
+        "privatePathsIncluded": False,
+        "secretsIncluded": False,
+        "tokensIncluded": False,
+        "providerConfigsIncluded": False,
+        "modelWeightPathsIncluded": False,
+        "generatedBlobsIncluded": False,
+    },
+    "safetyFlags": {
+        "contractKind": "read_only_handoff",
+        "descriptorPolicy": "descriptor_ref_only",
+        "writeBackPolicy": "no_auto_writeback",
+        "runtimePolicy": "no_runtime_execution",
+        "hardwarePolicy": "no_hardware_access",
+        "evidencePolicy": "evidence_required",
+        "dataOnly": True,
+        "readOnly": True,
+        "executesPccxLab": False,
+        "executesLauncher": False,
+        "runtimeExecution": False,
+        "touchesHardware": False,
+        "kv260Access": False,
+        "modelExecution": False,
+        "networkCalls": False,
+        "providerCalls": False,
+        "shellExecution": False,
+        "mcpServerImplemented": False,
+        "lspImplemented": False,
+        "marketplaceFlow": False,
+        "telemetry": False,
+        "automaticUpload": False,
+        "writeBack": False,
+    },
+    "transport": [
+        {
+            "transportKind": "json_file",
+            "state": "sketch",
+            "direction": "launcher_to_pccx_lab_future_consumer",
+            "mode": "read_only_handoff",
+            "execution": "no_pccx_lab_execution",
+        },
+        {
+            "transportKind": "stdout_json",
+            "state": "sketch",
+            "direction": "launcher_to_pccx_lab_future_consumer",
+            "mode": "read_only_handoff",
+            "execution": "no_pccx_lab_execution",
+        },
+        {
+            "transportKind": "read_only_local_artifact_reference",
+            "state": "sketch",
+            "direction": "launcher_to_pccx_lab_future_consumer",
+            "mode": "read_only_handoff",
+            "execution": "no_pccx_lab_execution",
+        },
+    ],
+    "limitations": [
+        "Data-only placeholder; no pccx-lab execution is performed.",
+        "No launcher runtime execution, model execution, provider call, or network call is performed.",
+        "No KV260 hardware access is performed.",
+        "No telemetry, automatic upload, or auto write-back is included.",
+        "No raw full logs, prompts, source code, private paths, secrets, tokens, provider configuration, generated blobs, or model weight paths are included.",
+        "The contract is not a versioned compatibility commitment.",
+    ],
+    "issueRefs": [
+        "pccxai/pccx-llm-launcher#5",
+        "pccxai/pccx-llm-launcher#3",
+        "pccxai/pccx-llm-launcher#12",
+    ],
+}
+
+
+def create_diagnostics_handoff_contract() -> dict:
+    """Return a defensive copy of the placeholder handoff contract."""
+    return copy.deepcopy(_DIAGNOSTICS_HANDOFF)
+
+
+def handoff_json(handoff: dict | None = None) -> str:
+    """Render a deterministic JSON representation."""
+    return json.dumps(
+        handoff if handoff is not None else create_diagnostics_handoff_contract(),
+        indent=2,
+        sort_keys=True,
+    ) + "\n"
+
+
+def main() -> int:
+    sys.stdout.write(handoff_json())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contracts/fixtures/diagnostics-handoff.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/diagnostics-handoff.gemma3n-e4b-kv260-placeholder.json
@@ -1,0 +1,223 @@
+{
+  "artifactRefs": [
+    {
+      "artifactId": "launcher_status_contract_fixture",
+      "artifactKind": "json_fixture",
+      "reference": "contracts/fixtures/launcher-ide-status.placeholder.json",
+      "referenceKind": "read_only_local_artifact_reference"
+    },
+    {
+      "artifactId": "model_runtime_descriptor_fixture",
+      "artifactKind": "json_fixture",
+      "reference": "contracts/fixtures/model-runtime-descriptor.gemma3n-e4b-kv260-placeholder.json",
+      "referenceKind": "read_only_local_artifact_reference"
+    }
+  ],
+  "consumer": {
+    "boundary": "cli_core_future_consumer",
+    "id": "pccx-lab",
+    "role": "pccx_lab_future_consumer",
+    "state": "planned"
+  },
+  "createdAt": "1970-01-01T00:00:00Z",
+  "diagnostics": [
+    {
+      "category": "configuration",
+      "diagnosticId": "launcher_target_not_configured",
+      "evidenceState": "evidence_required",
+      "redactionState": "sanitized_summary",
+      "relatedContractRefs": [
+        "pccx.launcherIdeStatus.v0"
+      ],
+      "severity": "warning",
+      "source": "pccx-llm-launcher",
+      "suggestedNextAction": "Keep the handoff read-only until target configuration evidence exists.",
+      "summary": "The handoff records a placeholder target state only.",
+      "title": "Launcher target is not configured"
+    },
+    {
+      "category": "model_descriptor",
+      "diagnosticId": "gemma3n_e4b_descriptor_reference_only",
+      "evidenceState": "evidence_required",
+      "redactionState": "sanitized_summary",
+      "relatedContractRefs": [
+        "pccx.modelDescriptor.v0"
+      ],
+      "severity": "info",
+      "source": "pccx-llm-launcher",
+      "suggestedNextAction": "Collect descriptor and asset evidence before runtime claims.",
+      "summary": "Gemma 3N E4B is represented as descriptor_ref_only with no bundled assets.",
+      "title": "Model descriptor is referenced by id"
+    },
+    {
+      "category": "runtime_descriptor",
+      "diagnosticId": "kv260_runtime_placeholder_not_configured",
+      "evidenceState": "evidence_required",
+      "redactionState": "sanitized_summary",
+      "relatedContractRefs": [
+        "pccx.runtimeDescriptor.v0",
+        "pccx.modelRuntimeCompatibility.v0"
+      ],
+      "severity": "blocked",
+      "source": "pccx-llm-launcher",
+      "suggestedNextAction": "Require pccx-lab/core evidence before enabling runtime integration.",
+      "summary": "The runtime descriptor is planned, unavailable, and not configured.",
+      "title": "KV260 runtime remains placeholder"
+    },
+    {
+      "category": "evidence",
+      "diagnosticId": "hardware_and_measurement_evidence_missing",
+      "evidenceState": "not_measured",
+      "redactionState": "sanitized_summary",
+      "relatedContractRefs": [
+        "pccx.modelRuntimeCompatibility.v0"
+      ],
+      "severity": "blocked",
+      "source": "pccx-llm-launcher",
+      "suggestedNextAction": "Treat all hardware and performance claims as not measured.",
+      "summary": "Compatibility stays provisional until checked evidence exists.",
+      "title": "Hardware and measurement evidence are missing"
+    },
+    {
+      "category": "safety",
+      "diagnosticId": "read_only_privacy_boundary",
+      "evidenceState": "placeholder",
+      "redactionState": "sanitized_summary",
+      "relatedContractRefs": [
+        "pccx.diagnosticsHandoff.v0"
+      ],
+      "severity": "info",
+      "source": "pccx-llm-launcher",
+      "suggestedNextAction": "Keep future consumer behavior explicit and opt-in.",
+      "summary": "The fixture carries no telemetry, upload, write-back, raw logs, prompts, or private paths.",
+      "title": "Read-only privacy boundary is active"
+    }
+  ],
+  "evidenceRefs": [
+    {
+      "evidenceId": "model_descriptor_evidence",
+      "referenceKind": "descriptor_ref_only",
+      "state": "evidence_required"
+    },
+    {
+      "evidenceId": "kv260_hardware_evidence",
+      "referenceKind": "descriptor_ref_only",
+      "state": "evidence_required"
+    },
+    {
+      "evidenceId": "measurement_evidence",
+      "referenceKind": "descriptor_ref_only",
+      "state": "not_measured"
+    }
+  ],
+  "handoffId": "launcher_diagnostics_handoff_gemma3n_e4b_kv260_placeholder",
+  "handoffKind": "read_only_handoff",
+  "issueRefs": [
+    "pccxai/pccx-llm-launcher#5",
+    "pccxai/pccx-llm-launcher#3",
+    "pccxai/pccx-llm-launcher#12"
+  ],
+  "launcherStatusRef": {
+    "coupling": "data_reference_only",
+    "fixture": "contracts/fixtures/launcher-ide-status.placeholder.json",
+    "operationId": "pccxlab.diagnostics.handoff",
+    "referenceKind": "descriptor_ref_only",
+    "schemaVersion": "pccx.launcherIdeStatus.v0"
+  },
+  "limitations": [
+    "Data-only placeholder; no pccx-lab execution is performed.",
+    "No launcher runtime execution, model execution, provider call, or network call is performed.",
+    "No KV260 hardware access is performed.",
+    "No telemetry, automatic upload, or auto write-back is included.",
+    "No raw full logs, prompts, source code, private paths, secrets, tokens, provider configuration, generated blobs, or model weight paths are included.",
+    "The contract is not a versioned compatibility commitment."
+  ],
+  "modelDescriptorRef": {
+    "fixture": "contracts/fixtures/model-runtime-descriptor.gemma3n-e4b-kv260-placeholder.json",
+    "modelId": "gemma3n_e4b_placeholder",
+    "referenceKind": "descriptor_ref_only",
+    "schemaVersion": "pccx.modelDescriptor.v0"
+  },
+  "privacyFlags": {
+    "automaticUpload": false,
+    "generatedBlobsIncluded": false,
+    "modelWeightPathsIncluded": false,
+    "privatePathsIncluded": false,
+    "providerConfigsIncluded": false,
+    "rawFullLogsIncluded": false,
+    "secretsIncluded": false,
+    "telemetryPolicy": "no_telemetry",
+    "tokensIncluded": false,
+    "uploadPolicy": "no_user_data_upload",
+    "userPromptsIncluded": false,
+    "userSourceCodeIncluded": false
+  },
+  "producer": {
+    "execution": "data_only",
+    "id": "pccx-llm-launcher",
+    "role": "launcher_generated_summary"
+  },
+  "runtimeDescriptorRef": {
+    "fixture": "contracts/fixtures/model-runtime-descriptor.gemma3n-e4b-kv260-placeholder.json",
+    "referenceKind": "descriptor_ref_only",
+    "runtimeId": "kv260_pccx_placeholder",
+    "schemaVersion": "pccx.runtimeDescriptor.v0"
+  },
+  "safetyFlags": {
+    "automaticUpload": false,
+    "contractKind": "read_only_handoff",
+    "dataOnly": true,
+    "descriptorPolicy": "descriptor_ref_only",
+    "evidencePolicy": "evidence_required",
+    "executesLauncher": false,
+    "executesPccxLab": false,
+    "hardwarePolicy": "no_hardware_access",
+    "kv260Access": false,
+    "lspImplemented": false,
+    "marketplaceFlow": false,
+    "mcpServerImplemented": false,
+    "modelExecution": false,
+    "networkCalls": false,
+    "providerCalls": false,
+    "readOnly": true,
+    "runtimeExecution": false,
+    "runtimePolicy": "no_runtime_execution",
+    "shellExecution": false,
+    "telemetry": false,
+    "touchesHardware": false,
+    "writeBack": false,
+    "writeBackPolicy": "no_auto_writeback"
+  },
+  "schemaVersion": "pccx.diagnosticsHandoff.v0",
+  "sessionId": "placeholder_session",
+  "targetDevice": {
+    "accessState": "no_hardware_access",
+    "configurationState": "not_configured",
+    "id": "kv260_pccx_placeholder",
+    "label": "KV260 PCCX placeholder"
+  },
+  "targetKind": "kv260",
+  "transport": [
+    {
+      "direction": "launcher_to_pccx_lab_future_consumer",
+      "execution": "no_pccx_lab_execution",
+      "mode": "read_only_handoff",
+      "state": "sketch",
+      "transportKind": "json_file"
+    },
+    {
+      "direction": "launcher_to_pccx_lab_future_consumer",
+      "execution": "no_pccx_lab_execution",
+      "mode": "read_only_handoff",
+      "state": "sketch",
+      "transportKind": "stdout_json"
+    },
+    {
+      "direction": "launcher_to_pccx_lab_future_consumer",
+      "execution": "no_pccx_lab_execution",
+      "mode": "read_only_handoff",
+      "state": "sketch",
+      "transportKind": "read_only_local_artifact_reference"
+    }
+  ]
+}

--- a/docs/DIAGNOSTICS_HANDOFF_CONTRACT.md
+++ b/docs/DIAGNOSTICS_HANDOFF_CONTRACT.md
@@ -1,0 +1,151 @@
+# Diagnostics Handoff Contract
+
+This note defines the first launcher-side diagnostics handoff boundary
+for future pccx-lab consumers. It is a data-only contract and a checked
+fixture. It does not execute pccx-lab, start launcher runtime code, probe
+hardware, load a model, call a provider, or publish user data.
+
+The implementation lives in:
+
+- `contracts/diagnostics_handoff_contract.py`
+- `contracts/fixtures/diagnostics-handoff.gemma3n-e4b-kv260-placeholder.json`
+- `scripts/tests/diagnostics_handoff_contract_test.py`
+
+## What Is Implemented
+
+The contract currently provides:
+
+- a deterministic diagnostics handoff shape
+- a compact diagnostic item shape
+- a checked Gemma 3N E4B plus KV260 placeholder handoff fixture
+- references to the launcher/IDE status contract and model/runtime
+  descriptor fixture
+- read-only, no-upload, no-telemetry, and no-write-back flags
+- transport sketches for future JSON file, stdout JSON, and read-only
+  local artifact reference use
+
+This is enough for review and future pccx-lab alignment without binding
+either side to runtime execution.
+
+## Handoff Shape
+
+The handoff records:
+
+- `schemaVersion`
+- `handoffId`
+- `handoffKind`
+- `producer`
+- `consumer`
+- `createdAt`
+- `sessionId`
+- `launcherStatusRef`
+- `modelDescriptorRef`
+- `runtimeDescriptorRef`
+- `targetKind`
+- `targetDevice`
+- `diagnostics`
+- `evidenceRefs`
+- `artifactRefs`
+- `privacyFlags`
+- `safetyFlags`
+- `transport`
+- `limitations`
+- `issueRefs`
+
+The producer is `pccx-llm-launcher`. The consumer is pccx-lab as a
+future CLI/core consumer. The current fixture uses placeholder values and
+checked references only.
+
+## Diagnostic Items
+
+Each diagnostic item records:
+
+- `diagnosticId`
+- `severity`
+- `category`
+- `source`
+- `title`
+- `summary`
+- `relatedContractRefs`
+- `suggestedNextAction`
+- `evidenceState`
+- `redactionState`
+
+Severity values are `info`, `warning`, `blocked`, and `error`.
+
+Category values are `configuration`, `model_descriptor`,
+`runtime_descriptor`, `target_device`, `evidence`, `safety`, and
+`diagnostics_handoff`.
+
+The fixture uses sanitized summaries only. It does not include raw full
+logs, prompts, source code, private paths, secrets, tokens, provider
+configuration, generated blobs, or model weight paths.
+
+## Placeholder Fixture
+
+The checked fixture shows a conservative launcher summary for Gemma 3N
+E4B and the KV260 PCCX placeholder runtime:
+
+- launcher target: not configured
+- model descriptor: referenced by `gemma3n_e4b_placeholder`
+- runtime descriptor: referenced by `kv260_pccx_placeholder`
+- target device: placeholder, not configured, no hardware access
+- compatibility state: provisional by reference to the descriptor
+  boundary
+- evidence: required before hardware or performance claims
+- telemetry: disabled
+- automatic upload: disabled
+- write-back: disabled
+
+The fixture does not embed model/runtime descriptor bodies. It only
+references their checked fixture and identifiers. That keeps this
+handoff from becoming a second model/runtime contract.
+
+## Transport Sketch
+
+The current contract names three future-safe transport options:
+
+- JSON file handoff
+- stdout JSON handoff
+- read-only local artifact reference
+
+These are sketches, not implementations. This PR does not add a file
+watcher, background daemon, network transport, plugin execution, MCP
+server/client, LSP flow, marketplace flow, or pccx-lab command
+invocation.
+
+## pccx-lab Boundary
+
+pccx-lab remains CLI-first and core-first. Future pccx-lab work may read
+the handoff as a local artifact and validate the schema before any
+deeper integration. That consumer should not scrape launcher internals,
+call launcher commands, or turn GUI/editor code into the source of
+verification logic.
+
+The launcher may produce a sanitized, read-only summary. pccx-lab may
+consume that summary later as evidence-adjacent input. This repository
+does not implement that pccx-lab consumer in this PR.
+
+## Safety Notes
+
+This boundary does not add:
+
+- launcher runtime execution
+- pccx-lab execution
+- KV260 hardware access
+- model execution
+- provider calls
+- network calls
+- telemetry
+- automatic upload
+- automatic write-back
+- MCP implementation
+- LSP implementation
+- editor bridge runtime
+- marketplace or publisher flow
+- release or tag behavior
+- a versioned API or ABI commitment
+
+No stronger runtime, hardware, or performance claim should be made from
+this fixture. Evidence is required before those claims belong in public
+status output.

--- a/docs/LAUNCHER_IDE_BRIDGE_CONTRACT.md
+++ b/docs/LAUNCHER_IDE_BRIDGE_CONTRACT.md
@@ -79,6 +79,17 @@ Diagnostics handoff is planned as read-only first:
 - no user data
 - no model weight path
 
+The launcher now has a separate diagnostics handoff fixture for this
+planned boundary:
+
+- `contracts/diagnostics_handoff_contract.py`
+- `contracts/fixtures/diagnostics-handoff.gemma3n-e4b-kv260-placeholder.json`
+- [`DIAGNOSTICS_HANDOFF_CONTRACT.md`](./DIAGNOSTICS_HANDOFF_CONTRACT.md)
+
+That fixture references this status operation by id. It does not execute
+pccx-lab, invoke the launcher runtime, watch files, upload data, or write
+back into launcher state.
+
 ## Safety Notes
 
 This contract does not claim a KV260 run. It does not report throughput,

--- a/scripts/tests/diagnostics_handoff_contract_test.py
+++ b/scripts/tests/diagnostics_handoff_contract_test.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Fixture tests for the launcher diagnostics handoff contract."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "contracts" / "diagnostics_handoff_contract.py"
+STATUS_MODULE_PATH = ROOT / "contracts" / "launcher_ide_status_contract.py"
+FIXTURE_PATH = (
+    ROOT
+    / "contracts"
+    / "fixtures"
+    / "diagnostics-handoff.gemma3n-e4b-kv260-placeholder.json"
+)
+DOC_PATH = ROOT / "docs" / "DIAGNOSTICS_HANDOFF_CONTRACT.md"
+STATUS_DOC_PATH = ROOT / "docs" / "LAUNCHER_IDE_BRIDGE_CONTRACT.md"
+README_PATH = ROOT / "README.md"
+
+
+def load_module(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def flatten(value) -> str:
+    return json.dumps(value, sort_keys=True)
+
+
+def iter_keys(value):
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            yield key
+            yield from iter_keys(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            yield from iter_keys(nested)
+
+
+def assert_no_private_or_generated_data(text: str) -> None:
+    forbidden_patterns = [
+        r"/home/[^\s\"']+",
+        r"/Users/[^\s\"']+",
+        r"[A-Za-z]:\\Users\\",
+        r"\b(?:api[_-]?key|authorization|bearer|client[_-]?secret|password|private[_-]?key|secret|token)\b\s*[:=]",
+        r"\.(?:gguf|safetensors|ckpt|pt|pth|onnx)\b",
+        r"(?:weights|model_weights|model-cache)/(?:[^\"'\s]+)",
+        r"(?:raw[_-]?full[_-]?logs|hardware[_-]?dump|bitstream|generated[_-]?blob)\s*[:=]",
+    ]
+    for pattern in forbidden_patterns:
+        assert not re.search(pattern, text, re.IGNORECASE), pattern
+
+
+def assert_no_runtime_implementation_terms(source: str) -> None:
+    forbidden = [
+        "subprocess",
+        "os.system",
+        "popen",
+        "socket",
+        "urllib",
+        "requests",
+        "http.client",
+        "openai",
+        "anthropic",
+        "gemini",
+        "modelcontextprotocol",
+        "vscode-languageclient",
+        "vsce",
+        "watchdog",
+        "filewatcher",
+        "websocket",
+    ]
+    lowered = source.lower()
+    for term in forbidden:
+        assert term not in lowered, term
+
+
+def assert_no_provider_configs(value) -> None:
+    forbidden_keys = {
+        "apiKey",
+        "accessToken",
+        "refreshToken",
+        "authorization",
+        "bearerToken",
+        "provider",
+        "providers",
+        "providerConfig",
+        "providerConfigs",
+    }
+    for key in iter_keys(value):
+        assert key not in forbidden_keys, key
+
+
+def assert_no_unsupported_claims(text: str) -> None:
+    literal_claims = [
+        "production-ready",
+        "marketplace-ready",
+        "stable API",
+        "stable ABI",
+        "KV260 inference works",
+        "Gemma 3N E4B runs on KV260",
+        "20 tok/s achieved",
+        "timing closed",
+        "autonomous coding system",
+        "Claude directly controls",
+        "GPT directly controls",
+    ]
+    lowered = text.lower()
+    for claim in literal_claims:
+        assert claim.lower() not in lowered, claim
+
+    asserted_claim_patterns = [
+        r"\bMCP\s+(?:server|client)\s+(?:is\s+)?implemented\b",
+        r"\bLSP\s+(?:server|client)\s+(?:is\s+)?implemented\b",
+        r"\bAI\s+provider\s+(?:is\s+)?implemented\b",
+        r"\bKV260\s+run\s+(?:is\s+)?claimed\b",
+    ]
+    for pattern in asserted_claim_patterns:
+        assert not re.search(pattern, text, re.IGNORECASE), pattern
+
+
+def test_handoff_matches_fixture_and_is_deterministic() -> None:
+    module = load_module(MODULE_PATH, "diagnostics_handoff_contract")
+    generated = module.create_diagnostics_handoff_contract()
+    fixture = json.loads(read_text(FIXTURE_PATH))
+
+    assert generated == fixture
+    assert module.handoff_json(generated) == module.handoff_json(generated)
+    assert module.handoff_json(generated).endswith("\n")
+    assert json.loads(module.handoff_json(generated)) == fixture
+
+
+def test_handoff_shape_and_diagnostic_values() -> None:
+    module = load_module(MODULE_PATH, "diagnostics_handoff_contract")
+    handoff = module.create_diagnostics_handoff_contract()
+
+    assert tuple(handoff.keys()) == module.HANDOFF_FIELDS
+    assert handoff["schemaVersion"] == "pccx.diagnosticsHandoff.v0"
+    assert handoff["handoffKind"] == "read_only_handoff"
+    assert handoff["producer"]["role"] == "launcher_generated_summary"
+    assert handoff["consumer"]["role"] == "pccx_lab_future_consumer"
+    assert handoff["targetKind"] == "kv260"
+    assert handoff["targetDevice"]["configurationState"] == "not_configured"
+    assert handoff["targetDevice"]["accessState"] == "no_hardware_access"
+
+    severities = set()
+    categories = set()
+    diagnostic_ids = set()
+    for diagnostic in handoff["diagnostics"]:
+        assert tuple(diagnostic.keys()) == module.DIAGNOSTIC_ITEM_FIELDS
+        severities.add(diagnostic["severity"])
+        categories.add(diagnostic["category"])
+        diagnostic_ids.add(diagnostic["diagnosticId"])
+        assert diagnostic["evidenceState"] in {
+            "evidence_required",
+            "not_measured",
+            "placeholder",
+        }
+        assert diagnostic["redactionState"] == "sanitized_summary"
+
+    assert severities <= set(module.SEVERITY_VALUES)
+    assert categories <= set(module.CATEGORY_VALUES)
+    assert {"info", "warning", "blocked"} <= severities
+    assert "launcher_target_not_configured" in diagnostic_ids
+    assert "kv260_runtime_placeholder_not_configured" in diagnostic_ids
+    assert "read_only_privacy_boundary" in diagnostic_ids
+
+
+def test_read_only_privacy_and_safety_flags() -> None:
+    handoff = load_module(
+        MODULE_PATH,
+        "diagnostics_handoff_contract",
+    ).create_diagnostics_handoff_contract()
+
+    privacy = handoff["privacyFlags"]
+    assert privacy["uploadPolicy"] == "no_user_data_upload"
+    assert privacy["telemetryPolicy"] == "no_telemetry"
+    for name in [
+        "automaticUpload",
+        "rawFullLogsIncluded",
+        "userPromptsIncluded",
+        "userSourceCodeIncluded",
+        "privatePathsIncluded",
+        "secretsIncluded",
+        "tokensIncluded",
+        "providerConfigsIncluded",
+        "modelWeightPathsIncluded",
+        "generatedBlobsIncluded",
+    ]:
+        assert privacy[name] is False, name
+
+    flags = handoff["safetyFlags"]
+    assert flags["contractKind"] == "read_only_handoff"
+    assert flags["descriptorPolicy"] == "descriptor_ref_only"
+    assert flags["writeBackPolicy"] == "no_auto_writeback"
+    assert flags["runtimePolicy"] == "no_runtime_execution"
+    assert flags["hardwarePolicy"] == "no_hardware_access"
+    assert flags["evidencePolicy"] == "evidence_required"
+    assert flags["dataOnly"] is True
+    assert flags["readOnly"] is True
+    for name in [
+        "executesPccxLab",
+        "executesLauncher",
+        "runtimeExecution",
+        "touchesHardware",
+        "kv260Access",
+        "modelExecution",
+        "networkCalls",
+        "providerCalls",
+        "shellExecution",
+        "mcpServerImplemented",
+        "lspImplemented",
+        "marketplaceFlow",
+        "telemetry",
+        "automaticUpload",
+        "writeBack",
+    ]:
+        assert flags[name] is False, name
+
+
+def test_transport_sketches_are_future_safe() -> None:
+    handoff = load_module(
+        MODULE_PATH,
+        "diagnostics_handoff_contract",
+    ).create_diagnostics_handoff_contract()
+    transports = {item["transportKind"]: item for item in handoff["transport"]}
+
+    assert set(transports) == {
+        "json_file",
+        "stdout_json",
+        "read_only_local_artifact_reference",
+    }
+    for item in transports.values():
+        assert item["state"] == "sketch"
+        assert item["mode"] == "read_only_handoff"
+        assert item["execution"] == "no_pccx_lab_execution"
+
+
+def test_fixture_references_descriptors_without_runtime_coupling() -> None:
+    handoff = load_module(
+        MODULE_PATH,
+        "diagnostics_handoff_contract",
+    ).create_diagnostics_handoff_contract()
+
+    assert "modelDescriptor" not in handoff
+    assert "runtimeDescriptor" not in handoff
+    assert handoff["modelDescriptorRef"]["modelId"] == "gemma3n_e4b_placeholder"
+    assert handoff["runtimeDescriptorRef"]["runtimeId"] == "kv260_pccx_placeholder"
+    assert handoff["modelDescriptorRef"]["referenceKind"] == "descriptor_ref_only"
+    assert handoff["runtimeDescriptorRef"]["referenceKind"] == "descriptor_ref_only"
+    assert handoff["launcherStatusRef"]["coupling"] == "data_reference_only"
+    assert handoff["launcherStatusRef"]["operationId"] == "pccxlab.diagnostics.handoff"
+
+    fixture_refs = flatten(handoff)
+    assert "model-runtime-descriptor.gemma3n-e4b-kv260-placeholder.json" in fixture_refs
+    assert "launcher-ide-status.placeholder.json" in fixture_refs
+
+
+def test_handoff_can_be_referenced_by_launcher_status_contract() -> None:
+    handoff = load_module(
+        MODULE_PATH,
+        "diagnostics_handoff_contract",
+    ).create_diagnostics_handoff_contract()
+    status = load_module(
+        STATUS_MODULE_PATH,
+        "launcher_ide_status_contract",
+    ).create_launcher_ide_status_contract()
+
+    operations = {operation["id"]: operation for operation in status["supportedOperations"]}
+    operation = operations[handoff["launcherStatusRef"]["operationId"]]
+    assert operation["handoffMode"] == "read_only_handoff"
+    assert operation["lowerBoundary"] == "pccx-lab CLI/core"
+    assert status["diagnosticsHandoff"]["mode"] == "read_only_handoff"
+    assert status["diagnosticsHandoff"]["writeBack"] is False
+    assert status["diagnosticsHandoff"]["automaticUpload"] is False
+
+
+def test_no_private_data_runtime_calls_or_overclaims() -> None:
+    module_source = read_text(MODULE_PATH)
+    handoff = load_module(
+        MODULE_PATH,
+        "diagnostics_handoff_contract",
+    ).create_diagnostics_handoff_contract()
+    scan_text = "\n".join([
+        read_text(FIXTURE_PATH),
+        read_text(DOC_PATH),
+        read_text(STATUS_DOC_PATH),
+        read_text(README_PATH),
+        flatten(handoff),
+        module_source,
+    ])
+
+    assert_no_runtime_implementation_terms(module_source)
+    assert_no_private_or_generated_data(scan_text)
+    assert_no_provider_configs(handoff)
+    assert_no_unsupported_claims(scan_text)
+
+
+test_handoff_matches_fixture_and_is_deterministic()
+test_handoff_shape_and_diagnostic_values()
+test_read_only_privacy_and_safety_flags()
+test_transport_sketches_are_future_safe()
+test_fixture_references_descriptors_without_runtime_coupling()
+test_handoff_can_be_referenced_by_launcher_status_contract()
+test_no_private_data_runtime_calls_or_overclaims()
+
+print("diagnostics handoff contract tests ok")


### PR DESCRIPTION
## Summary

Adds a data-only launcher diagnostics handoff contract for future pccx-lab consumers, including a deterministic Gemma 3N E4B plus KV260 placeholder fixture and tests.

## Scope

- New `contracts/diagnostics_handoff_contract.py` module.
- New checked diagnostics handoff fixture.
- New fixture/guard tests for shape, deterministic output, severity/category values, read-only flags, transport sketches, descriptor references, and safety scans.
- Docs and README notes for the read-only handoff boundary.

## Non-goals

- No pccx-lab execution.
- No launcher runtime execution.
- No KV260 hardware access.
- No model execution, provider calls, telemetry, upload, or write-back.
- No MCP, LSP, marketplace, release, or tag work.
- No versioned API or ABI commitment.

## Validation

- `git diff --check`
- `python3 scripts/tests/diagnostics_handoff_contract_test.py`
- `python3 scripts/tests/launcher_ide_contract_test.py`
- `python3 scripts/tests/model_runtime_descriptor_test.py`
- `python3 -m pytest -q`
- `bash scripts/check.sh`
- `bash scripts/check-device-stub.sh`
- `bash scripts/install-stub.sh`
- `bash scripts/launch-stub.sh --dry-run`
- `bash scripts/status-stub.sh`
- `bash scripts/chat-stub.sh --dry-run --prompt hello`
- `bash scripts/tests/status-backend.sh scripts/status-stub.sh`

Local notes: `package.json` is absent, so no npm test target exists. `shellcheck` is not installed locally; `scripts/check.sh` reports it as unavailable.

## Safety notes

The fixture stores sanitized summary data only. It contains no private absolute paths, secrets, tokens, provider configuration, raw full logs, user prompts, user source code, model weight paths, generated blobs, hardware dumps, telemetry payloads, or automatic upload/write-back behavior.

## Related issues

Refs #5.
Refs #12.