### PR TITLE
Surface runtime readiness in launcher status

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,8 @@ jobs:
           echo "launch-stub correctly refused without --dry-run"
       - name: run scripts/status-stub.sh
         run: ./scripts/status-stub.sh
+      - name: run scripts/status-stub.sh with runtime readiness
+        run: ./scripts/status-stub.sh --include-runtime-readiness
       - name: run scripts/runtime-readiness-stub.sh
         run: ./scripts/runtime-readiness-stub.sh --model gemma3n-e4b --target kv260
       - name: run scripts/chat-stub.sh --dry-run
@@ -174,10 +176,14 @@ jobs:
           chmod +x scripts/chat-stub.sh
           chmod +x scripts/launch-stub.sh
           chmod +x scripts/tests/status-backend.sh
+          chmod +x scripts/tests/status-readiness.sh
       - name: shellcheck status-stub and test script
         run: |
           sudo apt-get update -q && sudo apt-get install -y -q shellcheck
           shellcheck scripts/status-stub.sh
           shellcheck scripts/tests/status-backend.sh
+          shellcheck scripts/tests/status-readiness.sh
       - name: run status-backend tests
         run: bash scripts/tests/status-backend.sh scripts/status-stub.sh
+      - name: run status-readiness tests
+        run: bash scripts/tests/status-readiness.sh scripts/status-stub.sh

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ and verify host-side prerequisites before the real engine lands.
 | [`scripts/check.sh`](./scripts/check.sh) | Probe host info, tooling availability, edge-device hints. Always exits 0. |
 | [`scripts/check-device-stub.sh`](./scripts/check-device-stub.sh) | Narrowly scoped device-tree / FPGA-node probe (KV260 / Kria detection only). Always exits 0. |
 | [`scripts/install-stub.sh`](./scripts/install-stub.sh) | Preview of the planned install flow; reports which host runtime pieces are present, lists device-side pieces as future deliverables. Always exits 0. |
-| [`scripts/status-stub.sh`](./scripts/status-stub.sh) | Launcher state summary. Default mode: local scaffold output, always exits 0. With `--backend pccx-lab`, calls `pccx-lab status --format json` and forwards the run-status envelope (exits non-zero if binary is missing or output is invalid). |
+| [`scripts/status-stub.sh`](./scripts/status-stub.sh) | Launcher state summary. Default mode: local scaffold output, always exits 0. With `--include-runtime-readiness`, adds a read-only runtime readiness summary. With `--backend pccx-lab`, calls `pccx-lab status --format json` and forwards the run-status envelope (exits non-zero if binary is missing or output is invalid). |
 | [`scripts/runtime-readiness-stub.sh`](./scripts/runtime-readiness-stub.sh) | Data-only runtime readiness JSON for the Gemma 3N E4B + KV260 target. Reports blocked / not yet evidence-backed. |
 | [`scripts/launch-stub.sh`](./scripts/launch-stub.sh) | Dry-run preview of the intended launch sequence. Requires `--dry-run`; exits 1 without it. |
 | [`scripts/chat-stub.sh`](./scripts/chat-stub.sh) | Dry-run chat stub. Requires `--dry-run`; exits 1 without it. Accepts `--prompt "..."` or stdin. No model is executed. |
@@ -94,6 +94,7 @@ bash scripts/check.sh
 bash scripts/check-device-stub.sh
 bash scripts/install-stub.sh
 bash scripts/status-stub.sh
+bash scripts/status-stub.sh --include-runtime-readiness
 bash scripts/runtime-readiness-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/launch-stub.sh --dry-run
 bash scripts/chat-stub.sh --dry-run --prompt "hello"
@@ -202,6 +203,7 @@ surface for the Gemma 3N E4B + KV260 target:
 ```bash
 python3 contracts/runtime_readiness_contract.py --model gemma3n-e4b --target kv260
 bash scripts/runtime-readiness-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/status-stub.sh --include-runtime-readiness
 python3 scripts/tests/runtime_readiness_contract_test.py
 ```
 
@@ -212,6 +214,9 @@ descriptor evidence, xsim evidence of 11 passed and 0 failed, and Vivado
 synthesis evidence while keeping timing, implementation, bitstream,
 KV260 smoke, runtime evidence, and throughput measurement in blocked or
 target-only states. 20 tok/s remains a target until measured.
+
+The status command reads the same local readiness stub and prints a
+short human summary. It is still read-only status data.
 
 This surface does not load weights, execute a runtime, touch KV260
 hardware, call providers, invoke pccx-lab, invoke systemverilog-ide,

--- a/docs/RUNTIME_READINESS_STATUS.md
+++ b/docs/RUNTIME_READINESS_STATUS.md
@@ -37,6 +37,13 @@ JSON for the supported model and target pair:
 bash scripts/runtime-readiness-stub.sh --model gemma3n-e4b --target kv260
 ```
 
+The launcher status surface can include a short read-only summary of the
+same data:
+
+```bash
+bash scripts/status-stub.sh --include-runtime-readiness
+```
+
 The stub does not probe hardware, load weights, run inference, call a
 provider, invoke pccx-lab, invoke systemverilog-ide, upload telemetry,
 or write artifacts.

--- a/scripts/status-stub.sh
+++ b/scripts/status-stub.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
 # scripts/status-stub.sh — launcher state summary
 # Default mode: local scaffold output, no external calls, always exits 0.
+#
+# Runtime readiness summary (explicit opt-in, read-only local data):
+#   --include-runtime-readiness
 #
 # pccx-lab backend (explicit opt-in):
 #   --backend pccx-lab        call pccx-lab status --format json
@@ -17,9 +22,85 @@ ERROR() { printf '[ERROR] %s\n' "$*" >&2; }
 HEAD()  { printf '\n=== %s ===\n' "$*"; }
 
 BACKEND=""
+INCLUDE_RUNTIME_READINESS="0"
+
+print_runtime_readiness_summary() {
+    SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+    ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+    READINESS_STUB="$ROOT_DIR/scripts/runtime-readiness-stub.sh"
+
+    if [ ! -f "$READINESS_STUB" ]; then
+        ERROR "runtime readiness stub not found: $READINESS_STUB"
+        return 1
+    fi
+
+    if ! READINESS_JSON="$(bash "$READINESS_STUB" --model gemma3n-e4b --target kv260 2>&1)"; then
+        ERROR "runtime readiness stub failed"
+        printf '%s\n' "$READINESS_JSON" >&2
+        return 1
+    fi
+
+    if ! READINESS_SUMMARY="$(
+        printf '%s\n' "$READINESS_JSON" | python3 -c '
+import json
+import sys
+
+data = json.load(sys.stdin)
+performance = data["performanceTargets"][0]
+flags = data["safetyFlags"]
+
+def b(value):
+    return "true" if value else "false"
+
+print("[INFO]  source     : scripts/runtime-readiness-stub.sh --model gemma3n-e4b --target kv260")
+print("[INFO]  boundary   : read-only data; no hardware/model/provider/lab/IDE execution")
+print("[INFO]  model      : {} {}".format(data["modelFamily"], data["modelVariant"]))
+print("[INFO]  target     : {}".format(data["targetDevice"]))
+print("[INFO]  status     : {}".format(data["statusAnswer"]))
+print("[INFO]  readiness  : {}".format(data["readinessState"]))
+print("[INFO]  evidence   : {}".format(data["evidenceState"]))
+print("[INFO]  descriptor : {}".format(data["descriptorState"]))
+print("[INFO]  xsim       : {}".format(data["simulationEvidenceState"]))
+print("[INFO]  synth      : {}".format(data["vivadoSynthState"]))
+print("[INFO]  timing     : {}".format(data["timingEvidenceState"]))
+print("[INFO]  impl       : {}".format(data["implementationState"]))
+print("[INFO]  bitstream  : {}".format(data["bitstreamState"]))
+print("[INFO]  smoke      : {}".format(data["kv260SmokeState"]))
+print("[INFO]  runtime    : {}".format(data["runtimeEvidenceState"]))
+print("[INFO]  throughput : target-only; {} unmeasured".format(performance["target"]))
+print(
+    "[INFO]  flags      : readOnly={} dataOnly={} deterministic={} "
+    "runtimeExecution={} modelLoaded={} modelExecution={} kv260Access={} "
+    "providerCalls={} networkCalls={} executesPccxLab={} executesSystemverilogIde={}".format(
+        b(flags["readOnly"]),
+        b(flags["dataOnly"]),
+        b(flags["deterministic"]),
+        b(flags["runtimeExecution"]),
+        b(flags["modelLoaded"]),
+        b(flags["modelExecution"]),
+        b(flags["kv260Access"]),
+        b(flags["providerCalls"]),
+        b(flags["networkCalls"]),
+        b(flags["executesPccxLab"]),
+        b(flags["executesSystemverilogIde"]),
+    )
+)
+'
+    )"; then
+        ERROR "runtime readiness JSON could not be summarized"
+        return 1
+    fi
+
+    HEAD "runtime readiness"
+    printf '%s\n' "$READINESS_SUMMARY"
+}
 
 while [ $# -gt 0 ]; do
     case "$1" in
+        --include-runtime-readiness)
+            INCLUDE_RUNTIME_READINESS="1"
+            shift
+            ;;
         --backend)
             BACKEND="${2:-}"
             if [ -z "$BACKEND" ]; then
@@ -35,6 +116,11 @@ while [ $# -gt 0 ]; do
     esac
 done
 
+if [ -n "$BACKEND" ] && [ "$INCLUDE_RUNTIME_READINESS" = "1" ]; then
+    ERROR "--include-runtime-readiness is only supported in local scaffold mode"
+    exit 1
+fi
+
 # ── Default mode ──────────────────────────────────────────────────────────────
 if [ -z "$BACKEND" ]; then
     HEAD "launcher state"
@@ -44,7 +130,14 @@ if [ -z "$BACKEND" ]; then
     NOTE "KV260 path     : gated on pccxai/pccx-FPGA-NPU-LLM-kv260 bring-up"
     NOTE "pccx-lab diag  : deferred (analyze handoff not yet wired into launcher)"
     NOTE "pccx-lab status: opt-in via --backend pccx-lab (host-dry-run scaffold)"
+    NOTE "runtime ready  : opt-in via --include-runtime-readiness (read-only data)"
     NOTE "editor bridge  : planned (VS Code / other IDEs)"
+
+    if [ "$INCLUDE_RUNTIME_READINESS" = "1" ]; then
+        if ! print_runtime_readiness_summary; then
+            exit 1
+        fi
+    fi
 
     HEAD "summary"
     INFO "no inference engine is wired up; all paths are planned or deferred"

--- a/scripts/tests/status-readiness.sh
+++ b/scripts/tests/status-readiness.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+# scripts/tests/status-readiness.sh — status runtime-readiness summary tests.
+#
+# Usage: bash scripts/tests/status-readiness.sh [path/to/status-stub.sh]
+
+set -eu
+
+PASS() { printf '[PASS]  %s\n' "$*"; }
+FAIL() { printf '[FAIL]  %s\n' "$*" >&2; }
+HEAD() { printf '\n=== %s ===\n' "$*"; }
+
+STUB="${1:-scripts/status-stub.sh}"
+
+if [ ! -x "$STUB" ]; then
+    chmod +x "$STUB"
+fi
+
+contains() {
+    case "$1" in
+        *"$2"*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+require_contains() {
+    local output="$1"
+    local expected="$2"
+    if ! contains "$output" "$expected"; then
+        FAIL "expected output to contain: $expected"
+        printf '%s\n' "$output" >&2
+        exit 1
+    fi
+}
+
+require_not_contains() {
+    local output="$1"
+    local forbidden="$2"
+    if contains "$output" "$forbidden"; then
+        FAIL "output contained forbidden text: $forbidden"
+        printf '%s\n' "$output" >&2
+        exit 1
+    fi
+}
+
+HEAD "1: status can include runtime readiness"
+OUTPUT="$("$STUB" --include-runtime-readiness)"
+require_contains "$OUTPUT" "=== runtime readiness ==="
+require_contains "$OUTPUT" "source     : scripts/runtime-readiness-stub.sh --model gemma3n-e4b --target kv260"
+require_contains "$OUTPUT" "boundary   : read-only data; no hardware/model/provider/lab/IDE execution"
+require_contains "$OUTPUT" "status     : blocked_not_yet_evidence_backed"
+require_contains "$OUTPUT" "readiness  : blocked"
+require_contains "$OUTPUT" "evidence   : blocked"
+require_contains "$OUTPUT" "descriptor : evidence_present"
+require_contains "$OUTPUT" "xsim       : evidence_present"
+require_contains "$OUTPUT" "synth      : evidence_present"
+require_contains "$OUTPUT" "timing     : blocked"
+require_contains "$OUTPUT" "impl       : blocked"
+require_contains "$OUTPUT" "bitstream  : blocked"
+require_contains "$OUTPUT" "smoke      : blocked"
+require_contains "$OUTPUT" "runtime    : blocked"
+require_contains "$OUTPUT" "throughput : target-only; 20 tok/s unmeasured"
+PASS "runtime readiness section is present and conservative"
+
+HEAD "2: safety flags stay read-only and non-executing"
+require_contains "$OUTPUT" "readOnly=true"
+require_contains "$OUTPUT" "dataOnly=true"
+require_contains "$OUTPUT" "deterministic=true"
+require_contains "$OUTPUT" "runtimeExecution=false"
+require_contains "$OUTPUT" "modelLoaded=false"
+require_contains "$OUTPUT" "modelExecution=false"
+require_contains "$OUTPUT" "kv260Access=false"
+require_contains "$OUTPUT" "providerCalls=false"
+require_contains "$OUTPUT" "networkCalls=false"
+require_contains "$OUTPUT" "executesPccxLab=false"
+require_contains "$OUTPUT" "executesSystemverilogIde=false"
+PASS "execution-related flags remain false"
+
+HEAD "3: output is deterministic"
+OUTPUT_AGAIN="$("$STUB" --include-runtime-readiness)"
+if [ "$OUTPUT" != "$OUTPUT_AGAIN" ]; then
+    FAIL "status readiness output changed between runs"
+    exit 1
+fi
+PASS "status readiness output is deterministic"
+
+HEAD "4: readiness option does not combine with pccx-lab backend"
+if "$STUB" --include-runtime-readiness --backend pccx-lab >/dev/null 2>&1; then
+    FAIL "expected combined readiness/backend mode to fail"
+    exit 1
+fi
+PASS "runtime readiness status remains separate from backend execution"
+
+HEAD "5: output avoids known overclaims"
+FORBIDDEN_PREFIX="KV260 inference"
+FORBIDDEN_CLAIM="${FORBIDDEN_PREFIX} works"
+require_not_contains "$OUTPUT" "$FORBIDDEN_CLAIM"
+THROUGHPUT_PREFIX="20 tok/s"
+THROUGHPUT_CLAIM="${THROUGHPUT_PREFIX} achieved"
+require_not_contains "$OUTPUT" "$THROUGHPUT_CLAIM"
+PASS "no readiness or throughput overclaim in status output"
+
+printf '\n[DONE]  all status-readiness tests passed\n'


### PR DESCRIPTION
## Summary

Surfaces the runtime readiness status from the launcher status path.

The Gemma 3N E4B + KV260 readiness state remains blocked / not yet evidence-backed. 20 tok/s is still target-only and unmeasured.

## Scope

- Reuse the runtime readiness contract added in #21.
- Add read-only status output for runtime readiness.
- Add tests for deterministic status output and safety flags.
- Update docs for local status usage.

## Non-goals

- No KV260 runtime execution.
- No model loading or model execution.
- No provider, network, telemetry, upload, or write-back flow.
- No pccx-lab or systemverilog-ide invocation.
- No MCP, LSP, marketplace, release, or tag work.
- No readiness, timing closure, bitstream, runtime, or throughput achievement claim.

## Validation

- `git diff --check`
- `python3 scripts/tests/diagnostics_handoff_contract_test.py`
- `python3 scripts/tests/launcher_ide_contract_test.py`
- `python3 scripts/tests/model_runtime_descriptor_test.py`
- `python3 scripts/tests/runtime_readiness_contract_test.py`
- `python3 -m pytest -q`
- `bash scripts/check.sh`
- `bash scripts/check-device-stub.sh`
- `bash scripts/install-stub.sh`
- `bash scripts/launch-stub.sh --dry-run`
- `bash scripts/status-stub.sh`
- `bash scripts/status-stub.sh --include-runtime-readiness`
- `bash scripts/chat-stub.sh --dry-run --prompt hello`
- `bash scripts/tests/status-backend.sh scripts/status-stub.sh`
- `bash scripts/tests/status-readiness.sh scripts/status-stub.sh`
- `bash scripts/runtime-readiness-stub.sh --model gemma3n-e4b --target kv260`
