### PR TITLE
Reference pccx-lab diagnostics handoff validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,9 @@ touch KV260 hardware, call providers, implement MCP/LSP, or add a
 marketplace flow. See
 [docs/DIAGNOSTICS_HANDOFF_CONTRACT.md](./docs/DIAGNOSTICS_HANDOFF_CONTRACT.md).
 
+pccx-lab has a separate read-only validator for this JSON shape. The
+launcher does not invoke that command or depend on it at runtime.
+
 The legacy launcher scripts from the `llm-lite` era are preserved
 read-only under [`scripts/legacy/`](./scripts/legacy/) as historical
 reference (see that directory's README for status).

--- a/docs/DIAGNOSTICS_HANDOFF_CONTRACT.md
+++ b/docs/DIAGNOSTICS_HANDOFF_CONTRACT.md
@@ -126,6 +126,17 @@ The launcher may produce a sanitized, read-only summary. pccx-lab may
 consume that summary later as evidence-adjacent input. This repository
 does not implement that pccx-lab consumer in this PR.
 
+pccx-lab now has a matching read-only validation boundary:
+
+```bash
+pccx-lab diagnostics-handoff validate --file <path> --format json
+```
+
+That command lives on the pccx-lab side and validates a local JSON file.
+This launcher repository does not invoke it, require it, watch for it,
+or write back from it. Fixture sync is manual while the handoff remains
+pre-compatibility.
+
 ## Safety Notes
 
 This boundary does not add:

--- a/scripts/tests/diagnostics_handoff_contract_test.py
+++ b/scripts/tests/diagnostics_handoff_contract_test.py
@@ -308,6 +308,16 @@ def test_no_private_data_runtime_calls_or_overclaims() -> None:
     assert_no_unsupported_claims(scan_text)
 
 
+def test_docs_reference_pccx_lab_read_only_consumer_without_invocation() -> None:
+    docs_text = read_text(DOC_PATH)
+    readme_text = read_text(README_PATH)
+
+    assert "pccx-lab diagnostics-handoff validate --file <path> --format json" in docs_text
+    assert "matching read-only validation boundary" in docs_text
+    assert "This launcher repository does not invoke it" in docs_text
+    assert "does not invoke that command" in readme_text
+
+
 test_handoff_matches_fixture_and_is_deterministic()
 test_handoff_shape_and_diagnostic_values()
 test_read_only_privacy_and_safety_flags()
@@ -315,5 +325,6 @@ test_transport_sketches_are_future_safe()
 test_fixture_references_descriptors_without_runtime_coupling()
 test_handoff_can_be_referenced_by_launcher_status_contract()
 test_no_private_data_runtime_calls_or_overclaims()
+test_docs_reference_pccx_lab_read_only_consumer_without_invocation()
 
 print("diagnostics handoff contract tests ok")


### PR DESCRIPTION
## Summary

Documents the pccx-lab read-only diagnostics handoff validator added after the launcher handoff contract, and adds a small docs assertion to keep the boundary wording honest.

## Scope

- Update diagnostics handoff docs with the pccx-lab validator command as a cross-reference.
- Update README with the same runtime boundary note.
- Add a docs test assertion that the launcher references the pccx-lab consumer without implying launcher-side invocation.

## Non-goals

- No schema changes.
- No pccx-lab command invocation.
- No launcher runtime execution.
- No KV260 hardware access, provider calls, telemetry, upload, write-back, MCP, LSP, marketplace, release, or tag work.

## Validation

- `git diff --check`
- `python3 scripts/tests/diagnostics_handoff_contract_test.py`
- `python3 scripts/tests/launcher_ide_contract_test.py`
- `python3 scripts/tests/model_runtime_descriptor_test.py`
- `python3 -m pytest -q`
- `bash scripts/check.sh`
- `bash scripts/check-device-stub.sh`
- `bash scripts/install-stub.sh`
- `bash scripts/launch-stub.sh --dry-run`
- `bash scripts/status-stub.sh`
- `bash scripts/chat-stub.sh --dry-run --prompt hello`
- `bash scripts/tests/status-backend.sh scripts/status-stub.sh`

Local notes: `package.json` is absent, so no npm test target exists. `shellcheck` is not installed locally; `scripts/check.sh` reports it as unavailable.

## Safety notes

This is docs/test alignment only. The launcher does not call pccx-lab, watch files, execute runtime code, access hardware, upload data, or write back from the pccx-lab validator.

## Related

Refs #5.
Refs pccxai/pccx-lab#30.