### PR TITLE
Add runtime readiness status contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+
 name: ci
 
 on:
@@ -107,6 +110,7 @@ jobs:
                    scripts/install-stub.sh \
                    scripts/launch-stub.sh \
                    scripts/status-stub.sh \
+                   scripts/runtime-readiness-stub.sh \
                    scripts/chat-stub.sh; do
             [ -f "$f" ] && chmod +x "$f" || true
           done
@@ -138,6 +142,8 @@ jobs:
           echo "launch-stub correctly refused without --dry-run"
       - name: run scripts/status-stub.sh
         run: ./scripts/status-stub.sh
+      - name: run scripts/runtime-readiness-stub.sh
+        run: ./scripts/runtime-readiness-stub.sh --model gemma3n-e4b --target kv260
       - name: run scripts/chat-stub.sh --dry-run
         run: ./scripts/chat-stub.sh --dry-run --prompt "hello"
       - name: chat-stub refuses without --dry-run
@@ -152,6 +158,10 @@ jobs:
         run: python3 scripts/tests/launcher_ide_contract_test.py
       - name: run model/runtime descriptor tests
         run: python3 scripts/tests/model_runtime_descriptor_test.py
+      - name: run diagnostics handoff contract tests
+        run: python3 scripts/tests/diagnostics_handoff_contract_test.py
+      - name: run runtime readiness contract tests
+        run: python3 scripts/tests/runtime_readiness_contract_test.py
 
   status-backend:
     name: status-backend-tests

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ and verify host-side prerequisites before the real engine lands.
 | [`scripts/check-device-stub.sh`](./scripts/check-device-stub.sh) | Narrowly scoped device-tree / FPGA-node probe (KV260 / Kria detection only). Always exits 0. |
 | [`scripts/install-stub.sh`](./scripts/install-stub.sh) | Preview of the planned install flow; reports which host runtime pieces are present, lists device-side pieces as future deliverables. Always exits 0. |
 | [`scripts/status-stub.sh`](./scripts/status-stub.sh) | Launcher state summary. Default mode: local scaffold output, always exits 0. With `--backend pccx-lab`, calls `pccx-lab status --format json` and forwards the run-status envelope (exits non-zero if binary is missing or output is invalid). |
+| [`scripts/runtime-readiness-stub.sh`](./scripts/runtime-readiness-stub.sh) | Data-only runtime readiness JSON for the Gemma 3N E4B + KV260 target. Reports blocked / not yet evidence-backed. |
 | [`scripts/launch-stub.sh`](./scripts/launch-stub.sh) | Dry-run preview of the intended launch sequence. Requires `--dry-run`; exits 1 without it. |
 | [`scripts/chat-stub.sh`](./scripts/chat-stub.sh) | Dry-run chat stub. Requires `--dry-run`; exits 1 without it. Accepts `--prompt "..."` or stdin. No model is executed. |
 
@@ -93,6 +94,7 @@ bash scripts/check.sh
 bash scripts/check-device-stub.sh
 bash scripts/install-stub.sh
 bash scripts/status-stub.sh
+bash scripts/runtime-readiness-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/launch-stub.sh --dry-run
 bash scripts/chat-stub.sh --dry-run --prompt "hello"
 ```
@@ -191,6 +193,30 @@ marketplace flow. See
 
 pccx-lab has a separate read-only validator for this JSON shape. The
 launcher does not invoke that command or depend on it at runtime.
+
+### Runtime readiness status (planned)
+
+The launcher now has a data-only, evidence-aware runtime readiness
+surface for the Gemma 3N E4B + KV260 target:
+
+```bash
+python3 contracts/runtime_readiness_contract.py --model gemma3n-e4b --target kv260
+bash scripts/runtime-readiness-stub.sh --model gemma3n-e4b --target kv260
+python3 scripts/tests/runtime_readiness_contract_test.py
+```
+
+The checked fixture reports the current answer as blocked / not yet
+evidence-backed. It includes a deterministic fixture version,
+last-updated source boundary, top-level readiness/evidence states,
+descriptor evidence, xsim evidence of 11 passed and 0 failed, and Vivado
+synthesis evidence while keeping timing, implementation, bitstream,
+KV260 smoke, runtime evidence, and throughput measurement in blocked or
+target-only states. 20 tok/s remains a target until measured.
+
+This surface does not load weights, execute a runtime, touch KV260
+hardware, call providers, invoke pccx-lab, invoke systemverilog-ide,
+upload telemetry, or write artifacts. See
+[docs/RUNTIME_READINESS_STATUS.md](./docs/RUNTIME_READINESS_STATUS.md).
 
 The legacy launcher scripts from the `llm-lite` era are preserved
 read-only under [`scripts/legacy/`](./scripts/legacy/) as historical

--- a/contracts/fixtures/runtime-readiness.gemma3n-e4b-kv260.json
+++ b/contracts/fixtures/runtime-readiness.gemma3n-e4b-kv260.json
@@ -1,0 +1,207 @@
+{
+  "bitstreamState": "blocked",
+  "blockers": [
+    {
+      "blockerId": "board_model_bitstream_runtime_environment_missing",
+      "requiredBefore": "kv260_smoke_or_runtime_claim",
+      "state": "blocked",
+      "summary": "KV260 board, model assets, generated bitstream, and runtime environment are not provided by this launcher fixture."
+    },
+    {
+      "blockerId": "post_synth_drc_timing_open",
+      "requiredBefore": "implementation_or_bitstream_claim",
+      "state": "blocked",
+      "summary": "Post-synthesis DRC and timing issues remain open in the FPGA closure state."
+    },
+    {
+      "blockerId": "implementation_incomplete",
+      "requiredBefore": "bitstream_or_board_smoke_claim",
+      "state": "blocked",
+      "summary": "Implementation is not complete, so hardware closure is not available."
+    },
+    {
+      "blockerId": "bitstream_not_generated",
+      "requiredBefore": "kv260_board_smoke_claim",
+      "state": "blocked",
+      "summary": "A generated bitstream is not proven by this launcher surface."
+    },
+    {
+      "blockerId": "gemma3n_e4b_runtime_evidence_absent",
+      "requiredBefore": "runtime_or_performance_claim",
+      "state": "blocked",
+      "summary": "Gemma 3N E4B has no KV260 hardware runtime evidence in this launcher fixture."
+    },
+    {
+      "blockerId": "throughput_measurement_absent",
+      "requiredBefore": "performance_claim",
+      "state": "blocked",
+      "summary": "Throughput measurement is unavailable."
+    }
+  ],
+  "boardInputState": "ready_for_inputs",
+  "compatibilityState": "blocked",
+  "coordinationNotes": {
+    "launcher": "The launcher provides data contracts first and does not add runtime integration in this phase.",
+    "pccxLab": "pccx-lab remains the future CLI/core diagnostics and verification backend; this launcher fixture does not invoke it.",
+    "systemverilogIde": "systemverilog-ide may consume launcher or lab data later as read-only context; this fixture does not invoke or control it."
+  },
+  "descriptorState": "evidence_present",
+  "evidenceRefs": [
+    {
+      "evidenceId": "launcher_model_runtime_descriptor_fixture",
+      "referenceKind": "repo_fixture_reference",
+      "state": "evidence_present",
+      "summary": "The launcher has a checked descriptor fixture for Gemma 3N E4B and the KV260 placeholder runtime."
+    },
+    {
+      "evidenceId": "fpga_v002_xsim_validation",
+      "referenceKind": "external_repo_state_summary",
+      "state": "evidence_present",
+      "summary": "pccx-FPGA-NPU-LLM-kv260 v002 repo-local xsim evidence reports 11 passed and 0 failed."
+    },
+    {
+      "evidenceId": "fpga_v002_vivado_synth",
+      "referenceKind": "external_repo_state_summary",
+      "state": "evidence_present",
+      "summary": "Vivado synthesis evidence exists, but this is not hardware closure."
+    },
+    {
+      "evidenceId": "fpga_post_synth_drc_timing",
+      "referenceKind": "external_repo_state_summary",
+      "state": "blocked",
+      "summary": "Post-synthesis DRC and timing issues are current closure blockers."
+    },
+    {
+      "evidenceId": "kv260_board_smoke",
+      "referenceKind": "future_evidence_required",
+      "state": "blocked",
+      "summary": "KV260 board smoke is blocked by missing board, model, bitstream, and runtime environment."
+    },
+    {
+      "evidenceId": "gemma3n_e4b_kv260_runtime",
+      "referenceKind": "future_evidence_required",
+      "state": "blocked",
+      "summary": "Gemma 3N E4B KV260 hardware runtime evidence is absent."
+    },
+    {
+      "evidenceId": "gemma3n_e4b_kv260_throughput",
+      "referenceKind": "future_measurement_required",
+      "state": "target",
+      "summary": "Throughput remains a target-only item until measured evidence exists."
+    }
+  ],
+  "evidenceState": "blocked",
+  "fixtureVersion": "runtime-readiness.gemma3n-e4b-kv260.2026-05-03",
+  "implementationState": "blocked",
+  "issueRefs": [
+    "pccxai/pccx-llm-launcher#3",
+    "pccxai/pccx-llm-launcher#5",
+    "pccxai/pccx-llm-launcher#12"
+  ],
+  "kv260SmokeState": "blocked",
+  "lastUpdatedSource": "pccx_evidence_boundary_2026-05-03",
+  "limitations": [
+    "Data-only runtime readiness surface; no runtime is executed.",
+    "No model assets are bundled, loaded, or referenced by path.",
+    "No KV260 hardware access, board smoke, bitstream programming, or provider call is performed.",
+    "xsim and Vivado synthesis evidence are recorded as evidence-aware status only, not hardware closure.",
+    "Timing, implementation, bitstream, KV260 smoke, runtime, and throughput evidence remain missing for this launcher fixture.",
+    "20 tok/s is a target only until measured evidence exists.",
+    "This is not a release, tag, versioned compatibility commitment, MCP, LSP, IDE, marketplace, or telemetry implementation."
+  ],
+  "modelFamily": "gemma3n",
+  "modelId": "gemma3n_e4b_placeholder",
+  "modelVariant": "e4b",
+  "modelWeightState": "ready_for_inputs",
+  "nextInputsRequired": [
+    {
+      "inputId": "external_model_assets",
+      "sourceBoundary": "user_or_future_runtime_integration",
+      "state": "ready_for_inputs",
+      "summary": "Gemma 3N E4B model assets remain external and are not loaded or referenced by path."
+    },
+    {
+      "inputId": "kv260_board_environment",
+      "sourceBoundary": "future_pccx_lab_or_core_handoff",
+      "state": "ready_for_inputs",
+      "summary": "KV260 board and runtime environment evidence must arrive from lower layers before smoke status changes."
+    },
+    {
+      "inputId": "timing_and_implementation_closure",
+      "sourceBoundary": "pccx_fpga_kv260_repo",
+      "state": "ready_for_inputs",
+      "summary": "Post-synthesis DRC, timing, implementation, and bitstream evidence must be supplied by FPGA closure work."
+    },
+    {
+      "inputId": "kv260_smoke_evidence",
+      "sourceBoundary": "future_pccx_lab_or_core_handoff",
+      "state": "ready_for_inputs",
+      "summary": "Board smoke evidence is required before KV260 runtime status can move beyond blocked."
+    },
+    {
+      "inputId": "throughput_measurement",
+      "sourceBoundary": "future_pccx_lab_or_core_handoff",
+      "state": "ready_for_inputs",
+      "summary": "Measured throughput evidence is required before any performance claim."
+    }
+  ],
+  "overallState": "blocked",
+  "performanceTargets": [
+    {
+      "achieved": false,
+      "measured": false,
+      "metricId": "decode_throughput",
+      "state": "target",
+      "summary": "20 tok/s remains a target until measured on the Gemma 3N E4B plus KV260 path.",
+      "target": "20 tok/s"
+    }
+  ],
+  "readinessId": "runtime_readiness_gemma3n_e4b_kv260",
+  "readinessState": "blocked",
+  "runtimeEvidenceState": "blocked",
+  "safetyFlags": {
+    "automaticUpload": false,
+    "dataOnly": true,
+    "descriptorOnly": true,
+    "deterministic": true,
+    "executesPccxLab": false,
+    "executesSystemverilogIde": false,
+    "generatedBlobsIncluded": false,
+    "hardwareDumpsIncluded": false,
+    "kv260Access": false,
+    "lspImplemented": false,
+    "marketplaceFlow": false,
+    "mcpServerImplemented": false,
+    "modelExecution": false,
+    "modelLoaded": false,
+    "modelWeightPathsIncluded": false,
+    "networkCalls": false,
+    "privatePathsIncluded": false,
+    "providerCalls": false,
+    "readOnly": true,
+    "runtimeExecution": false,
+    "secretsIncluded": false,
+    "stableApiAbiClaim": false,
+    "telemetry": false,
+    "tokensIncluded": false,
+    "touchesHardware": false,
+    "writeBack": false,
+    "writesArtifacts": false
+  },
+  "schemaVersion": "pccx.runtimeReadiness.v0",
+  "simulationEvidenceState": "evidence_present",
+  "stateVocabulary": {
+    "blocked": "A required input, artifact, closure step, or runtime evidence item is missing.",
+    "evidence_present": "Checked non-runtime evidence exists for this item.",
+    "measured": "A runtime or hardware measurement exists. The current fixture does not use this state for Gemma 3N E4B on KV260.",
+    "ready_for_inputs": "The launcher can describe the required input without bundling or reading it.",
+    "target": "Named planned target only."
+  },
+  "statusAnswer": "blocked_not_yet_evidence_backed",
+  "targetBoard": "xilinx_kria_kv260",
+  "targetDevice": "kv260",
+  "targetState": "target",
+  "throughputEvidenceState": "target",
+  "timingEvidenceState": "blocked",
+  "vivadoSynthState": "evidence_present"
+}

--- a/contracts/runtime_readiness_contract.py
+++ b/contracts/runtime_readiness_contract.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Data-only runtime readiness contract for the planned KV260 path.
+
+The contract reports evidence-aware launcher readiness without loading model
+assets, touching KV260 hardware, executing runtime commands, calling providers,
+or invoking pccx-lab or editor tooling.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import sys
+
+
+SCHEMA_VERSION = "pccx.runtimeReadiness.v0"
+
+READINESS_STATE_VALUES = (
+    "target",
+    "blocked",
+    "ready_for_inputs",
+    "evidence_present",
+    "measured",
+)
+
+READINESS_FIELDS = (
+    "schemaVersion",
+    "readinessId",
+    "fixtureVersion",
+    "lastUpdatedSource",
+    "statusAnswer",
+    "readinessState",
+    "evidenceState",
+    "modelId",
+    "modelFamily",
+    "modelVariant",
+    "targetDevice",
+    "targetBoard",
+    "targetState",
+    "overallState",
+    "descriptorState",
+    "modelWeightState",
+    "boardInputState",
+    "bitstreamState",
+    "simulationEvidenceState",
+    "vivadoSynthState",
+    "timingEvidenceState",
+    "implementationState",
+    "kv260SmokeState",
+    "runtimeEvidenceState",
+    "throughputEvidenceState",
+    "compatibilityState",
+    "stateVocabulary",
+    "blockers",
+    "nextInputsRequired",
+    "performanceTargets",
+    "evidenceRefs",
+    "coordinationNotes",
+    "safetyFlags",
+    "limitations",
+    "issueRefs",
+)
+
+BLOCKER_FIELDS = (
+    "blockerId",
+    "state",
+    "summary",
+    "requiredBefore",
+)
+
+NEXT_INPUT_FIELDS = (
+    "inputId",
+    "state",
+    "summary",
+    "sourceBoundary",
+)
+
+EVIDENCE_REF_FIELDS = (
+    "evidenceId",
+    "state",
+    "summary",
+    "referenceKind",
+)
+
+PERFORMANCE_TARGET_FIELDS = (
+    "metricId",
+    "state",
+    "target",
+    "measured",
+    "achieved",
+    "summary",
+)
+
+_GEMMA3N_E4B_KV260_RUNTIME_READINESS = {
+    "schemaVersion": SCHEMA_VERSION,
+    "readinessId": "runtime_readiness_gemma3n_e4b_kv260",
+    "fixtureVersion": "runtime-readiness.gemma3n-e4b-kv260.2026-05-03",
+    "lastUpdatedSource": "pccx_evidence_boundary_2026-05-03",
+    "statusAnswer": "blocked_not_yet_evidence_backed",
+    "readinessState": "blocked",
+    "evidenceState": "blocked",
+    "modelId": "gemma3n_e4b_placeholder",
+    "modelFamily": "gemma3n",
+    "modelVariant": "e4b",
+    "targetDevice": "kv260",
+    "targetBoard": "xilinx_kria_kv260",
+    "targetState": "target",
+    "overallState": "blocked",
+    "descriptorState": "evidence_present",
+    "modelWeightState": "ready_for_inputs",
+    "boardInputState": "ready_for_inputs",
+    "bitstreamState": "blocked",
+    "simulationEvidenceState": "evidence_present",
+    "vivadoSynthState": "evidence_present",
+    "timingEvidenceState": "blocked",
+    "implementationState": "blocked",
+    "kv260SmokeState": "blocked",
+    "runtimeEvidenceState": "blocked",
+    "throughputEvidenceState": "target",
+    "compatibilityState": "blocked",
+    "stateVocabulary": {
+        "target": "Named planned target only.",
+        "blocked": "A required input, artifact, closure step, or runtime evidence item is missing.",
+        "ready_for_inputs": "The launcher can describe the required input without bundling or reading it.",
+        "evidence_present": "Checked non-runtime evidence exists for this item.",
+        "measured": "A runtime or hardware measurement exists. The current fixture does not use this state for Gemma 3N E4B on KV260.",
+    },
+    "blockers": [
+        {
+            "blockerId": "board_model_bitstream_runtime_environment_missing",
+            "state": "blocked",
+            "summary": "KV260 board, model assets, generated bitstream, and runtime environment are not provided by this launcher fixture.",
+            "requiredBefore": "kv260_smoke_or_runtime_claim",
+        },
+        {
+            "blockerId": "post_synth_drc_timing_open",
+            "state": "blocked",
+            "summary": "Post-synthesis DRC and timing issues remain open in the FPGA closure state.",
+            "requiredBefore": "implementation_or_bitstream_claim",
+        },
+        {
+            "blockerId": "implementation_incomplete",
+            "state": "blocked",
+            "summary": "Implementation is not complete, so hardware closure is not available.",
+            "requiredBefore": "bitstream_or_board_smoke_claim",
+        },
+        {
+            "blockerId": "bitstream_not_generated",
+            "state": "blocked",
+            "summary": "A generated bitstream is not proven by this launcher surface.",
+            "requiredBefore": "kv260_board_smoke_claim",
+        },
+        {
+            "blockerId": "gemma3n_e4b_runtime_evidence_absent",
+            "state": "blocked",
+            "summary": "Gemma 3N E4B has no KV260 hardware runtime evidence in this launcher fixture.",
+            "requiredBefore": "runtime_or_performance_claim",
+        },
+        {
+            "blockerId": "throughput_measurement_absent",
+            "state": "blocked",
+            "summary": "Throughput measurement is unavailable.",
+            "requiredBefore": "performance_claim",
+        },
+    ],
+    "nextInputsRequired": [
+        {
+            "inputId": "external_model_assets",
+            "state": "ready_for_inputs",
+            "summary": "Gemma 3N E4B model assets remain external and are not loaded or referenced by path.",
+            "sourceBoundary": "user_or_future_runtime_integration",
+        },
+        {
+            "inputId": "kv260_board_environment",
+            "state": "ready_for_inputs",
+            "summary": "KV260 board and runtime environment evidence must arrive from lower layers before smoke status changes.",
+            "sourceBoundary": "future_pccx_lab_or_core_handoff",
+        },
+        {
+            "inputId": "timing_and_implementation_closure",
+            "state": "ready_for_inputs",
+            "summary": "Post-synthesis DRC, timing, implementation, and bitstream evidence must be supplied by FPGA closure work.",
+            "sourceBoundary": "pccx_fpga_kv260_repo",
+        },
+        {
+            "inputId": "kv260_smoke_evidence",
+            "state": "ready_for_inputs",
+            "summary": "Board smoke evidence is required before KV260 runtime status can move beyond blocked.",
+            "sourceBoundary": "future_pccx_lab_or_core_handoff",
+        },
+        {
+            "inputId": "throughput_measurement",
+            "state": "ready_for_inputs",
+            "summary": "Measured throughput evidence is required before any performance claim.",
+            "sourceBoundary": "future_pccx_lab_or_core_handoff",
+        },
+    ],
+    "performanceTargets": [
+        {
+            "metricId": "decode_throughput",
+            "state": "target",
+            "target": "20 tok/s",
+            "measured": False,
+            "achieved": False,
+            "summary": "20 tok/s remains a target until measured on the Gemma 3N E4B plus KV260 path.",
+        },
+    ],
+    "evidenceRefs": [
+        {
+            "evidenceId": "launcher_model_runtime_descriptor_fixture",
+            "state": "evidence_present",
+            "summary": "The launcher has a checked descriptor fixture for Gemma 3N E4B and the KV260 placeholder runtime.",
+            "referenceKind": "repo_fixture_reference",
+        },
+        {
+            "evidenceId": "fpga_v002_xsim_validation",
+            "state": "evidence_present",
+            "summary": "pccx-FPGA-NPU-LLM-kv260 v002 repo-local xsim evidence reports 11 passed and 0 failed.",
+            "referenceKind": "external_repo_state_summary",
+        },
+        {
+            "evidenceId": "fpga_v002_vivado_synth",
+            "state": "evidence_present",
+            "summary": "Vivado synthesis evidence exists, but this is not hardware closure.",
+            "referenceKind": "external_repo_state_summary",
+        },
+        {
+            "evidenceId": "fpga_post_synth_drc_timing",
+            "state": "blocked",
+            "summary": "Post-synthesis DRC and timing issues are current closure blockers.",
+            "referenceKind": "external_repo_state_summary",
+        },
+        {
+            "evidenceId": "kv260_board_smoke",
+            "state": "blocked",
+            "summary": "KV260 board smoke is blocked by missing board, model, bitstream, and runtime environment.",
+            "referenceKind": "future_evidence_required",
+        },
+        {
+            "evidenceId": "gemma3n_e4b_kv260_runtime",
+            "state": "blocked",
+            "summary": "Gemma 3N E4B KV260 hardware runtime evidence is absent.",
+            "referenceKind": "future_evidence_required",
+        },
+        {
+            "evidenceId": "gemma3n_e4b_kv260_throughput",
+            "state": "target",
+            "summary": "Throughput remains a target-only item until measured evidence exists.",
+            "referenceKind": "future_measurement_required",
+        },
+    ],
+    "coordinationNotes": {
+        "pccxLab": "pccx-lab remains the future CLI/core diagnostics and verification backend; this launcher fixture does not invoke it.",
+        "systemverilogIde": "systemverilog-ide may consume launcher or lab data later as read-only context; this fixture does not invoke or control it.",
+        "launcher": "The launcher provides data contracts first and does not add runtime integration in this phase.",
+    },
+    "safetyFlags": {
+        "dataOnly": True,
+        "readOnly": True,
+        "deterministic": True,
+        "descriptorOnly": True,
+        "writesArtifacts": False,
+        "touchesHardware": False,
+        "kv260Access": False,
+        "runtimeExecution": False,
+        "modelLoaded": False,
+        "modelExecution": False,
+        "modelWeightPathsIncluded": False,
+        "privatePathsIncluded": False,
+        "secretsIncluded": False,
+        "tokensIncluded": False,
+        "generatedBlobsIncluded": False,
+        "hardwareDumpsIncluded": False,
+        "networkCalls": False,
+        "providerCalls": False,
+        "telemetry": False,
+        "automaticUpload": False,
+        "writeBack": False,
+        "executesPccxLab": False,
+        "executesSystemverilogIde": False,
+        "mcpServerImplemented": False,
+        "lspImplemented": False,
+        "marketplaceFlow": False,
+        "stableApiAbiClaim": False,
+    },
+    "limitations": [
+        "Data-only runtime readiness surface; no runtime is executed.",
+        "No model assets are bundled, loaded, or referenced by path.",
+        "No KV260 hardware access, board smoke, bitstream programming, or provider call is performed.",
+        "xsim and Vivado synthesis evidence are recorded as evidence-aware status only, not hardware closure.",
+        "Timing, implementation, bitstream, KV260 smoke, runtime, and throughput evidence remain missing for this launcher fixture.",
+        "20 tok/s is a target only until measured evidence exists.",
+        "This is not a release, tag, versioned compatibility commitment, MCP, LSP, IDE, marketplace, or telemetry implementation.",
+    ],
+    "issueRefs": [
+        "pccxai/pccx-llm-launcher#3",
+        "pccxai/pccx-llm-launcher#5",
+        "pccxai/pccx-llm-launcher#12",
+    ],
+}
+
+
+def create_gemma3n_e4b_kv260_runtime_readiness() -> dict:
+    """Return the checked Gemma 3N E4B plus KV260 readiness fixture."""
+    return copy.deepcopy(_GEMMA3N_E4B_KV260_RUNTIME_READINESS)
+
+
+def readiness_json(readiness: dict | None = None) -> str:
+    """Render a deterministic JSON representation."""
+    return json.dumps(
+        readiness
+        if readiness is not None
+        else create_gemma3n_e4b_kv260_runtime_readiness(),
+        indent=2,
+        sort_keys=True,
+    ) + "\n"
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Print data-only runtime readiness JSON.",
+    )
+    parser.add_argument(
+        "--model",
+        default="gemma3n-e4b",
+        choices=("gemma3n-e4b",),
+        help="model descriptor target",
+    )
+    parser.add_argument(
+        "--target",
+        default="kv260",
+        choices=("kv260",),
+        help="target board/device",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parse_args(sys.argv[1:] if argv is None else argv)
+    sys.stdout.write(readiness_json())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/RUNTIME_READINESS_STATUS.md
+++ b/docs/RUNTIME_READINESS_STATUS.md
@@ -1,0 +1,112 @@
+# Runtime Readiness Status
+
+This note defines the launcher-side runtime readiness surface for the
+planned KV260-oriented launcher path. It is data-only and evidence-aware.
+It answers whether the Gemma 3N E4B plus KV260 target is ready to run,
+blocked, or backed by checked evidence.
+
+Current answer: **blocked / not yet evidence-backed**.
+
+The implementation lives in:
+
+- `contracts/runtime_readiness_contract.py`
+- `contracts/fixtures/runtime-readiness.gemma3n-e4b-kv260.json`
+- `scripts/runtime-readiness-stub.sh`
+- `scripts/tests/runtime_readiness_contract_test.py`
+
+## What Is Implemented
+
+The readiness contract records:
+
+- fixture version and last-updated source boundary
+- target model and target board identity
+- top-level readiness and evidence states
+- descriptor, input, bitstream, synthesis, timing, implementation, board
+  smoke, runtime, throughput, and compatibility states
+- a small state vocabulary: `target`, `blocked`, `ready_for_inputs`,
+  `evidence_present`, and `measured`
+- blockers and next inputs required
+- safety flags for the read-only boundary
+- evidence references that separate checked non-runtime evidence from
+  missing runtime and measurement evidence
+
+The checked fixture is deterministic JSON. The stub command prints that
+JSON for the supported model and target pair:
+
+```bash
+bash scripts/runtime-readiness-stub.sh --model gemma3n-e4b --target kv260
+```
+
+The stub does not probe hardware, load weights, run inference, call a
+provider, invoke pccx-lab, invoke systemverilog-ide, upload telemetry,
+or write artifacts.
+
+## Current Evidence
+
+The fixture reflects the current PCCX ecosystem state as launcher data:
+
+- the launcher has a checked model/runtime descriptor fixture for Gemma
+  3N E4B and the KV260 placeholder runtime
+- pccx-FPGA-NPU-LLM-kv260 v002 repo-local xsim evidence reports 11
+  passed and 0 failed
+- Vivado synthesis evidence exists, but that is not hardware closure
+- post-synthesis DRC and timing issues remain closure blockers
+- implementation is incomplete
+- a generated bitstream is not proven by this launcher surface
+- KV260 board smoke is blocked by missing board, model, bitstream, and
+  runtime environment
+- Gemma 3N E4B has no KV260 hardware runtime evidence in this launcher
+  fixture
+- throughput measurement is unavailable
+- 20 tok/s remains a target until measured
+
+## State Separation
+
+The readiness states are deliberately narrow:
+
+- `target`: named planned target only
+- `blocked`: a required input, artifact, closure step, or evidence item
+  is missing
+- `ready_for_inputs`: the launcher can describe a needed input without
+  bundling or reading it
+- `evidence_present`: checked non-runtime evidence exists
+- `measured`: runtime or hardware measurement exists
+
+The current Gemma 3N E4B plus KV260 fixture uses `target`,
+`blocked`, `ready_for_inputs`, and `evidence_present`. It does not use
+`measured` for the current target because runtime and throughput
+measurement evidence are absent.
+
+## Coordination Boundary
+
+pccx-lab remains CLI-first and core-boundary-first, with GUI work
+second. It is the diagnostics and verification backend for future
+evidence handling. This launcher repository only provides a read-only
+diagnostics handoff contract and this readiness data surface; the
+readiness stub does not invoke pccx-lab.
+
+systemverilog-ide may consume launcher or lab data later as read-only
+context. The IDE side has diagnostics handoff consumer, context bundle,
+validation proposal, and preflight audit work, but this launcher change
+does not add an IDE invocation path or control surface.
+
+## Non-Goals
+
+This readiness surface does not add:
+
+- KV260 runtime execution
+- model loading or model weight paths
+- provider or network calls
+- pccx-lab invocation
+- systemverilog-ide invocation
+- MCP implementation
+- LSP implementation
+- marketplace flow
+- telemetry, upload, or write-back
+- release or tag behavior
+- versioned API or ABI commitment
+- a performance achievement claim
+
+Evidence from FPGA closure, KV260 board smoke, runtime execution, and
+throughput measurement is required before this status can move beyond
+blocked for the Gemma 3N E4B plus KV260 target.

--- a/scripts/runtime-readiness-stub.sh
+++ b/scripts/runtime-readiness-stub.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+# scripts/runtime-readiness-stub.sh — deterministic readiness JSON stub.
+#
+# This script prints the checked Gemma 3N E4B plus KV260 readiness fixture.
+# It does not touch hardware, load a model, call providers, upload telemetry,
+# write artifacts, or invoke pccx-lab or editor tooling.
+
+set -eu
+
+ERROR() { printf '[ERROR] %s\n' "$*" >&2; }
+
+MODEL=""
+TARGET=""
+
+usage() {
+    printf 'Usage: bash scripts/runtime-readiness-stub.sh --model gemma3n-e4b --target kv260\n'
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --model)
+            MODEL="${2:-}"
+            if [ -z "$MODEL" ]; then
+                ERROR "--model requires an argument"
+                exit 1
+            fi
+            shift 2
+            ;;
+        --target)
+            TARGET="${2:-}"
+            if [ -z "$TARGET" ]; then
+                ERROR "--target requires an argument"
+                exit 1
+            fi
+            shift 2
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *)
+            ERROR "unknown option: $1"
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [ "$MODEL" != "gemma3n-e4b" ]; then
+    ERROR "--model must be gemma3n-e4b"
+    exit 1
+fi
+
+if [ "$TARGET" != "kv260" ]; then
+    ERROR "--target must be kv260"
+    exit 1
+fi
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+ROOT_DIR="$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)"
+
+python3 "$ROOT_DIR/contracts/runtime_readiness_contract.py" \
+    --model "$MODEL" \
+    --target "$TARGET"

--- a/scripts/runtime-readiness-stub.sh
+++ b/scripts/runtime-readiness-stub.sh
@@ -58,8 +58,8 @@ if [ "$TARGET" != "kv260" ]; then
     exit 1
 fi
 
-SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
-ROOT_DIR="$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)"
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
 
 python3 "$ROOT_DIR/contracts/runtime_readiness_contract.py" \
     --model "$MODEL" \

--- a/scripts/tests/runtime_readiness_contract_test.py
+++ b/scripts/tests/runtime_readiness_contract_test.py
@@ -1,0 +1,403 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Fixture tests for the runtime readiness contract."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "contracts" / "runtime_readiness_contract.py"
+FIXTURE_PATH = (
+    ROOT
+    / "contracts"
+    / "fixtures"
+    / "runtime-readiness.gemma3n-e4b-kv260.json"
+)
+SCRIPT_PATH = ROOT / "scripts" / "runtime-readiness-stub.sh"
+DOC_PATH = ROOT / "docs" / "RUNTIME_READINESS_STATUS.md"
+README_PATH = ROOT / "README.md"
+TEST_PATH = Path(__file__).resolve()
+CI_PATH = ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location(
+        "runtime_readiness_contract",
+        MODULE_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def flatten(value) -> str:
+    return json.dumps(value, sort_keys=True)
+
+
+def iter_state_values(value):
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            if key == "state" or key.endswith("State"):
+                yield nested
+            yield from iter_state_values(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            yield from iter_state_values(nested)
+
+
+def iter_keys(value):
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            yield key
+            yield from iter_keys(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            yield from iter_keys(nested)
+
+
+def assert_no_private_or_generated_data(text: str) -> None:
+    forbidden_patterns = [
+        r"/home/[^\s\"']+",
+        r"/Users/[^\s\"']+",
+        r"[A-Za-z]:\\Users\\",
+        r"\b(?:api[_-]?key|authorization|bearer|client[_-]?secret|password|private[_-]?key|secret|token)\b\s*[:=]",
+        r"\.(?:gguf|safetensors|ckpt|pt|pth|onnx)\b",
+        r"(?:weights|model_weights|model-cache)/(?:[^\"'\s]+)",
+        r"(?:raw[_-]?full[_-]?logs|hardware[_-]?dump|generated[_-]?blob)\s*[:=]",
+    ]
+    for pattern in forbidden_patterns:
+        assert not re.search(pattern, text, re.IGNORECASE), pattern
+
+
+def assert_no_runtime_implementation_terms(source: str) -> None:
+    forbidden = [
+        "subprocess",
+        "os.system",
+        "popen",
+        "socket",
+        "urllib",
+        "requests",
+        "http.client",
+        "openai",
+        "anthropic",
+        "gemini",
+        "modelcontextprotocol",
+        "vscode-languageclient",
+        "vsce",
+        "watchdog",
+        "filewatcher",
+        "websocket",
+        "xbutil",
+        "xrt",
+        "/proc/device-tree",
+    ]
+    lowered = source.lower()
+    for term in forbidden:
+        assert term not in lowered, term
+
+
+def assert_no_provider_configs(value) -> None:
+    forbidden_keys = {
+        "apiKey",
+        "accessToken",
+        "refreshToken",
+        "authorization",
+        "bearerToken",
+        "provider",
+        "providers",
+        "providerConfig",
+        "providerConfigs",
+    }
+    for key in iter_keys(value):
+        assert key not in forbidden_keys, key
+
+
+def assert_no_unsupported_claims(text: str) -> None:
+    literal_claims = [
+        "production-ready",
+        "marketplace-ready",
+        "stable API",
+        "stable ABI",
+        "KV260 inference works",
+        "Gemma 3N E4B runs on KV260",
+        "20 tok/s achieved",
+        "timing closed",
+        "bitstream ready",
+        "launcher executes pccx-lab",
+        "IDE controls launcher",
+        "AI provider integration is live",
+    ]
+    lowered = text.lower()
+    for claim in literal_claims:
+        assert claim.lower() not in lowered, claim
+
+    asserted_claim_patterns = [
+        r"\bMCP\s+(?:server|client)\s+(?:is\s+)?implemented\b",
+        r"\bLSP\s+(?:server|client)\s+(?:is\s+)?implemented\b",
+        r"\bAI\s+provider\s+(?:is\s+)?implemented\b",
+        r"\bKV260\s+run\s+(?:is\s+)?claimed\b",
+    ]
+    for pattern in asserted_claim_patterns:
+        assert not re.search(pattern, text, re.IGNORECASE), pattern
+
+
+def assert_no_readiness_invocation_flags(source: str) -> None:
+    forbidden_patterns = [
+        r"--backend\s+pccx-lab",
+        r"\bPCCX_LAB_BIN\b",
+        r"\bpccx-lab\s+(?:status|diagnostics|diagnostics-handoff|validate)\b",
+        r"\bsystemverilog-ide\s+--",
+        r"\bsystemverilog-ide\s+(?:open|run|status|validate|launch)\b",
+        r"\b(?:curl|wget)\b",
+        r"\b(?:upload|telemetry|write-back)\s+(?:enabled|true)\b",
+    ]
+    for pattern in forbidden_patterns:
+        assert not re.search(pattern, source, re.IGNORECASE), pattern
+
+
+def test_readiness_matches_fixture_and_is_deterministic() -> None:
+    module = load_module()
+    generated = module.create_gemma3n_e4b_kv260_runtime_readiness()
+    fixture = json.loads(read_text(FIXTURE_PATH))
+
+    assert generated == fixture
+    assert module.readiness_json(generated) == module.readiness_json(generated)
+    assert module.readiness_json(generated).endswith("\n")
+    assert json.loads(module.readiness_json(generated)) == fixture
+
+
+def test_cli_stub_outputs_deterministic_json() -> None:
+    fixture = json.loads(read_text(FIXTURE_PATH))
+    command = [
+        "bash",
+        str(SCRIPT_PATH),
+        "--model",
+        "gemma3n-e4b",
+        "--target",
+        "kv260",
+    ]
+    first = subprocess.run(
+        command,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    second = subprocess.run(
+        command,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert first.stderr == ""
+    assert first.stdout == second.stdout
+    assert first.stdout.endswith("\n")
+    assert json.loads(first.stdout) == fixture
+
+
+def test_required_fields_and_allowed_states() -> None:
+    module = load_module()
+    readiness = module.create_gemma3n_e4b_kv260_runtime_readiness()
+    allowed = set(module.READINESS_STATE_VALUES)
+
+    assert tuple(readiness.keys()) == module.READINESS_FIELDS
+    assert readiness["schemaVersion"] == "pccx.runtimeReadiness.v0"
+    assert set(readiness["stateVocabulary"]) == allowed
+
+    states = list(iter_state_values(readiness))
+    assert states
+    for state in states:
+        assert state in allowed, state
+
+    assert "target" in states
+    assert "blocked" in states
+    assert "ready_for_inputs" in states
+    assert "evidence_present" in states
+    assert "measured" not in states
+    assert "measured" in readiness["stateVocabulary"]
+
+
+def test_gemma3n_e4b_kv260_current_state_is_blocked() -> None:
+    readiness = load_module().create_gemma3n_e4b_kv260_runtime_readiness()
+    evidence = {item["evidenceId"]: item for item in readiness["evidenceRefs"]}
+    blocker_ids = [item["blockerId"] for item in readiness["blockers"]]
+    performance = readiness["performanceTargets"][0]
+
+    assert readiness["statusAnswer"] == "blocked_not_yet_evidence_backed"
+    assert readiness["fixtureVersion"] == "runtime-readiness.gemma3n-e4b-kv260.2026-05-03"
+    assert readiness["lastUpdatedSource"] == "pccx_evidence_boundary_2026-05-03"
+    assert readiness["readinessState"] == "blocked"
+    assert readiness["evidenceState"] == "blocked"
+    assert readiness["modelId"] == "gemma3n_e4b_placeholder"
+    assert readiness["modelFamily"] == "gemma3n"
+    assert readiness["modelVariant"] == "e4b"
+    assert readiness["targetDevice"] == "kv260"
+    assert readiness["targetBoard"] == "xilinx_kria_kv260"
+    assert readiness["targetState"] == "target"
+    assert readiness["overallState"] == "blocked"
+    assert readiness["descriptorState"] == "evidence_present"
+    assert readiness["modelWeightState"] == "ready_for_inputs"
+    assert readiness["boardInputState"] == "ready_for_inputs"
+    assert readiness["bitstreamState"] == "blocked"
+    assert readiness["simulationEvidenceState"] == "evidence_present"
+    assert readiness["vivadoSynthState"] == "evidence_present"
+    assert readiness["timingEvidenceState"] == "blocked"
+    assert readiness["implementationState"] == "blocked"
+    assert readiness["kv260SmokeState"] == "blocked"
+    assert readiness["runtimeEvidenceState"] == "blocked"
+    assert readiness["throughputEvidenceState"] == "target"
+    assert readiness["compatibilityState"] == "blocked"
+
+    assert evidence["fpga_v002_xsim_validation"]["state"] == "evidence_present"
+    assert "11 passed and 0 failed" in evidence["fpga_v002_xsim_validation"]["summary"]
+    assert evidence["fpga_v002_vivado_synth"]["state"] == "evidence_present"
+    assert evidence["fpga_post_synth_drc_timing"]["state"] == "blocked"
+    assert evidence["kv260_board_smoke"]["state"] == "blocked"
+    assert evidence["gemma3n_e4b_kv260_runtime"]["state"] == "blocked"
+    assert evidence["gemma3n_e4b_kv260_throughput"]["state"] == "target"
+
+    assert blocker_ids == [
+        "board_model_bitstream_runtime_environment_missing",
+        "post_synth_drc_timing_open",
+        "implementation_incomplete",
+        "bitstream_not_generated",
+        "gemma3n_e4b_runtime_evidence_absent",
+        "throughput_measurement_absent",
+    ]
+
+    assert performance["metricId"] == "decode_throughput"
+    assert performance["state"] == "target"
+    assert performance["target"] == "20 tok/s"
+    assert performance["measured"] is False
+    assert performance["achieved"] is False
+
+
+def test_nested_contract_shapes() -> None:
+    module = load_module()
+    readiness = module.create_gemma3n_e4b_kv260_runtime_readiness()
+
+    for blocker in readiness["blockers"]:
+        assert tuple(blocker.keys()) == module.BLOCKER_FIELDS
+        assert blocker["state"] == "blocked"
+
+    for item in readiness["nextInputsRequired"]:
+        assert tuple(item.keys()) == module.NEXT_INPUT_FIELDS
+        assert item["state"] == "ready_for_inputs"
+
+    for item in readiness["evidenceRefs"]:
+        assert tuple(item.keys()) == module.EVIDENCE_REF_FIELDS
+        assert item["state"] in set(module.READINESS_STATE_VALUES)
+
+    for item in readiness["performanceTargets"]:
+        assert tuple(item.keys()) == module.PERFORMANCE_TARGET_FIELDS
+        assert item["state"] == "target"
+        assert item["measured"] is False
+        assert item["achieved"] is False
+
+
+def test_safety_flags_preserve_data_only_boundary() -> None:
+    readiness = load_module().create_gemma3n_e4b_kv260_runtime_readiness()
+    flags = readiness["safetyFlags"]
+
+    assert flags["dataOnly"] is True
+    assert flags["readOnly"] is True
+    assert flags["deterministic"] is True
+    assert flags["descriptorOnly"] is True
+    for name in [
+        "writesArtifacts",
+        "touchesHardware",
+        "kv260Access",
+        "runtimeExecution",
+        "modelLoaded",
+        "modelExecution",
+        "modelWeightPathsIncluded",
+        "privatePathsIncluded",
+        "secretsIncluded",
+        "tokensIncluded",
+        "generatedBlobsIncluded",
+        "hardwareDumpsIncluded",
+        "networkCalls",
+        "providerCalls",
+        "telemetry",
+        "automaticUpload",
+        "writeBack",
+        "executesPccxLab",
+        "executesSystemverilogIde",
+        "mcpServerImplemented",
+        "lspImplemented",
+        "marketplaceFlow",
+        "stableApiAbiClaim",
+    ]:
+        assert flags[name] is False, name
+
+
+def test_no_private_data_runtime_calls_or_overclaims() -> None:
+    module_source = read_text(MODULE_PATH)
+    script_source = read_text(SCRIPT_PATH)
+    readiness = load_module().create_gemma3n_e4b_kv260_runtime_readiness()
+    scan_text = "\n".join([
+        read_text(FIXTURE_PATH),
+        read_text(DOC_PATH),
+        read_text(README_PATH),
+        flatten(readiness),
+        module_source,
+        script_source,
+    ])
+    readiness_runtime_source = "\n".join([module_source, script_source])
+
+    assert_no_runtime_implementation_terms(module_source)
+    assert_no_private_or_generated_data(scan_text)
+    assert_no_provider_configs(readiness)
+    assert_no_unsupported_claims(scan_text)
+    assert_no_readiness_invocation_flags(readiness_runtime_source)
+
+
+def test_source_headers_for_touched_code_files() -> None:
+    expected_headers = {
+        MODULE_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        SCRIPT_PATH: [
+            "#!/usr/bin/env bash",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        TEST_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        CI_PATH: [
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+    }
+
+    for path, header in expected_headers.items():
+        assert read_text(path).splitlines()[: len(header)] == header, path
+
+
+test_readiness_matches_fixture_and_is_deterministic()
+test_cli_stub_outputs_deterministic_json()
+test_required_fields_and_allowed_states()
+test_gemma3n_e4b_kv260_current_state_is_blocked()
+test_nested_contract_shapes()
+test_safety_flags_preserve_data_only_boundary()
+test_no_private_data_runtime_calls_or_overclaims()
+test_source_headers_for_touched_code_files()
+
+print("runtime readiness contract tests ok")


### PR DESCRIPTION
## Summary

Adds a read-only runtime readiness status contract for Gemma 3N E4B on KV260.

Current status is blocked / not yet evidence-backed. The fixture records descriptor, xsim, and Vivado synthesis evidence as present. Timing closure, implementation, bitstream generation, KV260 smoke, hardware runtime logs, and throughput measurement remain unresolved. 20 tok/s remains target-only and unmeasured.

## Scope

- Add runtime readiness contract and fixture.
- Add deterministic readiness stub output.
- Add tests for state fields, safety flags, blocked evidence state, headers, and unsupported-claim protection.
- Document the readiness status boundary.
- Run the readiness stub and contract test in CI.

## Non-goals

- No KV260 runtime execution.
- No model loading or model execution.
- No provider, network, telemetry, upload, or write-back flow.
- No pccx-lab or systemverilog-ide invocation.
- No MCP, LSP, marketplace, release, or tag work.
- No closure, generated bitstream, runtime, or throughput achievement claim.

## Validation

- `git diff --check`
- `python3 scripts/tests/diagnostics_handoff_contract_test.py`
- `python3 scripts/tests/launcher_ide_contract_test.py`
- `python3 scripts/tests/model_runtime_descriptor_test.py`
- `python3 scripts/tests/runtime_readiness_contract_test.py`
- `python3 -m pytest -q` (28 passed)
- `bash scripts/check.sh`
- `bash scripts/check-device-stub.sh`
- `bash scripts/install-stub.sh`
- `bash scripts/launch-stub.sh --dry-run`
- `bash scripts/status-stub.sh`
- `bash scripts/chat-stub.sh --dry-run --prompt hello`
- `bash scripts/tests/status-backend.sh scripts/status-stub.sh`
- `bash scripts/runtime-readiness-stub.sh --model gemma3n-e4b --target kv260`
- Claim scan over public/runtime readiness surfaces
