### PR TITLE
Add device/session status panel flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,7 @@ jobs:
                    scripts/install-stub.sh \
                    scripts/launch-stub.sh \
                    scripts/status-stub.sh \
+                   scripts/device-session-status-stub.sh \
                    scripts/runtime-readiness-stub.sh \
                    scripts/chat-stub.sh; do
             [ -f "$f" ] && chmod +x "$f" || true
@@ -142,6 +143,10 @@ jobs:
           echo "launch-stub correctly refused without --dry-run"
       - name: run scripts/status-stub.sh
         run: ./scripts/status-stub.sh
+      - name: run scripts/status-stub.sh with device/session status
+        run: ./scripts/status-stub.sh --include-device-session
+      - name: run scripts/device-session-status-stub.sh
+        run: ./scripts/device-session-status-stub.sh --model gemma3n-e4b --target kv260
       - name: run scripts/status-stub.sh with runtime readiness
         run: ./scripts/status-stub.sh --include-runtime-readiness
       - name: run scripts/runtime-readiness-stub.sh
@@ -162,6 +167,8 @@ jobs:
         run: python3 scripts/tests/model_runtime_descriptor_test.py
       - name: run diagnostics handoff contract tests
         run: python3 scripts/tests/diagnostics_handoff_contract_test.py
+      - name: run device/session status contract tests
+        run: python3 scripts/tests/device_session_status_contract_test.py
       - name: run runtime readiness contract tests
         run: python3 scripts/tests/runtime_readiness_contract_test.py
 
@@ -176,14 +183,18 @@ jobs:
           chmod +x scripts/chat-stub.sh
           chmod +x scripts/launch-stub.sh
           chmod +x scripts/tests/status-backend.sh
+          chmod +x scripts/tests/status-device-session.sh
           chmod +x scripts/tests/status-readiness.sh
       - name: shellcheck status-stub and test script
         run: |
           sudo apt-get update -q && sudo apt-get install -y -q shellcheck
           shellcheck scripts/status-stub.sh
           shellcheck scripts/tests/status-backend.sh
+          shellcheck scripts/tests/status-device-session.sh
           shellcheck scripts/tests/status-readiness.sh
       - name: run status-backend tests
         run: bash scripts/tests/status-backend.sh scripts/status-stub.sh
+      - name: run status-device-session tests
+        run: bash scripts/tests/status-device-session.sh scripts/status-stub.sh
       - name: run status-readiness tests
         run: bash scripts/tests/status-readiness.sh scripts/status-stub.sh

--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ and verify host-side prerequisites before the real engine lands.
 | [`scripts/check.sh`](./scripts/check.sh) | Probe host info, tooling availability, edge-device hints. Always exits 0. |
 | [`scripts/check-device-stub.sh`](./scripts/check-device-stub.sh) | Narrowly scoped device-tree / FPGA-node probe (KV260 / Kria detection only). Always exits 0. |
 | [`scripts/install-stub.sh`](./scripts/install-stub.sh) | Preview of the planned install flow; reports which host runtime pieces are present, lists device-side pieces as future deliverables. Always exits 0. |
-| [`scripts/status-stub.sh`](./scripts/status-stub.sh) | Launcher state summary. Default mode: local scaffold output, always exits 0. With `--include-runtime-readiness`, adds a read-only runtime readiness summary. With `--backend pccx-lab`, calls `pccx-lab status --format json` and forwards the run-status envelope (exits non-zero if binary is missing or output is invalid). |
+| [`scripts/status-stub.sh`](./scripts/status-stub.sh) | Launcher state summary. Default mode: local scaffold output, always exits 0. With `--include-device-session`, adds a read-only device/session status panel. With `--include-runtime-readiness`, adds a read-only runtime readiness summary. With `--backend pccx-lab`, calls `pccx-lab status --format json` and forwards the run-status envelope (exits non-zero if binary is missing or output is invalid). |
+| [`scripts/device-session-status-stub.sh`](./scripts/device-session-status-stub.sh) | Data-only device/session status JSON for the Gemma 3N E4B + KV260 target. Reports connection, model load, session, diagnostics, readiness, discovery paths, flow steps, and error taxonomy as placeholder / blocked. |
 | [`scripts/runtime-readiness-stub.sh`](./scripts/runtime-readiness-stub.sh) | Data-only runtime readiness JSON for the Gemma 3N E4B + KV260 target. Reports blocked / not yet evidence-backed. |
 | [`scripts/launch-stub.sh`](./scripts/launch-stub.sh) | Dry-run preview of the intended launch sequence. Requires `--dry-run`; exits 1 without it. |
 | [`scripts/chat-stub.sh`](./scripts/chat-stub.sh) | Dry-run chat stub. Requires `--dry-run`; exits 1 without it. Accepts `--prompt "..."` or stdin. No model is executed. |
@@ -94,7 +95,9 @@ bash scripts/check.sh
 bash scripts/check-device-stub.sh
 bash scripts/install-stub.sh
 bash scripts/status-stub.sh
+bash scripts/status-stub.sh --include-device-session
 bash scripts/status-stub.sh --include-runtime-readiness
+bash scripts/device-session-status-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/runtime-readiness-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/launch-stub.sh --dry-run
 bash scripts/chat-stub.sh --dry-run --prompt "hello"
@@ -222,6 +225,30 @@ This surface does not load weights, execute a runtime, touch KV260
 hardware, call providers, invoke pccx-lab, invoke systemverilog-ide,
 upload telemetry, or write artifacts. See
 [docs/RUNTIME_READINESS_STATUS.md](./docs/RUNTIME_READINESS_STATUS.md).
+
+### Device/session status panel and KV260 flow (planned)
+
+The launcher now has a data-only status panel and connection-flow
+contract for the planned Gemma 3N E4B + KV260 path:
+
+```bash
+python3 contracts/device_session_status_contract.py --model gemma3n-e4b --target kv260
+bash scripts/device-session-status-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/status-stub.sh --include-device-session
+python3 scripts/tests/device_session_status_contract_test.py
+bash scripts/tests/status-device-session.sh
+```
+
+The checked fixture reports device connection as not configured, model
+load as not loaded, session activity as inactive, pccx-lab diagnostics
+as a read-only placeholder, and runtime readiness as blocked. It also
+documents planned discovery paths, a gated connection and launch flow,
+and an error taxonomy with user remediation text.
+
+This surface does not probe hardware, open serial ports, scan networks,
+attempt authentication, load model assets, invoke pccx-lab, start a
+runtime, stream logs, upload telemetry, or write artifacts. See
+[docs/KV260_CONNECTION_AND_STATUS_FLOW.md](./docs/KV260_CONNECTION_AND_STATUS_FLOW.md).
 
 The legacy launcher scripts from the `llm-lite` era are preserved
 read-only under [`scripts/legacy/`](./scripts/legacy/) as historical

--- a/contracts/device_session_status_contract.py
+++ b/contracts/device_session_status_contract.py
@@ -1,0 +1,442 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Data-only device/session status contract for the planned KV260 path.
+
+The contract describes status-panel rows, discovery paths, a gated connection
+and launch flow, and user-facing errors without probing hardware, opening a
+serial or network connection, loading models, invoking pccx-lab, or starting
+runtime code.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import sys
+
+
+SCHEMA_VERSION = "pccx.deviceSessionStatus.v0"
+
+STATUS_FIELDS = (
+    "schemaVersion",
+    "statusId",
+    "fixtureVersion",
+    "lastUpdatedSource",
+    "targetDevice",
+    "targetBoard",
+    "targetModel",
+    "statusAnswer",
+    "connectionState",
+    "discoveryState",
+    "authenticationState",
+    "runtimeState",
+    "modelLoadState",
+    "sessionState",
+    "logStreamState",
+    "diagnosticsState",
+    "readinessState",
+    "statusPanel",
+    "discoveryPaths",
+    "connectionLaunchFlow",
+    "errorTaxonomy",
+    "pccxLabDiagnostics",
+    "safetyFlags",
+    "limitations",
+    "issueRefs",
+)
+
+PANEL_ROW_FIELDS = (
+    "rowId",
+    "label",
+    "state",
+    "summary",
+    "nextAction",
+)
+
+DISCOVERY_PATH_FIELDS = (
+    "pathId",
+    "transport",
+    "state",
+    "summary",
+    "suggestedUserAction",
+)
+
+FLOW_STEP_FIELDS = (
+    "stepId",
+    "order",
+    "stage",
+    "state",
+    "userAction",
+    "launcherAction",
+    "statusPanelUpdate",
+    "sideEffectPolicy",
+)
+
+ERROR_FIELDS = (
+    "errorId",
+    "stage",
+    "severity",
+    "state",
+    "userMessage",
+    "suggestedRemediation",
+    "claimBoundary",
+)
+
+DEVICE_SESSION_STATE_VALUES = (
+    "target",
+    "planned",
+    "placeholder",
+    "not_configured",
+    "not_started",
+    "requires_configuration",
+    "ready_for_inputs",
+    "blocked",
+    "inactive",
+    "not_loaded",
+    "available_as_placeholder",
+    "future_only",
+)
+
+_DEVICE_SESSION_STATUS = {
+    "schemaVersion": SCHEMA_VERSION,
+    "statusId": "device_session_status_gemma3n_e4b_kv260_placeholder",
+    "fixtureVersion": "device-session-status.gemma3n-e4b-kv260.2026-05-03",
+    "lastUpdatedSource": "pccx_launcher_issues_2_10_boundary_2026-05-03",
+    "targetDevice": "kv260",
+    "targetBoard": "xilinx_kria_kv260",
+    "targetModel": "gemma3n-e4b",
+    "statusAnswer": "device_session_status_placeholder_blocked",
+    "connectionState": "not_configured",
+    "discoveryState": "not_started",
+    "authenticationState": "not_configured",
+    "runtimeState": "planned",
+    "modelLoadState": "not_loaded",
+    "sessionState": "inactive",
+    "logStreamState": "not_started",
+    "diagnosticsState": "available_as_placeholder",
+    "readinessState": "blocked",
+    "statusPanel": [
+        {
+            "rowId": "device_connection",
+            "label": "device connection",
+            "state": "not_configured",
+            "summary": "No KV260 target connection is configured by this fixture.",
+            "nextAction": "Run a read-only status check after a target is explicitly configured.",
+        },
+        {
+            "rowId": "model_load",
+            "label": "model load",
+            "state": "not_loaded",
+            "summary": "Gemma 3N E4B is a target descriptor only; no model assets are loaded.",
+            "nextAction": "Keep model assets external until runtime evidence exists.",
+        },
+        {
+            "rowId": "session_activity",
+            "label": "session activity",
+            "state": "inactive",
+            "summary": "No launcher session is active and no log stream has started.",
+            "nextAction": "Keep launch controls gated until readiness inputs are present.",
+        },
+        {
+            "rowId": "pccx_lab_diagnostics",
+            "label": "pccx-lab diagnostics",
+            "state": "available_as_placeholder",
+            "summary": "Diagnostics handoff is represented as read-only local data only.",
+            "nextAction": "Use the pccx-lab CLI/core boundary later for validation, not launcher internals.",
+        },
+        {
+            "rowId": "runtime_readiness",
+            "label": "runtime readiness",
+            "state": "blocked",
+            "summary": "Runtime, bitstream, board-smoke, and measurement evidence are still required.",
+            "nextAction": "Do not present the launch path as available until evidence-backed readiness changes.",
+        },
+    ],
+    "discoveryPaths": [
+        {
+            "pathId": "usb_serial_hint",
+            "transport": "usb_serial",
+            "state": "planned",
+            "summary": "Read-only USB and serial enumeration can provide a local device hint.",
+            "suggestedUserAction": "Connect the KV260 carrier-board USB path and rerun the status panel check.",
+        },
+        {
+            "pathId": "network_host_target",
+            "transport": "network_host",
+            "state": "requires_configuration",
+            "summary": "A network target must be provided explicitly; the launcher does not scan networks.",
+            "suggestedUserAction": "Configure the target host through a future explicit settings surface.",
+        },
+        {
+            "pathId": "serial_console_target",
+            "transport": "serial_console",
+            "state": "future_only",
+            "summary": "Serial-console interaction is a future explicit target path, not active in this fixture.",
+            "suggestedUserAction": "Use read-only enumeration until a reviewed serial boundary exists.",
+        },
+    ],
+    "connectionLaunchFlow": [
+        {
+            "stepId": "open_status_panel",
+            "order": 1,
+            "stage": "status_panel",
+            "state": "placeholder",
+            "userAction": "Open the launcher status panel.",
+            "launcherAction": "Render deterministic local status rows.",
+            "statusPanelUpdate": "Show connection, model load, session, diagnostics, and readiness rows.",
+            "sideEffectPolicy": "local_render_only",
+        },
+        {
+            "stepId": "select_kv260_target",
+            "order": 2,
+            "stage": "target_selection",
+            "state": "planned",
+            "userAction": "Select a KV260-class target when configuration exists.",
+            "launcherAction": "Record the selected target as status data only.",
+            "statusPanelUpdate": "Move target selection from placeholder to configured in a future implementation.",
+            "sideEffectPolicy": "no_hardware_access",
+        },
+        {
+            "stepId": "run_read_only_discovery",
+            "order": 3,
+            "stage": "discovery",
+            "state": "planned",
+            "userAction": "Request a status refresh.",
+            "launcherAction": "Use reviewed read-only discovery paths when implemented.",
+            "statusPanelUpdate": "Report detected, missing, or not configured discovery state.",
+            "sideEffectPolicy": "no_mutation_no_network_scan",
+        },
+        {
+            "stepId": "prepare_authentication",
+            "order": 4,
+            "stage": "authentication",
+            "state": "requires_configuration",
+            "userAction": "Provide target access details through a future explicit settings surface.",
+            "launcherAction": "Check only whether required inputs are present.",
+            "statusPanelUpdate": "Report authentication as not configured, configured, or blocked.",
+            "sideEffectPolicy": "no_secret_echo_no_login_attempt",
+        },
+        {
+            "stepId": "check_runtime_readiness",
+            "order": 5,
+            "stage": "readiness",
+            "state": "blocked",
+            "userAction": "Review readiness blockers before launch controls are enabled.",
+            "launcherAction": "Read local readiness data and keep launch controls gated.",
+            "statusPanelUpdate": "Show runtime, bitstream, board-smoke, and measurement blockers.",
+            "sideEffectPolicy": "data_only",
+        },
+        {
+            "stepId": "preview_launch",
+            "order": 6,
+            "stage": "launch_preview",
+            "state": "planned",
+            "userAction": "Review the planned launch sequence.",
+            "launcherAction": "Show the dry-run launch preview only.",
+            "statusPanelUpdate": "Keep the session inactive and logs not started.",
+            "sideEffectPolicy": "dry_run_only",
+        },
+        {
+            "stepId": "start_runtime_when_evidence_backed",
+            "order": 7,
+            "stage": "runtime_start",
+            "state": "blocked",
+            "userAction": "Start runtime only after the readiness gate changes.",
+            "launcherAction": "Refuse runtime start while evidence is missing.",
+            "statusPanelUpdate": "Keep runtime and session states blocked or inactive.",
+            "sideEffectPolicy": "blocked_until_evidence_backed",
+        },
+        {
+            "stepId": "stream_logs_when_session_exists",
+            "order": 8,
+            "stage": "logs",
+            "state": "blocked",
+            "userAction": "Inspect logs after a real session exists.",
+            "launcherAction": "Do not stream logs when no session exists.",
+            "statusPanelUpdate": "Show log stream as not started.",
+            "sideEffectPolicy": "no_log_stream_without_session",
+        },
+    ],
+    "errorTaxonomy": [
+        {
+            "errorId": "kv260_device_not_detected",
+            "stage": "discovery",
+            "severity": "blocked",
+            "state": "planned",
+            "userMessage": "No KV260 target is visible to the configured discovery path.",
+            "suggestedRemediation": "Check power, cabling, and the selected discovery path, then rerun a read-only status refresh.",
+            "claimBoundary": "No runtime or performance claim follows from discovery status.",
+        },
+        {
+            "errorId": "target_access_not_configured",
+            "stage": "authentication",
+            "severity": "blocked",
+            "state": "requires_configuration",
+            "userMessage": "Target access inputs are not configured.",
+            "suggestedRemediation": "Configure the target host and access method through a future explicit settings surface.",
+            "claimBoundary": "The launcher must not guess hosts, scan networks, or print access inputs.",
+        },
+        {
+            "errorId": "authentication_not_available",
+            "stage": "authentication",
+            "severity": "blocked",
+            "state": "planned",
+            "userMessage": "The reviewed authentication handshake is not implemented in this fixture.",
+            "suggestedRemediation": "Keep connection controls disabled until the authentication boundary is implemented and tested.",
+            "claimBoundary": "No login attempt is performed by this status surface.",
+        },
+        {
+            "errorId": "runtime_evidence_missing",
+            "stage": "readiness",
+            "severity": "blocked",
+            "state": "blocked",
+            "userMessage": "Runtime evidence is missing for the KV260 target path.",
+            "suggestedRemediation": "Wait for checked runtime evidence before enabling start controls.",
+            "claimBoundary": "The target remains blocked and not evidence-backed.",
+        },
+        {
+            "errorId": "model_assets_not_configured",
+            "stage": "model",
+            "severity": "blocked",
+            "state": "ready_for_inputs",
+            "userMessage": "Model assets are external and not configured by the launcher fixture.",
+            "suggestedRemediation": "Keep model asset selection explicit and outside repository fixtures.",
+            "claimBoundary": "No model is loaded or referenced by local path.",
+        },
+        {
+            "errorId": "bitstream_evidence_missing",
+            "stage": "readiness",
+            "severity": "blocked",
+            "state": "blocked",
+            "userMessage": "Bitstream and board-smoke evidence are missing for the launch path.",
+            "suggestedRemediation": "Keep launch controls gated until lower-layer evidence is available.",
+            "claimBoundary": "No bitstream or board-smoke success is claimed here.",
+        },
+        {
+            "errorId": "lab_diagnostics_unavailable",
+            "stage": "diagnostics",
+            "severity": "placeholder",
+            "state": "available_as_placeholder",
+            "userMessage": "pccx-lab diagnostics are represented as a read-only placeholder handoff.",
+            "suggestedRemediation": "Use the explicit pccx-lab CLI/core validator when that integration is requested.",
+            "claimBoundary": "The launcher does not execute pccx-lab for this status surface.",
+        },
+        {
+            "errorId": "session_inactive",
+            "stage": "session",
+            "severity": "placeholder",
+            "state": "inactive",
+            "userMessage": "No launcher session is active.",
+            "suggestedRemediation": "Show session controls as disabled until the readiness gate changes.",
+            "claimBoundary": "No inference session is started.",
+        },
+        {
+            "errorId": "log_stream_not_started",
+            "stage": "logs",
+            "severity": "placeholder",
+            "state": "not_started",
+            "userMessage": "No log stream exists because no runtime session exists.",
+            "suggestedRemediation": "Show logs as pending rather than empty success.",
+            "claimBoundary": "No runtime logs are produced or collected.",
+        },
+    ],
+    "pccxLabDiagnostics": {
+        "state": "planned",
+        "mode": "read_only_handoff",
+        "lowerBoundary": "pccx-lab CLI/core",
+        "automaticUpload": False,
+        "writeBack": False,
+        "executesPccxLab": False,
+    },
+    "safetyFlags": {
+        "dataOnly": True,
+        "readOnly": True,
+        "deterministic": True,
+        "writesArtifacts": False,
+        "touchesHardware": False,
+        "kv260Access": False,
+        "opensSerialPort": False,
+        "serialWrites": False,
+        "networkCalls": False,
+        "networkScan": False,
+        "sshExecution": False,
+        "authenticationAttempt": False,
+        "runtimeExecution": False,
+        "modelLoaded": False,
+        "modelExecution": False,
+        "modelWeightPathsIncluded": False,
+        "privatePathsIncluded": False,
+        "secretsIncluded": False,
+        "tokensIncluded": False,
+        "generatedBlobsIncluded": False,
+        "hardwareDumpsIncluded": False,
+        "providerCalls": False,
+        "telemetry": False,
+        "automaticUpload": False,
+        "writeBack": False,
+        "executesPccxLab": False,
+        "executesSystemverilogIde": False,
+        "firmwareFlashing": False,
+        "packageInstallation": False,
+        "stableApiAbiClaim": False,
+    },
+    "limitations": [
+        "Data-only status panel fixture; no runtime is executed.",
+        "No USB, serial, network, SSH, or authentication command is run by this contract.",
+        "No model assets are bundled, loaded, or referenced by path.",
+        "No KV260 hardware access, board programming, runtime start, provider call, telemetry, upload, or write-back is performed.",
+        "The connection and launch flow is a gated plan until checked readiness evidence exists.",
+        "This is not a release, tag, versioned compatibility commitment, MCP, LSP, IDE, marketplace, or telemetry implementation.",
+    ],
+    "issueRefs": [
+        "pccxai/pccx-llm-launcher#10",
+        "pccxai/pccx-llm-launcher#2",
+    ],
+}
+
+
+def create_gemma3n_e4b_kv260_device_session_status() -> dict:
+    """Return the checked Gemma 3N E4B plus KV260 status fixture."""
+    return copy.deepcopy(_DEVICE_SESSION_STATUS)
+
+
+def device_session_status_json(status: dict | None = None) -> str:
+    """Render a deterministic JSON representation."""
+    return json.dumps(
+        status
+        if status is not None
+        else create_gemma3n_e4b_kv260_device_session_status(),
+        indent=2,
+        sort_keys=True,
+    ) + "\n"
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Print data-only device/session status JSON.",
+    )
+    parser.add_argument(
+        "--model",
+        default="gemma3n-e4b",
+        choices=("gemma3n-e4b",),
+        help="model descriptor target",
+    )
+    parser.add_argument(
+        "--target",
+        default="kv260",
+        choices=("kv260",),
+        help="target board/device",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parse_args(sys.argv[1:] if argv is None else argv)
+    sys.stdout.write(device_session_status_json())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contracts/fixtures/device-session-status.gemma3n-e4b-kv260.json
+++ b/contracts/fixtures/device-session-status.gemma3n-e4b-kv260.json
@@ -1,0 +1,296 @@
+{
+  "authenticationState": "not_configured",
+  "connectionLaunchFlow": [
+    {
+      "launcherAction": "Render deterministic local status rows.",
+      "order": 1,
+      "sideEffectPolicy": "local_render_only",
+      "stage": "status_panel",
+      "state": "placeholder",
+      "statusPanelUpdate": "Show connection, model load, session, diagnostics, and readiness rows.",
+      "stepId": "open_status_panel",
+      "userAction": "Open the launcher status panel."
+    },
+    {
+      "launcherAction": "Record the selected target as status data only.",
+      "order": 2,
+      "sideEffectPolicy": "no_hardware_access",
+      "stage": "target_selection",
+      "state": "planned",
+      "statusPanelUpdate": "Move target selection from placeholder to configured in a future implementation.",
+      "stepId": "select_kv260_target",
+      "userAction": "Select a KV260-class target when configuration exists."
+    },
+    {
+      "launcherAction": "Use reviewed read-only discovery paths when implemented.",
+      "order": 3,
+      "sideEffectPolicy": "no_mutation_no_network_scan",
+      "stage": "discovery",
+      "state": "planned",
+      "statusPanelUpdate": "Report detected, missing, or not configured discovery state.",
+      "stepId": "run_read_only_discovery",
+      "userAction": "Request a status refresh."
+    },
+    {
+      "launcherAction": "Check only whether required inputs are present.",
+      "order": 4,
+      "sideEffectPolicy": "no_secret_echo_no_login_attempt",
+      "stage": "authentication",
+      "state": "requires_configuration",
+      "statusPanelUpdate": "Report authentication as not configured, configured, or blocked.",
+      "stepId": "prepare_authentication",
+      "userAction": "Provide target access details through a future explicit settings surface."
+    },
+    {
+      "launcherAction": "Read local readiness data and keep launch controls gated.",
+      "order": 5,
+      "sideEffectPolicy": "data_only",
+      "stage": "readiness",
+      "state": "blocked",
+      "statusPanelUpdate": "Show runtime, bitstream, board-smoke, and measurement blockers.",
+      "stepId": "check_runtime_readiness",
+      "userAction": "Review readiness blockers before launch controls are enabled."
+    },
+    {
+      "launcherAction": "Show the dry-run launch preview only.",
+      "order": 6,
+      "sideEffectPolicy": "dry_run_only",
+      "stage": "launch_preview",
+      "state": "planned",
+      "statusPanelUpdate": "Keep the session inactive and logs not started.",
+      "stepId": "preview_launch",
+      "userAction": "Review the planned launch sequence."
+    },
+    {
+      "launcherAction": "Refuse runtime start while evidence is missing.",
+      "order": 7,
+      "sideEffectPolicy": "blocked_until_evidence_backed",
+      "stage": "runtime_start",
+      "state": "blocked",
+      "statusPanelUpdate": "Keep runtime and session states blocked or inactive.",
+      "stepId": "start_runtime_when_evidence_backed",
+      "userAction": "Start runtime only after the readiness gate changes."
+    },
+    {
+      "launcherAction": "Do not stream logs when no session exists.",
+      "order": 8,
+      "sideEffectPolicy": "no_log_stream_without_session",
+      "stage": "logs",
+      "state": "blocked",
+      "statusPanelUpdate": "Show log stream as not started.",
+      "stepId": "stream_logs_when_session_exists",
+      "userAction": "Inspect logs after a real session exists."
+    }
+  ],
+  "connectionState": "not_configured",
+  "diagnosticsState": "available_as_placeholder",
+  "discoveryPaths": [
+    {
+      "pathId": "usb_serial_hint",
+      "state": "planned",
+      "suggestedUserAction": "Connect the KV260 carrier-board USB path and rerun the status panel check.",
+      "summary": "Read-only USB and serial enumeration can provide a local device hint.",
+      "transport": "usb_serial"
+    },
+    {
+      "pathId": "network_host_target",
+      "state": "requires_configuration",
+      "suggestedUserAction": "Configure the target host through a future explicit settings surface.",
+      "summary": "A network target must be provided explicitly; the launcher does not scan networks.",
+      "transport": "network_host"
+    },
+    {
+      "pathId": "serial_console_target",
+      "state": "future_only",
+      "suggestedUserAction": "Use read-only enumeration until a reviewed serial boundary exists.",
+      "summary": "Serial-console interaction is a future explicit target path, not active in this fixture.",
+      "transport": "serial_console"
+    }
+  ],
+  "discoveryState": "not_started",
+  "errorTaxonomy": [
+    {
+      "claimBoundary": "No runtime or performance claim follows from discovery status.",
+      "errorId": "kv260_device_not_detected",
+      "severity": "blocked",
+      "stage": "discovery",
+      "state": "planned",
+      "suggestedRemediation": "Check power, cabling, and the selected discovery path, then rerun a read-only status refresh.",
+      "userMessage": "No KV260 target is visible to the configured discovery path."
+    },
+    {
+      "claimBoundary": "The launcher must not guess hosts, scan networks, or print access inputs.",
+      "errorId": "target_access_not_configured",
+      "severity": "blocked",
+      "stage": "authentication",
+      "state": "requires_configuration",
+      "suggestedRemediation": "Configure the target host and access method through a future explicit settings surface.",
+      "userMessage": "Target access inputs are not configured."
+    },
+    {
+      "claimBoundary": "No login attempt is performed by this status surface.",
+      "errorId": "authentication_not_available",
+      "severity": "blocked",
+      "stage": "authentication",
+      "state": "planned",
+      "suggestedRemediation": "Keep connection controls disabled until the authentication boundary is implemented and tested.",
+      "userMessage": "The reviewed authentication handshake is not implemented in this fixture."
+    },
+    {
+      "claimBoundary": "The target remains blocked and not evidence-backed.",
+      "errorId": "runtime_evidence_missing",
+      "severity": "blocked",
+      "stage": "readiness",
+      "state": "blocked",
+      "suggestedRemediation": "Wait for checked runtime evidence before enabling start controls.",
+      "userMessage": "Runtime evidence is missing for the KV260 target path."
+    },
+    {
+      "claimBoundary": "No model is loaded or referenced by local path.",
+      "errorId": "model_assets_not_configured",
+      "severity": "blocked",
+      "stage": "model",
+      "state": "ready_for_inputs",
+      "suggestedRemediation": "Keep model asset selection explicit and outside repository fixtures.",
+      "userMessage": "Model assets are external and not configured by the launcher fixture."
+    },
+    {
+      "claimBoundary": "No bitstream or board-smoke success is claimed here.",
+      "errorId": "bitstream_evidence_missing",
+      "severity": "blocked",
+      "stage": "readiness",
+      "state": "blocked",
+      "suggestedRemediation": "Keep launch controls gated until lower-layer evidence is available.",
+      "userMessage": "Bitstream and board-smoke evidence are missing for the launch path."
+    },
+    {
+      "claimBoundary": "The launcher does not execute pccx-lab for this status surface.",
+      "errorId": "lab_diagnostics_unavailable",
+      "severity": "placeholder",
+      "stage": "diagnostics",
+      "state": "available_as_placeholder",
+      "suggestedRemediation": "Use the explicit pccx-lab CLI/core validator when that integration is requested.",
+      "userMessage": "pccx-lab diagnostics are represented as a read-only placeholder handoff."
+    },
+    {
+      "claimBoundary": "No inference session is started.",
+      "errorId": "session_inactive",
+      "severity": "placeholder",
+      "stage": "session",
+      "state": "inactive",
+      "suggestedRemediation": "Show session controls as disabled until the readiness gate changes.",
+      "userMessage": "No launcher session is active."
+    },
+    {
+      "claimBoundary": "No runtime logs are produced or collected.",
+      "errorId": "log_stream_not_started",
+      "severity": "placeholder",
+      "stage": "logs",
+      "state": "not_started",
+      "suggestedRemediation": "Show logs as pending rather than empty success.",
+      "userMessage": "No log stream exists because no runtime session exists."
+    }
+  ],
+  "fixtureVersion": "device-session-status.gemma3n-e4b-kv260.2026-05-03",
+  "issueRefs": [
+    "pccxai/pccx-llm-launcher#10",
+    "pccxai/pccx-llm-launcher#2"
+  ],
+  "lastUpdatedSource": "pccx_launcher_issues_2_10_boundary_2026-05-03",
+  "limitations": [
+    "Data-only status panel fixture; no runtime is executed.",
+    "No USB, serial, network, SSH, or authentication command is run by this contract.",
+    "No model assets are bundled, loaded, or referenced by path.",
+    "No KV260 hardware access, board programming, runtime start, provider call, telemetry, upload, or write-back is performed.",
+    "The connection and launch flow is a gated plan until checked readiness evidence exists.",
+    "This is not a release, tag, versioned compatibility commitment, MCP, LSP, IDE, marketplace, or telemetry implementation."
+  ],
+  "logStreamState": "not_started",
+  "modelLoadState": "not_loaded",
+  "pccxLabDiagnostics": {
+    "automaticUpload": false,
+    "executesPccxLab": false,
+    "lowerBoundary": "pccx-lab CLI/core",
+    "mode": "read_only_handoff",
+    "state": "planned",
+    "writeBack": false
+  },
+  "readinessState": "blocked",
+  "runtimeState": "planned",
+  "safetyFlags": {
+    "authenticationAttempt": false,
+    "automaticUpload": false,
+    "dataOnly": true,
+    "deterministic": true,
+    "executesPccxLab": false,
+    "executesSystemverilogIde": false,
+    "firmwareFlashing": false,
+    "generatedBlobsIncluded": false,
+    "hardwareDumpsIncluded": false,
+    "kv260Access": false,
+    "modelExecution": false,
+    "modelLoaded": false,
+    "modelWeightPathsIncluded": false,
+    "networkCalls": false,
+    "networkScan": false,
+    "opensSerialPort": false,
+    "packageInstallation": false,
+    "privatePathsIncluded": false,
+    "providerCalls": false,
+    "readOnly": true,
+    "runtimeExecution": false,
+    "secretsIncluded": false,
+    "serialWrites": false,
+    "sshExecution": false,
+    "stableApiAbiClaim": false,
+    "telemetry": false,
+    "tokensIncluded": false,
+    "touchesHardware": false,
+    "writeBack": false,
+    "writesArtifacts": false
+  },
+  "schemaVersion": "pccx.deviceSessionStatus.v0",
+  "sessionState": "inactive",
+  "statusAnswer": "device_session_status_placeholder_blocked",
+  "statusId": "device_session_status_gemma3n_e4b_kv260_placeholder",
+  "statusPanel": [
+    {
+      "label": "device connection",
+      "nextAction": "Run a read-only status check after a target is explicitly configured.",
+      "rowId": "device_connection",
+      "state": "not_configured",
+      "summary": "No KV260 target connection is configured by this fixture."
+    },
+    {
+      "label": "model load",
+      "nextAction": "Keep model assets external until runtime evidence exists.",
+      "rowId": "model_load",
+      "state": "not_loaded",
+      "summary": "Gemma 3N E4B is a target descriptor only; no model assets are loaded."
+    },
+    {
+      "label": "session activity",
+      "nextAction": "Keep launch controls gated until readiness inputs are present.",
+      "rowId": "session_activity",
+      "state": "inactive",
+      "summary": "No launcher session is active and no log stream has started."
+    },
+    {
+      "label": "pccx-lab diagnostics",
+      "nextAction": "Use the pccx-lab CLI/core boundary later for validation, not launcher internals.",
+      "rowId": "pccx_lab_diagnostics",
+      "state": "available_as_placeholder",
+      "summary": "Diagnostics handoff is represented as read-only local data only."
+    },
+    {
+      "label": "runtime readiness",
+      "nextAction": "Do not present the launch path as available until evidence-backed readiness changes.",
+      "rowId": "runtime_readiness",
+      "state": "blocked",
+      "summary": "Runtime, bitstream, board-smoke, and measurement evidence are still required."
+    }
+  ],
+  "targetBoard": "xilinx_kria_kv260",
+  "targetDevice": "kv260",
+  "targetModel": "gemma3n-e4b"
+}

--- a/docs/KV260_CONNECTION_AND_STATUS_FLOW.md
+++ b/docs/KV260_CONNECTION_AND_STATUS_FLOW.md
@@ -1,0 +1,122 @@
+# KV260 Connection And Status Flow
+
+This note defines the launcher-side device/session status panel and the
+planned KV260 connection and launch flow. The implementation is data-only
+and evidence-gated.
+
+Current answer: **status is placeholder / blocked until required evidence
+and target configuration exist**.
+
+The implementation lives in:
+
+- `contracts/device_session_status_contract.py`
+- `contracts/fixtures/device-session-status.gemma3n-e4b-kv260.json`
+- `scripts/device-session-status-stub.sh`
+- `scripts/tests/device_session_status_contract_test.py`
+- `scripts/tests/status-device-session.sh`
+
+## What Is Implemented
+
+The launcher now exposes a deterministic local status shape for:
+
+- device connection status
+- model load status
+- session activity
+- pccx-lab diagnostics handoff status
+- runtime readiness status
+- discovery paths for USB/serial hints, explicit network targets, and
+  future serial-console use
+- a gated connection and launch flow
+- user-facing error taxonomy with remediation text
+
+The status data is read-only. It does not probe hardware, open serial
+ports, scan networks, attempt authentication, load model assets, invoke
+pccx-lab, start runtime code, stream logs, upload telemetry, or write
+artifacts.
+
+## Status Panel
+
+The status panel rows are:
+
+| Row | Current state | Meaning |
+|---|---|---|
+| Device connection | `not_configured` | No KV260 target connection is configured by the fixture. |
+| Model load | `not_loaded` | Gemma 3N E4B is a target descriptor only; no model assets are loaded. |
+| Session activity | `inactive` | No launcher session is active and no log stream has started. |
+| pccx-lab diagnostics | `available_as_placeholder` | Diagnostics handoff is read-only local data only. |
+| Runtime readiness | `blocked` | Runtime, bitstream, board-smoke, and measurement evidence are still required. |
+
+The terminal status surface can show this panel with:
+
+```bash
+bash scripts/status-stub.sh --include-device-session
+```
+
+Raw JSON is available with:
+
+```bash
+bash scripts/device-session-status-stub.sh --model gemma3n-e4b --target kv260
+```
+
+## Flow Diagram
+
+```text
+open status panel
+  -> select KV260 target
+  -> run reviewed read-only discovery
+  -> check explicit target access inputs
+  -> check runtime readiness data
+  -> show dry-run launch preview
+  -> keep runtime start blocked until readiness evidence changes
+  -> stream logs only after a real session exists
+```
+
+The current fixture stops before any side-effecting action. Runtime start
+and log streaming remain blocked because required readiness evidence and
+session state are absent.
+
+## Discovery Paths
+
+The planned discovery paths are:
+
+- `usb_serial_hint`: read-only USB and serial enumeration as a local
+  device hint.
+- `network_host_target`: explicit target host configuration only; the
+  launcher must not scan networks or guess hosts.
+- `serial_console_target`: future explicit serial-console path after a
+  reviewed boundary exists.
+
+## Error Taxonomy
+
+| Error | Stage | Current state | Suggested remediation |
+|---|---|---|---|
+| `kv260_device_not_detected` | discovery | `planned` | Check power, cabling, and selected discovery path, then rerun a read-only status refresh. |
+| `target_access_not_configured` | authentication | `requires_configuration` | Configure the target host and access method through a future explicit settings surface. |
+| `authentication_not_available` | authentication | `planned` | Keep connection controls disabled until the authentication boundary is implemented and tested. |
+| `runtime_evidence_missing` | readiness | `blocked` | Wait for checked runtime evidence before enabling start controls. |
+| `model_assets_not_configured` | model | `ready_for_inputs` | Keep model asset selection explicit and outside repository fixtures. |
+| `bitstream_evidence_missing` | readiness | `blocked` | Keep launch controls gated until lower-layer evidence is available. |
+| `lab_diagnostics_unavailable` | diagnostics | `available_as_placeholder` | Use the explicit pccx-lab CLI/core validator when that integration is requested. |
+| `session_inactive` | session | `inactive` | Show session controls as disabled until the readiness gate changes. |
+| `log_stream_not_started` | logs | `not_started` | Show logs as pending rather than empty success. |
+
+Every error carries a claim boundary in the JSON fixture so the launcher
+can show a clear user message without implying runtime, hardware, or
+performance success.
+
+## Safety Notes
+
+This status surface does not add:
+
+- KV260 runtime execution
+- USB, serial, network, SSH, or authentication commands
+- model loading or model weight paths
+- pccx-lab invocation
+- systemverilog-ide invocation
+- provider calls
+- telemetry, upload, or write-back
+- release or tag behavior
+- MCP, LSP, marketplace, or versioned compatibility behavior
+
+The connection and launch flow remains a gated plan until checked
+readiness evidence exists.

--- a/scripts/device-session-status-stub.sh
+++ b/scripts/device-session-status-stub.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+# scripts/device-session-status-stub.sh - data-only device/session JSON.
+
+set -eu
+
+MODEL="gemma3n-e4b"
+TARGET="kv260"
+
+ERROR() { printf '[ERROR] %s\n' "$*" >&2; }
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --model)
+            MODEL="${2:-}"
+            if [ -z "$MODEL" ]; then
+                ERROR "--model requires an argument"
+                exit 1
+            fi
+            shift 2
+            ;;
+        --target)
+            TARGET="${2:-}"
+            if [ -z "$TARGET" ]; then
+                ERROR "--target requires an argument"
+                exit 1
+            fi
+            shift 2
+            ;;
+        *)
+            ERROR "unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
+
+if [ "$MODEL" != "gemma3n-e4b" ]; then
+    ERROR "unsupported model: $MODEL (supported: gemma3n-e4b)"
+    exit 1
+fi
+
+if [ "$TARGET" != "kv260" ]; then
+    ERROR "unsupported target: $TARGET (supported: kv260)"
+    exit 1
+fi
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+
+python3 "$ROOT_DIR/contracts/device_session_status_contract.py" \
+    --model "$MODEL" \
+    --target "$TARGET"

--- a/scripts/status-stub.sh
+++ b/scripts/status-stub.sh
@@ -7,6 +7,9 @@
 # Runtime readiness summary (explicit opt-in, read-only local data):
 #   --include-runtime-readiness
 #
+# Device/session status panel (explicit opt-in, read-only local data):
+#   --include-device-session
+#
 # pccx-lab backend (explicit opt-in):
 #   --backend pccx-lab        call pccx-lab status --format json
 #   PCCX_LAB_BIN              override path to pccx-lab binary (takes priority over PATH)
@@ -23,6 +26,82 @@ HEAD()  { printf '\n=== %s ===\n' "$*"; }
 
 BACKEND=""
 INCLUDE_RUNTIME_READINESS="0"
+INCLUDE_DEVICE_SESSION="0"
+
+print_device_session_summary() {
+    SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+    ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+    DEVICE_SESSION_STUB="$ROOT_DIR/scripts/device-session-status-stub.sh"
+
+    if [ ! -f "$DEVICE_SESSION_STUB" ]; then
+        ERROR "device/session status stub not found: $DEVICE_SESSION_STUB"
+        return 1
+    fi
+
+    if ! DEVICE_SESSION_JSON="$(bash "$DEVICE_SESSION_STUB" --model gemma3n-e4b --target kv260 2>&1)"; then
+        ERROR "device/session status stub failed"
+        printf '%s\n' "$DEVICE_SESSION_JSON" >&2
+        return 1
+    fi
+
+    if ! DEVICE_SESSION_SUMMARY="$(
+        printf '%s\n' "$DEVICE_SESSION_JSON" | python3 -c '
+import json
+import sys
+
+data = json.load(sys.stdin)
+flags = data["safetyFlags"]
+rows = " ".join(
+    "{}={}".format(row["rowId"], row["state"])
+    for row in data["statusPanel"]
+)
+
+def b(value):
+    return "true" if value else "false"
+
+print("[INFO]  source     : scripts/device-session-status-stub.sh --model gemma3n-e4b --target kv260")
+print("[INFO]  boundary   : read-only data; no hardware/model/provider/lab/IDE execution")
+print("[INFO]  target     : {}".format(data["targetDevice"]))
+print("[INFO]  model      : {}".format(data["targetModel"]))
+print("[INFO]  connection : {}".format(data["connectionState"]))
+print("[INFO]  discovery  : {}".format(data["discoveryState"]))
+print("[INFO]  auth       : {}".format(data["authenticationState"]))
+print("[INFO]  runtime    : {}".format(data["runtimeState"]))
+print("[INFO]  model load : {}".format(data["modelLoadState"]))
+print("[INFO]  session    : {}".format(data["sessionState"]))
+print("[INFO]  logs       : {}".format(data["logStreamState"]))
+print("[INFO]  diagnostic : {}".format(data["diagnosticsState"]))
+print("[INFO]  readiness  : {}".format(data["readinessState"]))
+print("[INFO]  panel      : {}".format(rows))
+print(
+    "[INFO]  flags      : readOnly={} dataOnly={} deterministic={} "
+    "runtimeExecution={} modelLoaded={} modelExecution={} kv260Access={} "
+    "opensSerialPort={} networkCalls={} networkScan={} sshExecution={} "
+    "authenticationAttempt={} executesPccxLab={}".format(
+        b(flags["readOnly"]),
+        b(flags["dataOnly"]),
+        b(flags["deterministic"]),
+        b(flags["runtimeExecution"]),
+        b(flags["modelLoaded"]),
+        b(flags["modelExecution"]),
+        b(flags["kv260Access"]),
+        b(flags["opensSerialPort"]),
+        b(flags["networkCalls"]),
+        b(flags["networkScan"]),
+        b(flags["sshExecution"]),
+        b(flags["authenticationAttempt"]),
+        b(flags["executesPccxLab"]),
+    )
+)
+'
+    )"; then
+        ERROR "device/session status JSON could not be summarized"
+        return 1
+    fi
+
+    HEAD "device/session status"
+    printf '%s\n' "$DEVICE_SESSION_SUMMARY"
+}
 
 print_runtime_readiness_summary() {
     SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
@@ -101,6 +180,10 @@ while [ $# -gt 0 ]; do
             INCLUDE_RUNTIME_READINESS="1"
             shift
             ;;
+        --include-device-session)
+            INCLUDE_DEVICE_SESSION="1"
+            shift
+            ;;
         --backend)
             BACKEND="${2:-}"
             if [ -z "$BACKEND" ]; then
@@ -116,8 +199,8 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-if [ -n "$BACKEND" ] && [ "$INCLUDE_RUNTIME_READINESS" = "1" ]; then
-    ERROR "--include-runtime-readiness is only supported in local scaffold mode"
+if [ -n "$BACKEND" ] && { [ "$INCLUDE_RUNTIME_READINESS" = "1" ] || [ "$INCLUDE_DEVICE_SESSION" = "1" ]; }; then
+    ERROR "--include-runtime-readiness and --include-device-session are only supported in local scaffold mode"
     exit 1
 fi
 
@@ -131,7 +214,14 @@ if [ -z "$BACKEND" ]; then
     NOTE "pccx-lab diag  : deferred (analyze handoff not yet wired into launcher)"
     NOTE "pccx-lab status: opt-in via --backend pccx-lab (host-dry-run scaffold)"
     NOTE "runtime ready  : opt-in via --include-runtime-readiness (read-only data)"
+    NOTE "device/session: opt-in via --include-device-session (read-only panel data)"
     NOTE "editor bridge  : planned (VS Code / other IDEs)"
+
+    if [ "$INCLUDE_DEVICE_SESSION" = "1" ]; then
+        if ! print_device_session_summary; then
+            exit 1
+        fi
+    fi
 
     if [ "$INCLUDE_RUNTIME_READINESS" = "1" ]; then
         if ! print_runtime_readiness_summary; then

--- a/scripts/tests/device_session_status_contract_test.py
+++ b/scripts/tests/device_session_status_contract_test.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Fixture tests for the device/session status contract."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "contracts" / "device_session_status_contract.py"
+FIXTURE_PATH = (
+    ROOT
+    / "contracts"
+    / "fixtures"
+    / "device-session-status.gemma3n-e4b-kv260.json"
+)
+SCRIPT_PATH = ROOT / "scripts" / "device-session-status-stub.sh"
+DOC_PATH = ROOT / "docs" / "KV260_CONNECTION_AND_STATUS_FLOW.md"
+README_PATH = ROOT / "README.md"
+TEST_PATH = Path(__file__).resolve()
+CI_PATH = ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location(
+        "device_session_status_contract",
+        MODULE_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def flatten(value) -> str:
+    return json.dumps(value, sort_keys=True)
+
+
+def iter_state_values(value):
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            if key == "state" or key.endswith("State"):
+                yield nested
+            yield from iter_state_values(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            yield from iter_state_values(nested)
+
+
+def iter_keys(value):
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            yield key
+            yield from iter_keys(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            yield from iter_keys(nested)
+
+
+def assert_no_private_or_generated_data(text: str) -> None:
+    forbidden_patterns = [
+        r"/home/[^\s\"']+",
+        r"/Users/[^\s\"']+",
+        r"[A-Za-z]:\\Users\\",
+        r"\b(?:api[_-]?key|authorization|bearer|client[_-]?secret|password|private[_-]?key|secret|token)\b\s*[:=]",
+        r"\.(?:gguf|safetensors|ckpt|pt|pth|onnx)\b",
+        r"(?:weights|model_weights|model-cache)/(?:[^\"'\s]+)",
+        r"(?:raw[_-]?full[_-]?logs|hardware[_-]?dump|generated[_-]?blob)\s*[:=]",
+    ]
+    for pattern in forbidden_patterns:
+        assert not re.search(pattern, text, re.IGNORECASE), pattern
+
+
+def assert_no_runtime_implementation_terms(source: str) -> None:
+    forbidden = [
+        "subprocess",
+        "os.system",
+        "popen",
+        "socket",
+        "urllib",
+        "requests",
+        "http.client",
+        "openai",
+        "anthropic",
+        "gemini",
+        "modelcontextprotocol",
+        "vscode-languageclient",
+        "vsce",
+        "watchdog",
+        "filewatcher",
+        "websocket",
+        "xmutil",
+        "xrt-smi",
+        "lsusb",
+        "dmesg",
+    ]
+    lowered = source.lower()
+    for term in forbidden:
+        assert term not in lowered, term
+
+
+def assert_no_provider_configs(value) -> None:
+    forbidden_keys = {
+        "apiKey",
+        "accessToken",
+        "refreshToken",
+        "authorization",
+        "bearerToken",
+        "provider",
+        "providers",
+        "providerConfig",
+        "providerConfigs",
+    }
+    for key in iter_keys(value):
+        assert key not in forbidden_keys, key
+
+
+def assert_no_unsupported_claims(text: str) -> None:
+    literal_claims = [
+        "production-ready",
+        "marketplace-ready",
+        "stable API",
+        "stable ABI",
+        "KV260 inference works",
+        "Gemma 3N E4B runs on KV260",
+        "20 tok/s achieved",
+        "timing closed",
+        "bitstream ready",
+        "launcher executes pccx-lab",
+        "IDE controls launcher",
+        "AI provider integration is live",
+    ]
+    lowered = text.lower()
+    for claim in literal_claims:
+        assert claim.lower() not in lowered, claim
+
+    asserted_claim_patterns = [
+        r"\bMCP\s+(?:server|client)\s+(?:is\s+)?implemented\b",
+        r"\bLSP\s+(?:server|client)\s+(?:is\s+)?implemented\b",
+        r"\bAI\s+provider\s+(?:is\s+)?implemented\b",
+        r"\bKV260\s+run\s+(?:is\s+)?claimed\b",
+    ]
+    for pattern in asserted_claim_patterns:
+        assert not re.search(pattern, text, re.IGNORECASE), pattern
+
+
+def assert_no_status_invocation_flags(source: str) -> None:
+    forbidden_patterns = [
+        r"--backend\s+pccx-lab",
+        r"\bPCCX_LAB_BIN\b",
+        r"\bpccx-lab\s+(?:status|diagnostics-handoff|validate)\b",
+        r"\bsystemverilog-ide\s+--",
+        r"\bsystemverilog-ide\s+(?:open|run|status|validate|launch)\b",
+        r"\b(?:curl|wget)\b",
+        r"\b(?:upload|telemetry|write-back)\s+(?:enabled|true)\b",
+    ]
+    for pattern in forbidden_patterns:
+        assert not re.search(pattern, source, re.IGNORECASE), pattern
+
+
+def test_status_matches_fixture_and_is_deterministic() -> None:
+    module = load_module()
+    generated = module.create_gemma3n_e4b_kv260_device_session_status()
+    fixture = json.loads(read_text(FIXTURE_PATH))
+
+    assert generated == fixture
+    assert module.device_session_status_json(generated) == module.device_session_status_json(generated)
+    assert module.device_session_status_json(generated).endswith("\n")
+    assert json.loads(module.device_session_status_json(generated)) == fixture
+
+
+def test_cli_stub_outputs_deterministic_json() -> None:
+    fixture = json.loads(read_text(FIXTURE_PATH))
+    command = [
+        "bash",
+        str(SCRIPT_PATH),
+        "--model",
+        "gemma3n-e4b",
+        "--target",
+        "kv260",
+    ]
+    first = subprocess.run(
+        command,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    second = subprocess.run(
+        command,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert first.stderr == ""
+    assert first.stdout == second.stdout
+    assert first.stdout.endswith("\n")
+    assert json.loads(first.stdout) == fixture
+
+
+def test_required_fields_and_allowed_states() -> None:
+    module = load_module()
+    status = module.create_gemma3n_e4b_kv260_device_session_status()
+    allowed = set(module.DEVICE_SESSION_STATE_VALUES)
+
+    assert tuple(status.keys()) == module.STATUS_FIELDS
+    assert status["schemaVersion"] == "pccx.deviceSessionStatus.v0"
+
+    states = list(iter_state_values(status))
+    assert states
+    for state in states:
+        assert state in allowed, state
+
+    for row in status["statusPanel"]:
+        assert tuple(row.keys()) == module.PANEL_ROW_FIELDS
+    for path in status["discoveryPaths"]:
+        assert tuple(path.keys()) == module.DISCOVERY_PATH_FIELDS
+    for step in status["connectionLaunchFlow"]:
+        assert tuple(step.keys()) == module.FLOW_STEP_FIELDS
+    for error in status["errorTaxonomy"]:
+        assert tuple(error.keys()) == module.ERROR_FIELDS
+
+
+def test_status_panel_covers_issue_10_rows() -> None:
+    status = load_module().create_gemma3n_e4b_kv260_device_session_status()
+    rows = {row["rowId"]: row for row in status["statusPanel"]}
+
+    assert set(rows) == {
+        "device_connection",
+        "model_load",
+        "session_activity",
+        "pccx_lab_diagnostics",
+        "runtime_readiness",
+    }
+    assert rows["device_connection"]["state"] == "not_configured"
+    assert rows["model_load"]["state"] == "not_loaded"
+    assert rows["session_activity"]["state"] == "inactive"
+    assert rows["pccx_lab_diagnostics"]["state"] == "available_as_placeholder"
+    assert rows["runtime_readiness"]["state"] == "blocked"
+
+
+def test_connection_flow_and_errors_cover_issue_2() -> None:
+    status = load_module().create_gemma3n_e4b_kv260_device_session_status()
+    steps = status["connectionLaunchFlow"]
+    errors = {error["errorId"]: error for error in status["errorTaxonomy"]}
+    paths = {path["pathId"]: path for path in status["discoveryPaths"]}
+
+    assert [step["order"] for step in steps] == list(range(1, len(steps) + 1))
+    assert {step["stage"] for step in steps} >= {
+        "status_panel",
+        "target_selection",
+        "discovery",
+        "authentication",
+        "readiness",
+        "launch_preview",
+        "runtime_start",
+        "logs",
+    }
+    assert set(paths) == {
+        "usb_serial_hint",
+        "network_host_target",
+        "serial_console_target",
+    }
+    assert {
+        "kv260_device_not_detected",
+        "target_access_not_configured",
+        "authentication_not_available",
+        "runtime_evidence_missing",
+        "model_assets_not_configured",
+        "bitstream_evidence_missing",
+        "lab_diagnostics_unavailable",
+        "session_inactive",
+        "log_stream_not_started",
+    } <= set(errors)
+    for error in errors.values():
+        assert error["suggestedRemediation"]
+        assert error["claimBoundary"]
+
+
+def test_safety_flags_preserve_data_only_boundary() -> None:
+    status = load_module().create_gemma3n_e4b_kv260_device_session_status()
+    flags = status["safetyFlags"]
+
+    assert flags["dataOnly"] is True
+    assert flags["readOnly"] is True
+    assert flags["deterministic"] is True
+    for name in [
+        "writesArtifacts",
+        "touchesHardware",
+        "kv260Access",
+        "opensSerialPort",
+        "serialWrites",
+        "networkCalls",
+        "networkScan",
+        "sshExecution",
+        "authenticationAttempt",
+        "runtimeExecution",
+        "modelLoaded",
+        "modelExecution",
+        "modelWeightPathsIncluded",
+        "privatePathsIncluded",
+        "secretsIncluded",
+        "tokensIncluded",
+        "generatedBlobsIncluded",
+        "hardwareDumpsIncluded",
+        "providerCalls",
+        "telemetry",
+        "automaticUpload",
+        "writeBack",
+        "executesPccxLab",
+        "executesSystemverilogIde",
+        "firmwareFlashing",
+        "packageInstallation",
+        "stableApiAbiClaim",
+    ]:
+        assert flags[name] is False, name
+
+
+def test_docs_and_sources_avoid_private_data_runtime_calls_or_overclaims() -> None:
+    module_source = read_text(MODULE_PATH)
+    script_source = read_text(SCRIPT_PATH)
+    status = load_module().create_gemma3n_e4b_kv260_device_session_status()
+    scan_text = "\n".join([
+        read_text(FIXTURE_PATH),
+        read_text(DOC_PATH),
+        read_text(README_PATH),
+        flatten(status),
+        module_source,
+        script_source,
+    ])
+    runtime_source = "\n".join([module_source, script_source])
+
+    assert_no_runtime_implementation_terms(module_source)
+    assert_no_private_or_generated_data(scan_text)
+    assert_no_provider_configs(status)
+    assert_no_unsupported_claims(scan_text)
+    assert_no_status_invocation_flags(runtime_source)
+
+
+def test_source_headers_for_touched_code_files() -> None:
+    expected_headers = {
+        MODULE_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        SCRIPT_PATH: [
+            "#!/usr/bin/env bash",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        TEST_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        CI_PATH: [
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+    }
+
+    for path, header in expected_headers.items():
+        assert read_text(path).splitlines()[: len(header)] == header, path
+
+
+test_status_matches_fixture_and_is_deterministic()
+test_cli_stub_outputs_deterministic_json()
+test_required_fields_and_allowed_states()
+test_status_panel_covers_issue_10_rows()
+test_connection_flow_and_errors_cover_issue_2()
+test_safety_flags_preserve_data_only_boundary()
+test_docs_and_sources_avoid_private_data_runtime_calls_or_overclaims()
+test_source_headers_for_touched_code_files()
+
+print("device/session status contract tests ok")

--- a/scripts/tests/status-device-session.sh
+++ b/scripts/tests/status-device-session.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+# scripts/tests/status-device-session.sh - status device/session summary tests.
+#
+# Usage: bash scripts/tests/status-device-session.sh [path/to/status-stub.sh]
+
+set -eu
+
+PASS() { printf '[PASS]  %s\n' "$*"; }
+FAIL() { printf '[FAIL]  %s\n' "$*" >&2; }
+HEAD() { printf '\n=== %s ===\n' "$*"; }
+
+STUB="${1:-scripts/status-stub.sh}"
+
+if [ ! -x "$STUB" ]; then
+    chmod +x "$STUB"
+fi
+
+contains() {
+    case "$1" in
+        *"$2"*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+require_contains() {
+    local output="$1"
+    local expected="$2"
+    if ! contains "$output" "$expected"; then
+        FAIL "expected output to contain: $expected"
+        printf '%s\n' "$output" >&2
+        exit 1
+    fi
+}
+
+require_not_contains() {
+    local output="$1"
+    local forbidden="$2"
+    if contains "$output" "$forbidden"; then
+        FAIL "output contained forbidden text: $forbidden"
+        printf '%s\n' "$output" >&2
+        exit 1
+    fi
+}
+
+HEAD "1: status can include device/session panel"
+OUTPUT="$("$STUB" --include-device-session)"
+require_contains "$OUTPUT" "=== device/session status ==="
+require_contains "$OUTPUT" "source     : scripts/device-session-status-stub.sh --model gemma3n-e4b --target kv260"
+require_contains "$OUTPUT" "boundary   : read-only data; no hardware/model/provider/lab/IDE execution"
+require_contains "$OUTPUT" "target     : kv260"
+require_contains "$OUTPUT" "model      : gemma3n-e4b"
+require_contains "$OUTPUT" "connection : not_configured"
+require_contains "$OUTPUT" "discovery  : not_started"
+require_contains "$OUTPUT" "auth       : not_configured"
+require_contains "$OUTPUT" "model load : not_loaded"
+require_contains "$OUTPUT" "session    : inactive"
+require_contains "$OUTPUT" "logs       : not_started"
+require_contains "$OUTPUT" "diagnostic : available_as_placeholder"
+require_contains "$OUTPUT" "readiness  : blocked"
+PASS "device/session section is present and conservative"
+
+HEAD "2: status panel rows cover device, model, session, diagnostics, readiness"
+require_contains "$OUTPUT" "panel      : device_connection=not_configured"
+require_contains "$OUTPUT" "model_load=not_loaded"
+require_contains "$OUTPUT" "session_activity=inactive"
+require_contains "$OUTPUT" "pccx_lab_diagnostics=available_as_placeholder"
+require_contains "$OUTPUT" "runtime_readiness=blocked"
+PASS "status panel rows are summarized"
+
+HEAD "3: safety flags stay read-only and non-executing"
+require_contains "$OUTPUT" "readOnly=true"
+require_contains "$OUTPUT" "dataOnly=true"
+require_contains "$OUTPUT" "deterministic=true"
+require_contains "$OUTPUT" "runtimeExecution=false"
+require_contains "$OUTPUT" "modelLoaded=false"
+require_contains "$OUTPUT" "modelExecution=false"
+require_contains "$OUTPUT" "kv260Access=false"
+require_contains "$OUTPUT" "opensSerialPort=false"
+require_contains "$OUTPUT" "networkCalls=false"
+require_contains "$OUTPUT" "networkScan=false"
+require_contains "$OUTPUT" "sshExecution=false"
+require_contains "$OUTPUT" "authenticationAttempt=false"
+require_contains "$OUTPUT" "executesPccxLab=false"
+PASS "execution-related flags remain false"
+
+HEAD "4: output is deterministic"
+OUTPUT_AGAIN="$("$STUB" --include-device-session)"
+if [ "$OUTPUT" != "$OUTPUT_AGAIN" ]; then
+    FAIL "status device/session output changed between runs"
+    exit 1
+fi
+PASS "status device/session output is deterministic"
+
+HEAD "5: device/session option does not combine with pccx-lab backend"
+if "$STUB" --include-device-session --backend pccx-lab >/dev/null 2>&1; then
+    FAIL "expected combined device-session/backend mode to fail"
+    exit 1
+fi
+PASS "device/session status remains separate from backend execution"
+
+HEAD "6: output avoids known overclaims"
+FORBIDDEN_PREFIX="KV260 inference"
+FORBIDDEN_CLAIM="${FORBIDDEN_PREFIX} works"
+require_not_contains "$OUTPUT" "$FORBIDDEN_CLAIM"
+THROUGHPUT_PREFIX="20 tok/s"
+THROUGHPUT_CLAIM="${THROUGHPUT_PREFIX} achieved"
+require_not_contains "$OUTPUT" "$THROUGHPUT_CLAIM"
+PASS "no device/session or throughput overclaim in status output"
+
+printf '\n[DONE]  all status-device-session tests passed\n'


### PR DESCRIPTION
## Summary

- Add a data-only device/session status contract, JSON fixture, and stub for the planned Gemma 3N E4B + KV260 path.
- Add `scripts/status-stub.sh --include-device-session` so the launcher can show a conservative status panel for device connection, model load, session activity, pccx-lab diagnostics, and runtime readiness.
- Document the planned KV260 discovery, connection, launch gating, and error taxonomy with user remediation text.
- Extend CI coverage for the new contract, stub, status output, and claim-scan surface.

Refs #10
Refs #2

## Safety

This is a read-only status/data surface. It does not probe hardware, open serial ports, scan networks, attempt authentication, load model assets, invoke pccx-lab, start runtime code, stream logs, upload telemetry, or write artifacts.

## Validation

- `python3 scripts/tests/launcher_ide_contract_test.py`
- `python3 scripts/tests/model_runtime_descriptor_test.py`
- `python3 scripts/tests/diagnostics_handoff_contract_test.py`
- `python3 scripts/tests/device_session_status_contract_test.py`
- `python3 scripts/tests/runtime_readiness_contract_test.py`
- `bash scripts/tests/status-backend.sh scripts/status-stub.sh`
- `bash scripts/tests/status-device-session.sh scripts/status-stub.sh`
- `bash scripts/tests/status-readiness.sh scripts/status-stub.sh`
- `bash scripts/check.sh`
- `bash scripts/check-device-stub.sh`
- `bash scripts/install-stub.sh`
- `bash scripts/launch-stub.sh --dry-run`
- `bash scripts/status-stub.sh --include-device-session`
- `bash scripts/status-stub.sh --include-runtime-readiness`
- `bash -n scripts/status-stub.sh scripts/device-session-status-stub.sh scripts/tests/status-device-session.sh`
- local claim scan matching `.github/workflows/ci.yml`

Local `shellcheck` is not installed on this workstation; the GitHub Actions workflow installs and runs it.
