### PR TITLE
Add standalone chat session contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,7 @@ jobs:
                    scripts/status-stub.sh \
                    scripts/device-session-status-stub.sh \
                    scripts/runtime-readiness-stub.sh \
+                   scripts/chat-session-stub.sh \
                    scripts/chat-stub.sh; do
             [ -f "$f" ] && chmod +x "$f" || true
           done
@@ -151,6 +152,8 @@ jobs:
         run: ./scripts/status-stub.sh --include-runtime-readiness
       - name: run scripts/runtime-readiness-stub.sh
         run: ./scripts/runtime-readiness-stub.sh --model gemma3n-e4b --target kv260
+      - name: run scripts/chat-session-stub.sh
+        run: ./scripts/chat-session-stub.sh --model gemma3n-e4b --target kv260
       - name: run scripts/chat-stub.sh --dry-run
         run: ./scripts/chat-stub.sh --dry-run --prompt "hello"
       - name: chat-stub refuses without --dry-run
@@ -171,6 +174,8 @@ jobs:
         run: python3 scripts/tests/device_session_status_contract_test.py
       - name: run runtime readiness contract tests
         run: python3 scripts/tests/runtime_readiness_contract_test.py
+      - name: run chat/session contract tests
+        run: python3 scripts/tests/chat_session_contract_test.py
 
   status-backend:
     name: status-backend-tests
@@ -181,10 +186,12 @@ jobs:
         run: |
           chmod +x scripts/status-stub.sh
           chmod +x scripts/chat-stub.sh
+          chmod +x scripts/chat-session-stub.sh
           chmod +x scripts/launch-stub.sh
           chmod +x scripts/tests/status-backend.sh
           chmod +x scripts/tests/status-device-session.sh
           chmod +x scripts/tests/status-readiness.sh
+          chmod +x scripts/tests/status-chat-session.sh
       - name: shellcheck status-stub and test script
         run: |
           sudo apt-get update -q && sudo apt-get install -y -q shellcheck
@@ -192,9 +199,12 @@ jobs:
           shellcheck scripts/tests/status-backend.sh
           shellcheck scripts/tests/status-device-session.sh
           shellcheck scripts/tests/status-readiness.sh
+          shellcheck scripts/tests/status-chat-session.sh
       - name: run status-backend tests
         run: bash scripts/tests/status-backend.sh scripts/status-stub.sh
       - name: run status-device-session tests
         run: bash scripts/tests/status-device-session.sh scripts/status-stub.sh
       - name: run status-readiness tests
         run: bash scripts/tests/status-readiness.sh scripts/status-stub.sh
+      - name: run status-chat-session tests
+        run: bash scripts/tests/status-chat-session.sh scripts/status-stub.sh

--- a/README.md
+++ b/README.md
@@ -84,9 +84,10 @@ and verify host-side prerequisites before the real engine lands.
 | [`scripts/check.sh`](./scripts/check.sh) | Probe host info, tooling availability, edge-device hints. Always exits 0. |
 | [`scripts/check-device-stub.sh`](./scripts/check-device-stub.sh) | Narrowly scoped device-tree / FPGA-node probe (KV260 / Kria detection only). Always exits 0. |
 | [`scripts/install-stub.sh`](./scripts/install-stub.sh) | Preview of the planned install flow; reports which host runtime pieces are present, lists device-side pieces as future deliverables. Always exits 0. |
-| [`scripts/status-stub.sh`](./scripts/status-stub.sh) | Launcher state summary. Default mode: local scaffold output, always exits 0. With `--include-device-session`, adds a read-only device/session status panel. With `--include-runtime-readiness`, adds a read-only runtime readiness summary. With `--backend pccx-lab`, calls `pccx-lab status --format json` and forwards the run-status envelope (exits non-zero if binary is missing or output is invalid). |
+| [`scripts/status-stub.sh`](./scripts/status-stub.sh) | Launcher state summary. Default mode: local scaffold output, always exits 0. With `--include-chat-session`, adds a read-only blocked chat/session summary. With `--include-device-session`, adds a read-only device/session status panel. With `--include-runtime-readiness`, adds a read-only runtime readiness summary. With `--backend pccx-lab`, calls `pccx-lab status --format json` and forwards the run-status envelope (exits non-zero if binary is missing or output is invalid). |
 | [`scripts/device-session-status-stub.sh`](./scripts/device-session-status-stub.sh) | Data-only device/session status JSON for the Gemma 3N E4B + KV260 target. Reports connection, model load, session, diagnostics, readiness, discovery paths, flow steps, and error taxonomy as placeholder / blocked. |
 | [`scripts/runtime-readiness-stub.sh`](./scripts/runtime-readiness-stub.sh) | Data-only runtime readiness JSON for the Gemma 3N E4B + KV260 target. Reports blocked / not yet evidence-backed. |
+| [`scripts/chat-session-stub.sh`](./scripts/chat-session-stub.sh) | Data-only standalone chat/session JSON for the Gemma 3N E4B + KV260 target. Reports disabled send controls, inactive session state, no prompt/response persistence, and readiness handoff references. |
 | [`scripts/launch-stub.sh`](./scripts/launch-stub.sh) | Dry-run preview of the intended launch sequence. Requires `--dry-run`; exits 1 without it. |
 | [`scripts/chat-stub.sh`](./scripts/chat-stub.sh) | Dry-run chat stub. Requires `--dry-run`; exits 1 without it. Accepts `--prompt "..."` or stdin. No model is executed. |
 
@@ -95,10 +96,12 @@ bash scripts/check.sh
 bash scripts/check-device-stub.sh
 bash scripts/install-stub.sh
 bash scripts/status-stub.sh
+bash scripts/status-stub.sh --include-chat-session
 bash scripts/status-stub.sh --include-device-session
 bash scripts/status-stub.sh --include-runtime-readiness
 bash scripts/device-session-status-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/runtime-readiness-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/chat-session-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/launch-stub.sh --dry-run
 bash scripts/chat-stub.sh --dry-run --prompt "hello"
 ```
@@ -249,6 +252,32 @@ This surface does not probe hardware, open serial ports, scan networks,
 attempt authentication, load model assets, invoke pccx-lab, start a
 runtime, stream logs, upload telemetry, or write artifacts. See
 [docs/KV260_CONNECTION_AND_STATUS_FLOW.md](./docs/KV260_CONNECTION_AND_STATUS_FLOW.md).
+
+### Standalone chat/session contract (planned)
+
+The launcher now has a data-only standalone chat/session contract for
+the planned local chat entry point:
+
+```bash
+python3 contracts/chat_session_contract.py --model gemma3n-e4b --target kv260
+bash scripts/chat-session-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/status-stub.sh --include-chat-session
+python3 scripts/tests/chat_session_contract_test.py
+bash scripts/tests/status-chat-session.sh
+```
+
+The checked fixture reports the chat surface as blocked, the model as
+not loaded, the session as inactive, and send controls as disabled. It
+defines a message envelope vocabulary without storing prompts,
+responses, transcripts, model paths, generated artifacts, private paths,
+secrets, or tokens. It references the runtime readiness and
+device/session status fixtures as local data only.
+
+This surface does not execute a model, generate responses, persist
+transcripts, touch KV260 hardware, open serial ports, scan networks, call
+providers, invoke pccx-lab, invoke systemverilog-ide, upload telemetry,
+or write artifacts. See
+[docs/STANDALONE_CHAT_SESSION_CONTRACT.md](./docs/STANDALONE_CHAT_SESSION_CONTRACT.md).
 
 The legacy launcher scripts from the `llm-lite` era are preserved
 read-only under [`scripts/legacy/`](./scripts/legacy/) as historical

--- a/contracts/chat_session_contract.py
+++ b/contracts/chat_session_contract.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Data-only standalone chat/session contract for the planned launcher UI.
+
+The contract describes local chat session state, disabled send controls,
+message envelope shape, model status, and readiness references without
+persisting prompts, contacting providers, loading model assets, touching KV260
+hardware, invoking pccx-lab, or starting runtime code.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import sys
+
+
+SCHEMA_VERSION = "pccx.chatSession.v0"
+MESSAGE_SCHEMA_VERSION = "pccx.chatMessage.v0"
+
+CHAT_SESSION_FIELDS = (
+    "schemaVersion",
+    "sessionId",
+    "fixtureVersion",
+    "lastUpdatedSource",
+    "surfaceState",
+    "targetDevice",
+    "targetBoard",
+    "targetModel",
+    "modelStatus",
+    "runtimeReadinessRef",
+    "deviceSessionStatusRef",
+    "chatState",
+    "inputState",
+    "sendState",
+    "transcriptPolicy",
+    "sessionControls",
+    "messageEnvelope",
+    "blockedReasons",
+    "handoffRefs",
+    "safetyFlags",
+    "limitations",
+    "issueRefs",
+)
+
+CONTROL_FIELDS = (
+    "controlId",
+    "label",
+    "state",
+    "enabled",
+    "userAction",
+    "launcherAction",
+    "sideEffectPolicy",
+)
+
+BLOCKED_REASON_FIELDS = (
+    "reasonId",
+    "state",
+    "summary",
+    "requiredBefore",
+)
+
+HANDOFF_REF_FIELDS = (
+    "refId",
+    "schemaVersion",
+    "fixturePath",
+    "state",
+    "summary",
+)
+
+CHAT_SESSION_STATE_VALUES = (
+    "target",
+    "planned",
+    "placeholder",
+    "blocked",
+    "inactive",
+    "disabled",
+    "ready_for_inputs",
+    "not_configured",
+    "not_loaded",
+    "not_started",
+    "unavailable",
+    "available_as_data",
+)
+
+_CHAT_SESSION_STATUS = {
+    "schemaVersion": SCHEMA_VERSION,
+    "sessionId": "chat_session_gemma3n_e4b_kv260_placeholder",
+    "fixtureVersion": "chat-session.gemma3n-e4b-kv260.2026-05-03",
+    "lastUpdatedSource": "pccx_launcher_issue_9_boundary_2026-05-03",
+    "surfaceState": "blocked",
+    "targetDevice": "kv260",
+    "targetBoard": "xilinx_kria_kv260",
+    "targetModel": "gemma3n-e4b",
+    "modelStatus": "not_loaded",
+    "runtimeReadinessRef": "runtime_readiness_gemma3n_e4b_kv260",
+    "deviceSessionStatusRef": "device_session_status_gemma3n_e4b_kv260_placeholder",
+    "chatState": "inactive",
+    "inputState": "ready_for_inputs",
+    "sendState": "disabled",
+    "transcriptPolicy": {
+        "state": "not_started",
+        "persistence": "not_configured",
+        "promptCapture": "disabled",
+        "responseCapture": "disabled",
+        "summary": "This fixture stores no user prompts, responses, transcripts, or generated content.",
+    },
+    "sessionControls": [
+        {
+            "controlId": "new_session",
+            "label": "new session",
+            "state": "placeholder",
+            "enabled": False,
+            "userAction": "Open the chat surface when the launcher UI exists.",
+            "launcherAction": "Render deterministic placeholder session state.",
+            "sideEffectPolicy": "local_render_only",
+        },
+        {
+            "controlId": "model_status",
+            "label": "model status",
+            "state": "not_loaded",
+            "enabled": False,
+            "userAction": "Review model readiness before chat controls are enabled.",
+            "launcherAction": "Show the target descriptor and blocked model-load state.",
+            "sideEffectPolicy": "data_only",
+        },
+        {
+            "controlId": "send_message",
+            "label": "send message",
+            "state": "disabled",
+            "enabled": False,
+            "userAction": "Draft input only after a reviewed local session boundary exists.",
+            "launcherAction": "Keep send disabled while runtime readiness is blocked.",
+            "sideEffectPolicy": "no_runtime_execution",
+        },
+        {
+            "controlId": "clear_session",
+            "label": "clear session",
+            "state": "inactive",
+            "enabled": False,
+            "userAction": "Clear only a future local transcript owned by the launcher.",
+            "launcherAction": "No-op because no transcript exists in this fixture.",
+            "sideEffectPolicy": "no_write",
+        },
+        {
+            "controlId": "export_summary",
+            "label": "export summary",
+            "state": "blocked",
+            "enabled": False,
+            "userAction": "Export only bounded summaries after an explicit export boundary exists.",
+            "launcherAction": "Refuse export because no chat session exists.",
+            "sideEffectPolicy": "no_artifact_write",
+        },
+    ],
+    "messageEnvelope": {
+        "schemaVersion": MESSAGE_SCHEMA_VERSION,
+        "state": "available_as_data",
+        "roleVocabulary": [
+            "system_notice",
+            "user",
+            "assistant",
+        ],
+        "messageIdPolicy": "local_session_scoped_future_id",
+        "contentPolicy": "fixture carries field shape only; no prompt or response content is stored",
+        "orderingPolicy": "future session-local monotonic order",
+        "redactionPolicy": "prompt and response bodies stay outside checked fixtures",
+        "responseState": "unavailable",
+    },
+    "blockedReasons": [
+        {
+            "reasonId": "runtime_readiness_blocked",
+            "state": "blocked",
+            "summary": "Runtime readiness remains blocked for the Gemma 3N E4B plus KV260 target.",
+            "requiredBefore": "send_message_enabled",
+        },
+        {
+            "reasonId": "model_assets_not_configured",
+            "state": "not_configured",
+            "summary": "Model assets are external and are not configured by this fixture.",
+            "requiredBefore": "model_load_enabled",
+        },
+        {
+            "reasonId": "chat_runtime_not_implemented",
+            "state": "planned",
+            "summary": "The local chat runtime boundary has not been implemented in this repository.",
+            "requiredBefore": "session_start_enabled",
+        },
+        {
+            "reasonId": "kv260_session_absent",
+            "state": "inactive",
+            "summary": "No target device session exists and no log stream has started.",
+            "requiredBefore": "assistant_response_available",
+        },
+    ],
+    "handoffRefs": [
+        {
+            "refId": "runtime_readiness",
+            "schemaVersion": "pccx.runtimeReadiness.v0",
+            "fixturePath": "contracts/fixtures/runtime-readiness.gemma3n-e4b-kv260.json",
+            "state": "blocked",
+            "summary": "Runtime readiness is consumed as local data only.",
+        },
+        {
+            "refId": "device_session_status",
+            "schemaVersion": "pccx.deviceSessionStatus.v0",
+            "fixturePath": "contracts/fixtures/device-session-status.gemma3n-e4b-kv260.json",
+            "state": "available_as_data",
+            "summary": "Device/session status is consumed as local data only.",
+        },
+    ],
+    "safetyFlags": {
+        "dataOnly": True,
+        "readOnly": True,
+        "deterministic": True,
+        "writesArtifacts": False,
+        "promptContentIncluded": False,
+        "responseContentIncluded": False,
+        "transcriptPersistence": False,
+        "touchesHardware": False,
+        "kv260Access": False,
+        "opensSerialPort": False,
+        "networkCalls": False,
+        "networkScan": False,
+        "runtimeExecution": False,
+        "modelLoaded": False,
+        "modelExecution": False,
+        "modelWeightPathsIncluded": False,
+        "privatePathsIncluded": False,
+        "secretsIncluded": False,
+        "tokensIncluded": False,
+        "generatedBlobsIncluded": False,
+        "hardwareDumpsIncluded": False,
+        "providerCalls": False,
+        "cloudCalls": False,
+        "telemetry": False,
+        "automaticUpload": False,
+        "writeBack": False,
+        "executesPccxLab": False,
+        "executesSystemverilogIde": False,
+        "mcpServerImplemented": False,
+        "lspImplemented": False,
+        "stableApiAbiClaim": False,
+    },
+    "limitations": [
+        "Data-only standalone chat/session fixture; no model response is generated.",
+        "No prompts, responses, transcripts, model paths, generated artifacts, private paths, secrets, or tokens are stored.",
+        "No KV260 hardware access, serial access, network call, provider call, telemetry, upload, or write-back is performed.",
+        "Send controls remain disabled until runtime readiness and model/session evidence are available.",
+        "This is not a release, tag, versioned compatibility commitment, MCP, LSP, IDE, marketplace, or telemetry implementation.",
+    ],
+    "issueRefs": [
+        "pccxai/pccx-llm-launcher#9",
+    ],
+}
+
+
+def create_gemma3n_e4b_kv260_chat_session() -> dict:
+    """Return the checked Gemma 3N E4B plus KV260 chat/session fixture."""
+    return copy.deepcopy(_CHAT_SESSION_STATUS)
+
+
+def chat_session_json(status: dict | None = None) -> str:
+    """Render a deterministic JSON representation."""
+    return json.dumps(
+        status if status is not None else create_gemma3n_e4b_kv260_chat_session(),
+        indent=2,
+        sort_keys=True,
+    ) + "\n"
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Print data-only chat/session status JSON.",
+    )
+    parser.add_argument(
+        "--model",
+        default="gemma3n-e4b",
+        choices=("gemma3n-e4b",),
+        help="model descriptor target",
+    )
+    parser.add_argument(
+        "--target",
+        default="kv260",
+        choices=("kv260",),
+        help="target board/device",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parse_args(sys.argv[1:] if argv is None else argv)
+    sys.stdout.write(chat_session_json())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contracts/fixtures/chat-session.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-session.gemma3n-e4b-kv260-placeholder.json
@@ -1,0 +1,169 @@
+{
+  "blockedReasons": [
+    {
+      "reasonId": "runtime_readiness_blocked",
+      "requiredBefore": "send_message_enabled",
+      "state": "blocked",
+      "summary": "Runtime readiness remains blocked for the Gemma 3N E4B plus KV260 target."
+    },
+    {
+      "reasonId": "model_assets_not_configured",
+      "requiredBefore": "model_load_enabled",
+      "state": "not_configured",
+      "summary": "Model assets are external and are not configured by this fixture."
+    },
+    {
+      "reasonId": "chat_runtime_not_implemented",
+      "requiredBefore": "session_start_enabled",
+      "state": "planned",
+      "summary": "The local chat runtime boundary has not been implemented in this repository."
+    },
+    {
+      "reasonId": "kv260_session_absent",
+      "requiredBefore": "assistant_response_available",
+      "state": "inactive",
+      "summary": "No target device session exists and no log stream has started."
+    }
+  ],
+  "chatState": "inactive",
+  "deviceSessionStatusRef": "device_session_status_gemma3n_e4b_kv260_placeholder",
+  "fixtureVersion": "chat-session.gemma3n-e4b-kv260.2026-05-03",
+  "handoffRefs": [
+    {
+      "fixturePath": "contracts/fixtures/runtime-readiness.gemma3n-e4b-kv260.json",
+      "refId": "runtime_readiness",
+      "schemaVersion": "pccx.runtimeReadiness.v0",
+      "state": "blocked",
+      "summary": "Runtime readiness is consumed as local data only."
+    },
+    {
+      "fixturePath": "contracts/fixtures/device-session-status.gemma3n-e4b-kv260.json",
+      "refId": "device_session_status",
+      "schemaVersion": "pccx.deviceSessionStatus.v0",
+      "state": "available_as_data",
+      "summary": "Device/session status is consumed as local data only."
+    }
+  ],
+  "inputState": "ready_for_inputs",
+  "issueRefs": [
+    "pccxai/pccx-llm-launcher#9"
+  ],
+  "lastUpdatedSource": "pccx_launcher_issue_9_boundary_2026-05-03",
+  "limitations": [
+    "Data-only standalone chat/session fixture; no model response is generated.",
+    "No prompts, responses, transcripts, model paths, generated artifacts, private paths, secrets, or tokens are stored.",
+    "No KV260 hardware access, serial access, network call, provider call, telemetry, upload, or write-back is performed.",
+    "Send controls remain disabled until runtime readiness and model/session evidence are available.",
+    "This is not a release, tag, versioned compatibility commitment, MCP, LSP, IDE, marketplace, or telemetry implementation."
+  ],
+  "messageEnvelope": {
+    "contentPolicy": "fixture carries field shape only; no prompt or response content is stored",
+    "messageIdPolicy": "local_session_scoped_future_id",
+    "orderingPolicy": "future session-local monotonic order",
+    "redactionPolicy": "prompt and response bodies stay outside checked fixtures",
+    "responseState": "unavailable",
+    "roleVocabulary": [
+      "system_notice",
+      "user",
+      "assistant"
+    ],
+    "schemaVersion": "pccx.chatMessage.v0",
+    "state": "available_as_data"
+  },
+  "modelStatus": "not_loaded",
+  "runtimeReadinessRef": "runtime_readiness_gemma3n_e4b_kv260",
+  "safetyFlags": {
+    "automaticUpload": false,
+    "cloudCalls": false,
+    "dataOnly": true,
+    "deterministic": true,
+    "executesPccxLab": false,
+    "executesSystemverilogIde": false,
+    "generatedBlobsIncluded": false,
+    "hardwareDumpsIncluded": false,
+    "kv260Access": false,
+    "lspImplemented": false,
+    "mcpServerImplemented": false,
+    "modelExecution": false,
+    "modelLoaded": false,
+    "modelWeightPathsIncluded": false,
+    "networkCalls": false,
+    "networkScan": false,
+    "opensSerialPort": false,
+    "privatePathsIncluded": false,
+    "promptContentIncluded": false,
+    "providerCalls": false,
+    "readOnly": true,
+    "responseContentIncluded": false,
+    "runtimeExecution": false,
+    "secretsIncluded": false,
+    "stableApiAbiClaim": false,
+    "telemetry": false,
+    "tokensIncluded": false,
+    "touchesHardware": false,
+    "transcriptPersistence": false,
+    "writeBack": false,
+    "writesArtifacts": false
+  },
+  "schemaVersion": "pccx.chatSession.v0",
+  "sendState": "disabled",
+  "sessionControls": [
+    {
+      "controlId": "new_session",
+      "enabled": false,
+      "label": "new session",
+      "launcherAction": "Render deterministic placeholder session state.",
+      "sideEffectPolicy": "local_render_only",
+      "state": "placeholder",
+      "userAction": "Open the chat surface when the launcher UI exists."
+    },
+    {
+      "controlId": "model_status",
+      "enabled": false,
+      "label": "model status",
+      "launcherAction": "Show the target descriptor and blocked model-load state.",
+      "sideEffectPolicy": "data_only",
+      "state": "not_loaded",
+      "userAction": "Review model readiness before chat controls are enabled."
+    },
+    {
+      "controlId": "send_message",
+      "enabled": false,
+      "label": "send message",
+      "launcherAction": "Keep send disabled while runtime readiness is blocked.",
+      "sideEffectPolicy": "no_runtime_execution",
+      "state": "disabled",
+      "userAction": "Draft input only after a reviewed local session boundary exists."
+    },
+    {
+      "controlId": "clear_session",
+      "enabled": false,
+      "label": "clear session",
+      "launcherAction": "No-op because no transcript exists in this fixture.",
+      "sideEffectPolicy": "no_write",
+      "state": "inactive",
+      "userAction": "Clear only a future local transcript owned by the launcher."
+    },
+    {
+      "controlId": "export_summary",
+      "enabled": false,
+      "label": "export summary",
+      "launcherAction": "Refuse export because no chat session exists.",
+      "sideEffectPolicy": "no_artifact_write",
+      "state": "blocked",
+      "userAction": "Export only bounded summaries after an explicit export boundary exists."
+    }
+  ],
+  "sessionId": "chat_session_gemma3n_e4b_kv260_placeholder",
+  "surfaceState": "blocked",
+  "targetBoard": "xilinx_kria_kv260",
+  "targetDevice": "kv260",
+  "targetModel": "gemma3n-e4b",
+  "transcriptPolicy": {
+    "persistence": "not_configured",
+    "promptCapture": "disabled",
+    "responseCapture": "disabled",
+    "state": "not_started",
+    "summary": "This fixture stores no user prompts, responses, transcripts, or generated content."
+  }
+}

--- a/docs/STANDALONE_CHAT_SESSION_CONTRACT.md
+++ b/docs/STANDALONE_CHAT_SESSION_CONTRACT.md
@@ -1,0 +1,87 @@
+# Standalone Chat Session Contract
+
+This note defines the launcher-side standalone chat/session surface for
+the planned local chat entry point. It is data-only and keeps the current
+answer blocked until model, runtime, and target-session evidence exists.
+
+Current answer: **blocked / no local chat runtime is active**.
+
+The implementation lives in:
+
+- `contracts/chat_session_contract.py`
+- `contracts/fixtures/chat-session.gemma3n-e4b-kv260-placeholder.json`
+- `scripts/chat-session-stub.sh`
+- `scripts/tests/chat_session_contract_test.py`
+
+## What Is Implemented
+
+The chat/session contract records:
+
+- target model and KV260-class target identity
+- chat surface, model-load, input, send, and session states
+- disabled session controls for new session, model status, send,
+  clear, and export actions
+- a message envelope vocabulary without prompt or response content
+- links to the runtime readiness and device/session status fixtures
+- blocked reasons that explain what must exist before send controls can
+  be enabled
+- safety flags for the read-only boundary
+
+The checked fixture is deterministic JSON. The stub command prints that
+JSON for the supported model and target pair:
+
+```bash
+bash scripts/chat-session-stub.sh --model gemma3n-e4b --target kv260
+```
+
+## State Separation
+
+The chat/session states are deliberately narrow:
+
+- `target`: named planned target only
+- `planned`: described for a future reviewed boundary
+- `placeholder`: visible as deterministic local fixture data
+- `blocked`: a required evidence item or boundary is missing
+- `inactive`: no runtime session exists
+- `disabled`: UI control is intentionally unavailable
+- `ready_for_inputs`: a future reviewed boundary can accept explicit
+  input, but this fixture stores none
+- `not_configured`: required configuration is absent
+- `not_loaded`: no model assets are loaded
+- `not_started`: no transcript or log stream exists
+- `unavailable`: output is not available
+- `available_as_data`: local fixture shape is available as data only
+
+## Coordination Boundary
+
+The standalone chat surface depends on the existing launcher readiness
+and device/session status contracts. It may later become the primary
+user-facing entry point, but this contract does not add runtime
+execution, model loading, provider calls, persistence, or target access.
+
+pccx-lab remains a separate CLI/core diagnostics and verification
+backend. systemverilog-ide may consume launcher data later as read-only
+context. This launcher contract does not invoke either repo.
+
+## Non-Goals
+
+This chat/session surface does not add:
+
+- model execution or generated responses
+- prompt, response, or transcript persistence
+- model loading or model weight paths
+- KV260 runtime execution
+- serial, SSH, or network target access
+- provider or cloud calls
+- pccx-lab invocation
+- systemverilog-ide invocation
+- MCP implementation
+- LSP implementation
+- marketplace flow
+- telemetry, upload, or write-back
+- release or tag behavior
+- versioned compatibility commitment
+
+Runtime readiness, explicit model/session evidence, and a reviewed local
+chat execution boundary are required before send controls can move beyond
+disabled for the Gemma 3N E4B plus KV260 target.

--- a/scripts/chat-session-stub.sh
+++ b/scripts/chat-session-stub.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+# Print the data-only chat/session status contract.
+
+set -eu
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+
+python3 "$ROOT_DIR/contracts/chat_session_contract.py" "$@"

--- a/scripts/status-stub.sh
+++ b/scripts/status-stub.sh
@@ -10,6 +10,9 @@
 # Device/session status panel (explicit opt-in, read-only local data):
 #   --include-device-session
 #
+# Chat/session status (explicit opt-in, read-only local data):
+#   --include-chat-session
+#
 # pccx-lab backend (explicit opt-in):
 #   --backend pccx-lab        call pccx-lab status --format json
 #   PCCX_LAB_BIN              override path to pccx-lab binary (takes priority over PATH)
@@ -27,6 +30,81 @@ HEAD()  { printf '\n=== %s ===\n' "$*"; }
 BACKEND=""
 INCLUDE_RUNTIME_READINESS="0"
 INCLUDE_DEVICE_SESSION="0"
+INCLUDE_CHAT_SESSION="0"
+
+print_chat_session_summary() {
+    SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+    ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+    CHAT_SESSION_STUB="$ROOT_DIR/scripts/chat-session-stub.sh"
+
+    if [ ! -f "$CHAT_SESSION_STUB" ]; then
+        ERROR "chat/session stub not found: $CHAT_SESSION_STUB"
+        return 1
+    fi
+
+    if ! CHAT_SESSION_JSON="$(bash "$CHAT_SESSION_STUB" --model gemma3n-e4b --target kv260 2>&1)"; then
+        ERROR "chat/session stub failed"
+        printf '%s\n' "$CHAT_SESSION_JSON" >&2
+        return 1
+    fi
+
+    if ! CHAT_SESSION_SUMMARY="$(
+        printf '%s\n' "$CHAT_SESSION_JSON" | python3 -c '
+import json
+import sys
+
+data = json.load(sys.stdin)
+flags = data["safetyFlags"]
+controls = " ".join(
+    "{}={}".format(control["controlId"], control["state"])
+    for control in data["sessionControls"]
+)
+
+def b(value):
+    return "true" if value else "false"
+
+print("[INFO]  source     : scripts/chat-session-stub.sh --model gemma3n-e4b --target kv260")
+print("[INFO]  boundary   : read-only data; no prompt/model/provider/hardware/lab/IDE execution")
+print("[INFO]  target     : {}".format(data["targetDevice"]))
+print("[INFO]  model      : {}".format(data["targetModel"]))
+print("[INFO]  surface    : {}".format(data["surfaceState"]))
+print("[INFO]  chat       : {}".format(data["chatState"]))
+print("[INFO]  input      : {}".format(data["inputState"]))
+print("[INFO]  send       : {}".format(data["sendState"]))
+print("[INFO]  model load : {}".format(data["modelStatus"]))
+print("[INFO]  transcript : {}".format(data["transcriptPolicy"]["state"]))
+print("[INFO]  response   : {}".format(data["messageEnvelope"]["responseState"]))
+print("[INFO]  controls   : {}".format(controls))
+print(
+    "[INFO]  flags      : readOnly={} dataOnly={} deterministic={} "
+    "runtimeExecution={} modelLoaded={} modelExecution={} kv260Access={} "
+    "providerCalls={} cloudCalls={} networkCalls={} transcriptPersistence={} "
+    "promptContentIncluded={} responseContentIncluded={} executesPccxLab={}".format(
+        b(flags["readOnly"]),
+        b(flags["dataOnly"]),
+        b(flags["deterministic"]),
+        b(flags["runtimeExecution"]),
+        b(flags["modelLoaded"]),
+        b(flags["modelExecution"]),
+        b(flags["kv260Access"]),
+        b(flags["providerCalls"]),
+        b(flags["cloudCalls"]),
+        b(flags["networkCalls"]),
+        b(flags["transcriptPersistence"]),
+        b(flags["promptContentIncluded"]),
+        b(flags["responseContentIncluded"]),
+        b(flags["executesPccxLab"]),
+    )
+)
+'
+    )"; then
+        ERROR "chat/session JSON could not be summarized"
+        return 1
+    fi
+
+    HEAD "chat/session status"
+    printf '%s\n' "$CHAT_SESSION_SUMMARY"
+}
 
 print_device_session_summary() {
     SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
@@ -184,6 +262,10 @@ while [ $# -gt 0 ]; do
             INCLUDE_DEVICE_SESSION="1"
             shift
             ;;
+        --include-chat-session)
+            INCLUDE_CHAT_SESSION="1"
+            shift
+            ;;
         --backend)
             BACKEND="${2:-}"
             if [ -z "$BACKEND" ]; then
@@ -199,8 +281,8 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-if [ -n "$BACKEND" ] && { [ "$INCLUDE_RUNTIME_READINESS" = "1" ] || [ "$INCLUDE_DEVICE_SESSION" = "1" ]; }; then
-    ERROR "--include-runtime-readiness and --include-device-session are only supported in local scaffold mode"
+if [ -n "$BACKEND" ] && { [ "$INCLUDE_RUNTIME_READINESS" = "1" ] || [ "$INCLUDE_DEVICE_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SESSION" = "1" ]; }; then
+    ERROR "--include-runtime-readiness, --include-device-session, and --include-chat-session are only supported in local scaffold mode"
     exit 1
 fi
 
@@ -215,7 +297,14 @@ if [ -z "$BACKEND" ]; then
     NOTE "pccx-lab status: opt-in via --backend pccx-lab (host-dry-run scaffold)"
     NOTE "runtime ready  : opt-in via --include-runtime-readiness (read-only data)"
     NOTE "device/session: opt-in via --include-device-session (read-only panel data)"
+    NOTE "chat/session  : opt-in via --include-chat-session (read-only blocked chat data)"
     NOTE "editor bridge  : planned (VS Code / other IDEs)"
+
+    if [ "$INCLUDE_CHAT_SESSION" = "1" ]; then
+        if ! print_chat_session_summary; then
+            exit 1
+        fi
+    fi
 
     if [ "$INCLUDE_DEVICE_SESSION" = "1" ]; then
         if ! print_device_session_summary; then

--- a/scripts/tests/chat_session_contract_test.py
+++ b/scripts/tests/chat_session_contract_test.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Fixture tests for the standalone chat/session contract."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "contracts" / "chat_session_contract.py"
+FIXTURE_PATH = (
+    ROOT
+    / "contracts"
+    / "fixtures"
+    / "chat-session.gemma3n-e4b-kv260-placeholder.json"
+)
+SCRIPT_PATH = ROOT / "scripts" / "chat-session-stub.sh"
+DOC_PATH = ROOT / "docs" / "STANDALONE_CHAT_SESSION_CONTRACT.md"
+README_PATH = ROOT / "README.md"
+TEST_PATH = Path(__file__).resolve()
+CI_PATH = ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location(
+        "chat_session_contract",
+        MODULE_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def flatten(value) -> str:
+    return json.dumps(value, sort_keys=True)
+
+
+def iter_state_values(value):
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            if key == "state" or key.endswith("State") or key.endswith("Status"):
+                yield nested
+            yield from iter_state_values(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            yield from iter_state_values(nested)
+
+
+def iter_keys(value):
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            yield key
+            yield from iter_keys(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            yield from iter_keys(nested)
+
+
+def assert_no_private_or_generated_data(text: str) -> None:
+    forbidden_patterns = [
+        r"/home/[^\s\"']+",
+        r"/Users/[^\s\"']+",
+        r"[A-Za-z]:\\Users\\",
+        r"\b(?:api[_-]?key|authorization|bearer|client[_-]?secret|password|private[_-]?key|secret|token)\b\s*[:=]",
+        r"\.(?:gguf|safetensors|ckpt|pt|pth|onnx)\b",
+        r"(?:weights|model_weights|model-cache)/(?:[^\"'\s]+)",
+        r"(?:raw[_-]?full[_-]?logs|hardware[_-]?dump|generated[_-]?blob)\s*[:=]",
+    ]
+    for pattern in forbidden_patterns:
+        assert not re.search(pattern, text, re.IGNORECASE), pattern
+
+
+def assert_no_runtime_implementation_terms(source: str) -> None:
+    forbidden = [
+        "subprocess",
+        "os.system",
+        "popen",
+        "socket",
+        "urllib",
+        "requests",
+        "http.client",
+        "openai",
+        "anthropic",
+        "gemini",
+        "modelcontextprotocol",
+        "websocket",
+        "xmutil",
+        "xrt-smi",
+        "lsusb",
+        "dmesg",
+    ]
+    lowered = source.lower()
+    for term in forbidden:
+        assert term not in lowered, term
+
+
+def assert_no_provider_configs(value) -> None:
+    forbidden_keys = {
+        "apiKey",
+        "accessToken",
+        "refreshToken",
+        "authorization",
+        "bearerToken",
+        "provider",
+        "providers",
+        "providerConfig",
+        "providerConfigs",
+    }
+    for key in iter_keys(value):
+        assert key not in forbidden_keys, key
+
+
+def assert_no_unsupported_claims(text: str) -> None:
+    literal_claims = [
+        "production-ready",
+        "marketplace-ready",
+        "stable API",
+        "stable ABI",
+        "KV260 inference works",
+        "Gemma 3N E4B runs on KV260",
+        "20 tok/s achieved",
+        "timing closed",
+        "bitstream ready",
+        "launcher executes pccx-lab",
+        "IDE controls launcher",
+        "AI provider integration is live",
+    ]
+    lowered = text.lower()
+    for claim in literal_claims:
+        assert claim.lower() not in lowered, claim
+
+    asserted_claim_patterns = [
+        r"\bMCP\s+(?:server|client)\s+(?:is\s+)?implemented\b",
+        r"\bLSP\s+(?:server|client)\s+(?:is\s+)?implemented\b",
+        r"\bAI\s+provider\s+(?:is\s+)?implemented\b",
+        r"\bKV260\s+run\s+(?:is\s+)?claimed\b",
+    ]
+    for pattern in asserted_claim_patterns:
+        assert not re.search(pattern, text, re.IGNORECASE), pattern
+
+
+def assert_no_chat_invocation_flags(source: str) -> None:
+    forbidden_patterns = [
+        r"--backend\s+pccx-lab",
+        r"\bPCCX_LAB_BIN\b",
+        r"\bpccx-lab\s+(?:status|diagnostics|validate)\b",
+        r"\bsystemverilog-ide\s+--",
+        r"\bsystemverilog-ide\s+(?:open|run|status|validate|launch)\b",
+        r"\b(?:curl|wget)\b",
+        r"\b(?:upload|telemetry|write-back)\s+(?:enabled|true)\b",
+    ]
+    for pattern in forbidden_patterns:
+        assert not re.search(pattern, source, re.IGNORECASE), pattern
+
+
+def test_chat_session_matches_fixture_and_is_deterministic() -> None:
+    module = load_module()
+    generated = module.create_gemma3n_e4b_kv260_chat_session()
+    fixture = json.loads(read_text(FIXTURE_PATH))
+
+    assert generated == fixture
+    assert module.chat_session_json(generated) == module.chat_session_json(generated)
+    assert module.chat_session_json(generated).endswith("\n")
+    assert json.loads(module.chat_session_json(generated)) == fixture
+
+
+def test_cli_stub_outputs_deterministic_json() -> None:
+    fixture = json.loads(read_text(FIXTURE_PATH))
+    command = [
+        "bash",
+        str(SCRIPT_PATH),
+        "--model",
+        "gemma3n-e4b",
+        "--target",
+        "kv260",
+    ]
+    first = subprocess.run(
+        command,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    second = subprocess.run(
+        command,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert first.stderr == ""
+    assert first.stdout == second.stdout
+    assert first.stdout.endswith("\n")
+    assert json.loads(first.stdout) == fixture
+
+
+def test_required_fields_and_allowed_states() -> None:
+    module = load_module()
+    status = module.create_gemma3n_e4b_kv260_chat_session()
+    allowed = set(module.CHAT_SESSION_STATE_VALUES)
+
+    assert tuple(status.keys()) == module.CHAT_SESSION_FIELDS
+    assert status["schemaVersion"] == "pccx.chatSession.v0"
+    assert status["messageEnvelope"]["schemaVersion"] == "pccx.chatMessage.v0"
+
+    states = list(iter_state_values(status))
+    assert states
+    for state in states:
+        assert state in allowed, state
+
+    for control in status["sessionControls"]:
+        assert tuple(control.keys()) == module.CONTROL_FIELDS
+    for reason in status["blockedReasons"]:
+        assert tuple(reason.keys()) == module.BLOCKED_REASON_FIELDS
+    for ref in status["handoffRefs"]:
+        assert tuple(ref.keys()) == module.HANDOFF_REF_FIELDS
+
+
+def test_chat_contract_covers_issue_9_surface() -> None:
+    status = load_module().create_gemma3n_e4b_kv260_chat_session()
+    controls = {control["controlId"]: control for control in status["sessionControls"]}
+    reasons = {reason["reasonId"]: reason for reason in status["blockedReasons"]}
+    refs = {ref["refId"]: ref for ref in status["handoffRefs"]}
+
+    assert status["surfaceState"] == "blocked"
+    assert status["chatState"] == "inactive"
+    assert status["modelStatus"] == "not_loaded"
+    assert status["inputState"] == "ready_for_inputs"
+    assert status["sendState"] == "disabled"
+    assert set(controls) == {
+        "new_session",
+        "model_status",
+        "send_message",
+        "clear_session",
+        "export_summary",
+    }
+    assert controls["send_message"]["enabled"] is False
+    assert controls["send_message"]["state"] == "disabled"
+    assert status["messageEnvelope"]["responseState"] == "unavailable"
+    assert status["transcriptPolicy"]["promptCapture"] == "disabled"
+    assert status["transcriptPolicy"]["responseCapture"] == "disabled"
+    assert {
+        "runtime_readiness_blocked",
+        "model_assets_not_configured",
+        "chat_runtime_not_implemented",
+        "kv260_session_absent",
+    } <= set(reasons)
+    assert set(refs) == {"runtime_readiness", "device_session_status"}
+
+
+def test_safety_flags_preserve_data_only_boundary() -> None:
+    status = load_module().create_gemma3n_e4b_kv260_chat_session()
+    flags = status["safetyFlags"]
+
+    assert flags["dataOnly"] is True
+    assert flags["readOnly"] is True
+    assert flags["deterministic"] is True
+    for name in [
+        "writesArtifacts",
+        "promptContentIncluded",
+        "responseContentIncluded",
+        "transcriptPersistence",
+        "touchesHardware",
+        "kv260Access",
+        "opensSerialPort",
+        "networkCalls",
+        "networkScan",
+        "runtimeExecution",
+        "modelLoaded",
+        "modelExecution",
+        "modelWeightPathsIncluded",
+        "privatePathsIncluded",
+        "secretsIncluded",
+        "tokensIncluded",
+        "generatedBlobsIncluded",
+        "hardwareDumpsIncluded",
+        "providerCalls",
+        "cloudCalls",
+        "telemetry",
+        "automaticUpload",
+        "writeBack",
+        "executesPccxLab",
+        "executesSystemverilogIde",
+        "mcpServerImplemented",
+        "lspImplemented",
+        "stableApiAbiClaim",
+    ]:
+        assert flags[name] is False, name
+
+
+def test_docs_and_sources_avoid_private_data_runtime_calls_or_overclaims() -> None:
+    module_source = read_text(MODULE_PATH)
+    script_source = read_text(SCRIPT_PATH)
+    status = load_module().create_gemma3n_e4b_kv260_chat_session()
+    scan_text = "\n".join([
+        read_text(FIXTURE_PATH),
+        read_text(DOC_PATH),
+        read_text(README_PATH),
+        flatten(status),
+        module_source,
+        script_source,
+    ])
+    runtime_source = "\n".join([module_source, script_source])
+
+    assert_no_runtime_implementation_terms(module_source)
+    assert_no_private_or_generated_data(scan_text)
+    assert_no_provider_configs(status)
+    assert_no_unsupported_claims(scan_text)
+    assert_no_chat_invocation_flags(runtime_source)
+
+
+def test_source_headers_for_touched_code_files() -> None:
+    expected_headers = {
+        MODULE_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        SCRIPT_PATH: [
+            "#!/usr/bin/env bash",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        TEST_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        CI_PATH: [
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+    }
+
+    for path, header in expected_headers.items():
+        assert read_text(path).splitlines()[: len(header)] == header, path
+
+
+test_chat_session_matches_fixture_and_is_deterministic()
+test_cli_stub_outputs_deterministic_json()
+test_required_fields_and_allowed_states()
+test_chat_contract_covers_issue_9_surface()
+test_safety_flags_preserve_data_only_boundary()
+test_docs_and_sources_avoid_private_data_runtime_calls_or_overclaims()
+test_source_headers_for_touched_code_files()
+
+print("chat/session contract tests ok")

--- a/scripts/tests/status-chat-session.sh
+++ b/scripts/tests/status-chat-session.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+# scripts/tests/status-chat-session.sh - status chat/session summary tests.
+#
+# Usage: bash scripts/tests/status-chat-session.sh [path/to/status-stub.sh]
+
+set -eu
+
+PASS() { printf '[PASS]  %s\n' "$*"; }
+FAIL() { printf '[FAIL]  %s\n' "$*" >&2; }
+HEAD() { printf '\n=== %s ===\n' "$*"; }
+
+STUB="${1:-scripts/status-stub.sh}"
+
+if [ ! -x "$STUB" ]; then
+    chmod +x "$STUB"
+fi
+
+contains() {
+    case "$1" in
+        *"$2"*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+require_contains() {
+    local output="$1"
+    local expected="$2"
+    if ! contains "$output" "$expected"; then
+        FAIL "expected output to contain: $expected"
+        printf '%s\n' "$output" >&2
+        exit 1
+    fi
+}
+
+require_not_contains() {
+    local output="$1"
+    local forbidden="$2"
+    if contains "$output" "$forbidden"; then
+        FAIL "output contained forbidden text: $forbidden"
+        printf '%s\n' "$output" >&2
+        exit 1
+    fi
+}
+
+HEAD "1: status can include chat/session state"
+OUTPUT="$("$STUB" --include-chat-session)"
+require_contains "$OUTPUT" "=== chat/session status ==="
+require_contains "$OUTPUT" "source     : scripts/chat-session-stub.sh --model gemma3n-e4b --target kv260"
+require_contains "$OUTPUT" "boundary   : read-only data; no prompt/model/provider/hardware/lab/IDE execution"
+require_contains "$OUTPUT" "target     : kv260"
+require_contains "$OUTPUT" "model      : gemma3n-e4b"
+require_contains "$OUTPUT" "surface    : blocked"
+require_contains "$OUTPUT" "chat       : inactive"
+require_contains "$OUTPUT" "input      : ready_for_inputs"
+require_contains "$OUTPUT" "send       : disabled"
+require_contains "$OUTPUT" "model load : not_loaded"
+require_contains "$OUTPUT" "transcript : not_started"
+require_contains "$OUTPUT" "response   : unavailable"
+PASS "chat/session section is present and conservative"
+
+HEAD "2: controls stay disabled or non-executing"
+require_contains "$OUTPUT" "controls   : new_session=placeholder"
+require_contains "$OUTPUT" "model_status=not_loaded"
+require_contains "$OUTPUT" "send_message=disabled"
+require_contains "$OUTPUT" "clear_session=inactive"
+require_contains "$OUTPUT" "export_summary=blocked"
+PASS "chat/session controls are summarized"
+
+HEAD "3: safety flags stay read-only and non-executing"
+require_contains "$OUTPUT" "readOnly=true"
+require_contains "$OUTPUT" "dataOnly=true"
+require_contains "$OUTPUT" "deterministic=true"
+require_contains "$OUTPUT" "runtimeExecution=false"
+require_contains "$OUTPUT" "modelLoaded=false"
+require_contains "$OUTPUT" "modelExecution=false"
+require_contains "$OUTPUT" "kv260Access=false"
+require_contains "$OUTPUT" "providerCalls=false"
+require_contains "$OUTPUT" "cloudCalls=false"
+require_contains "$OUTPUT" "networkCalls=false"
+require_contains "$OUTPUT" "transcriptPersistence=false"
+require_contains "$OUTPUT" "promptContentIncluded=false"
+require_contains "$OUTPUT" "responseContentIncluded=false"
+require_contains "$OUTPUT" "executesPccxLab=false"
+PASS "execution-related flags remain false"
+
+HEAD "4: output is deterministic"
+OUTPUT_AGAIN="$("$STUB" --include-chat-session)"
+if [ "$OUTPUT" != "$OUTPUT_AGAIN" ]; then
+    FAIL "status chat/session output changed between runs"
+    exit 1
+fi
+PASS "status chat/session output is deterministic"
+
+HEAD "5: chat/session option does not combine with pccx-lab backend"
+if "$STUB" --include-chat-session --backend pccx-lab >/dev/null 2>&1; then
+    FAIL "expected combined chat-session/backend mode to fail"
+    exit 1
+fi
+PASS "chat/session status remains separate from backend execution"
+
+HEAD "6: output avoids known overclaims"
+FORBIDDEN_PREFIX="KV260 inference"
+FORBIDDEN_CLAIM="${FORBIDDEN_PREFIX} works"
+require_not_contains "$OUTPUT" "$FORBIDDEN_CLAIM"
+THROUGHPUT_PREFIX="20 tok/s"
+THROUGHPUT_CLAIM="${THROUGHPUT_PREFIX} achieved"
+require_not_contains "$OUTPUT" "$THROUGHPUT_CLAIM"
+PASS "no chat/session or throughput overclaim in status output"
+
+printf '\n[DONE]  all status-chat-session tests passed\n'


### PR DESCRIPTION
## Summary

- add a data-only `pccx.chatSession.v0` contract and checked Gemma 3N E4B + KV260 placeholder fixture
- add `chat-session-stub.sh` plus status-stub `--include-chat-session` summary wiring
- document the blocked standalone chat/session boundary and add CI coverage

Refs #9.

## Validation

- `python3 scripts/tests/chat_session_contract_test.py`
- `bash scripts/tests/status-chat-session.sh scripts/status-stub.sh`
- `python3 scripts/tests/launcher_ide_contract_test.py`
- `python3 scripts/tests/model_runtime_descriptor_test.py`
- `python3 scripts/tests/diagnostics_handoff_contract_test.py`
- `python3 scripts/tests/device_session_status_contract_test.py`
- `python3 scripts/tests/runtime_readiness_contract_test.py`
- `bash scripts/tests/status-backend.sh scripts/status-stub.sh`
- `bash scripts/tests/status-device-session.sh scripts/status-stub.sh`
- `bash scripts/tests/status-readiness.sh scripts/status-stub.sh`
- `bash scripts/check.sh`
- `bash scripts/check-device-stub.sh`
- `bash scripts/install-stub.sh`
- `bash scripts/launch-stub.sh --dry-run`
- `bash scripts/chat-stub.sh --dry-run --prompt hello`
- `bash scripts/status-stub.sh --include-chat-session --include-device-session --include-runtime-readiness`
- `for f in scripts/*.sh scripts/tests/*.sh; do bash -n "$f"; done`
- `git diff --check`
- local claim-scan

## Notes

This is a placeholder/status contract only. It does not execute a model, generate responses, persist transcripts, access KV260 hardware, call providers, invoke pccx-lab, invoke systemverilog-ide, or make runtime/performance claims.