### PR TITLE
Add chat surface preview

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,7 @@ jobs:
                    scripts/device-session-status-stub.sh \
                    scripts/runtime-readiness-stub.sh \
                    scripts/chat-session-stub.sh \
+                   scripts/chat-surface-preview.sh \
                    scripts/chat-stub.sh; do
             [ -f "$f" ] && chmod +x "$f" || true
           done
@@ -154,6 +155,8 @@ jobs:
         run: ./scripts/runtime-readiness-stub.sh --model gemma3n-e4b --target kv260
       - name: run scripts/chat-session-stub.sh
         run: ./scripts/chat-session-stub.sh --model gemma3n-e4b --target kv260
+      - name: run scripts/chat-surface-preview.sh
+        run: ./scripts/chat-surface-preview.sh --model gemma3n-e4b --target kv260
       - name: run scripts/chat-stub.sh --dry-run
         run: ./scripts/chat-stub.sh --dry-run --prompt "hello"
       - name: chat-stub refuses without --dry-run
@@ -176,6 +179,8 @@ jobs:
         run: python3 scripts/tests/runtime_readiness_contract_test.py
       - name: run chat/session contract tests
         run: python3 scripts/tests/chat_session_contract_test.py
+      - name: run chat surface preview tests
+        run: python3 scripts/tests/chat_surface_preview_test.py
 
   status-backend:
     name: status-backend-tests

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ and verify host-side prerequisites before the real engine lands.
 | [`scripts/device-session-status-stub.sh`](./scripts/device-session-status-stub.sh) | Data-only device/session status JSON for the Gemma 3N E4B + KV260 target. Reports connection, model load, session, diagnostics, readiness, discovery paths, flow steps, and error taxonomy as placeholder / blocked. |
 | [`scripts/runtime-readiness-stub.sh`](./scripts/runtime-readiness-stub.sh) | Data-only runtime readiness JSON for the Gemma 3N E4B + KV260 target. Reports blocked / not yet evidence-backed. |
 | [`scripts/chat-session-stub.sh`](./scripts/chat-session-stub.sh) | Data-only standalone chat/session JSON for the Gemma 3N E4B + KV260 target. Reports disabled send controls, inactive session state, no prompt/response persistence, and readiness handoff references. |
+| [`scripts/chat-surface-preview.sh`](./scripts/chat-surface-preview.sh) | Read-only terminal preview of the standalone chat surface. Renders the checked chat/session contract as blocked UI state without accepting prompts, executing a model, or writing artifacts. |
 | [`scripts/launch-stub.sh`](./scripts/launch-stub.sh) | Dry-run preview of the intended launch sequence. Requires `--dry-run`; exits 1 without it. |
 | [`scripts/chat-stub.sh`](./scripts/chat-stub.sh) | Dry-run chat stub. Requires `--dry-run`; exits 1 without it. Accepts `--prompt "..."` or stdin. No model is executed. |
 
@@ -102,6 +103,7 @@ bash scripts/status-stub.sh --include-runtime-readiness
 bash scripts/device-session-status-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/runtime-readiness-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-session-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/chat-surface-preview.sh --model gemma3n-e4b --target kv260
 bash scripts/launch-stub.sh --dry-run
 bash scripts/chat-stub.sh --dry-run --prompt "hello"
 ```
@@ -261,8 +263,10 @@ the planned local chat entry point:
 ```bash
 python3 contracts/chat_session_contract.py --model gemma3n-e4b --target kv260
 bash scripts/chat-session-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/chat-surface-preview.sh --model gemma3n-e4b --target kv260
 bash scripts/status-stub.sh --include-chat-session
 python3 scripts/tests/chat_session_contract_test.py
+python3 scripts/tests/chat_surface_preview_test.py
 bash scripts/tests/status-chat-session.sh
 ```
 
@@ -272,6 +276,10 @@ defines a message envelope vocabulary without storing prompts,
 responses, transcripts, model paths, generated artifacts, private paths,
 secrets, or tokens. It references the runtime readiness and
 device/session status fixtures as local data only.
+
+The preview command renders that same contract as a deterministic
+terminal chat surface sketch with disabled controls, blocked reasons, and
+an unavailable assistant response. It does not accept or echo prompts.
 
 This surface does not execute a model, generate responses, persist
 transcripts, touch KV260 hardware, open serial ports, scan networks, call

--- a/docs/STANDALONE_CHAT_SESSION_CONTRACT.md
+++ b/docs/STANDALONE_CHAT_SESSION_CONTRACT.md
@@ -11,7 +11,9 @@ The implementation lives in:
 - `contracts/chat_session_contract.py`
 - `contracts/fixtures/chat-session.gemma3n-e4b-kv260-placeholder.json`
 - `scripts/chat-session-stub.sh`
+- `scripts/chat-surface-preview.sh`
 - `scripts/tests/chat_session_contract_test.py`
+- `scripts/tests/chat_surface_preview_test.py`
 
 ## What Is Implemented
 
@@ -33,6 +35,19 @@ JSON for the supported model and target pair:
 ```bash
 bash scripts/chat-session-stub.sh --model gemma3n-e4b --target kv260
 ```
+
+The terminal preview command renders the same checked contract as a
+read-only chat surface sketch:
+
+```bash
+bash scripts/chat-surface-preview.sh --model gemma3n-e4b --target kv260
+```
+
+The preview shows the blocked chat surface, inactive session state,
+disabled controls, blocked reasons, and unavailable assistant response.
+It does not accept or echo prompts, persist transcripts, execute a
+model, touch hardware, call providers, invoke pccx-lab, or write
+artifacts.
 
 ## State Separation
 

--- a/scripts/chat-surface-preview.sh
+++ b/scripts/chat-surface-preview.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+# Render a read-only standalone chat surface preview from the checked contract.
+
+set -eu
+
+ERROR() { printf '[ERROR] %s\n' "$*" >&2; }
+
+usage() {
+    cat <<'EOF'
+Usage: bash scripts/chat-surface-preview.sh [--model gemma3n-e4b] [--target kv260]
+
+Render the local standalone chat surface preview from the data-only
+chat/session contract. This does not capture prompts, execute a model,
+touch hardware, call providers, invoke pccx-lab, or write artifacts.
+EOF
+}
+
+MODEL="gemma3n-e4b"
+TARGET="kv260"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --model)
+            if [ -z "${2:-}" ]; then
+                ERROR "--model requires an argument"
+                exit 1
+            fi
+            MODEL="$2"
+            shift 2
+            ;;
+        --target)
+            if [ -z "${2:-}" ]; then
+                ERROR "--target requires an argument"
+                exit 1
+            fi
+            TARGET="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            ERROR "unknown option: $1"
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+CHAT_SESSION_STUB="$ROOT_DIR/scripts/chat-session-stub.sh"
+
+if [ ! -f "$CHAT_SESSION_STUB" ]; then
+    ERROR "chat/session stub not found: $CHAT_SESSION_STUB"
+    exit 1
+fi
+
+if ! CHAT_SESSION_JSON="$(bash "$CHAT_SESSION_STUB" --model "$MODEL" --target "$TARGET" 2>&1)"; then
+    ERROR "chat/session stub failed"
+    printf '%s\n' "$CHAT_SESSION_JSON" >&2
+    exit 1
+fi
+
+printf '%s\n' "$CHAT_SESSION_JSON" | python3 -c '
+import json
+import sys
+
+data = json.load(sys.stdin)
+flags = data["safetyFlags"]
+forbidden_true_flags = [
+    "writesArtifacts",
+    "promptContentIncluded",
+    "responseContentIncluded",
+    "transcriptPersistence",
+    "touchesHardware",
+    "kv260Access",
+    "opensSerialPort",
+    "networkCalls",
+    "networkScan",
+    "runtimeExecution",
+    "modelLoaded",
+    "modelExecution",
+    "providerCalls",
+    "cloudCalls",
+    "telemetry",
+    "automaticUpload",
+    "writeBack",
+    "executesPccxLab",
+    "executesSystemverilogIde",
+]
+
+unexpected = [name for name in forbidden_true_flags if flags.get(name)]
+if unexpected:
+    raise SystemExit("unsafe chat preview flags: {}".format(", ".join(unexpected)))
+
+controls = data["sessionControls"]
+blocked = data["blockedReasons"]
+
+print("=== standalone chat surface preview ===")
+print("[INFO]  boundary   : read-only local preview; no prompt/model/provider/hardware/lab/IDE execution")
+print("[INFO]  session    : {}".format(data["sessionId"]))
+print("[INFO]  target     : {}".format(data["targetDevice"]))
+print("[INFO]  model      : {}".format(data["targetModel"]))
+print("[INFO]  surface    : {}".format(data["surfaceState"]))
+print("[INFO]  chat       : {}".format(data["chatState"]))
+print("[INFO]  input      : {}".format(data["inputState"]))
+print("[INFO]  send       : {}".format(data["sendState"]))
+print("[INFO]  model load : {}".format(data["modelStatus"]))
+print("[INFO]  transcript : {} / {}".format(
+    data["transcriptPolicy"]["state"],
+    data["transcriptPolicy"]["persistence"],
+))
+print("[INFO]  response   : {}".format(data["messageEnvelope"]["responseState"]))
+print("")
+print("[CHAT]  system     : local chat is blocked until readiness and session evidence exist")
+print("[CHAT]  input      : ready for future explicit input; no content is captured here")
+print("[CHAT]  assistant  : unavailable")
+print("")
+print("[INFO]  controls")
+for control in controls:
+    enabled = "enabled" if control["enabled"] else "disabled"
+    print("[INFO]    {} : {} ({})".format(
+        control["controlId"],
+        control["state"],
+        enabled,
+    ))
+print("")
+print("[INFO]  blocked reasons")
+for reason in blocked:
+    print("[INFO]    {} -> {}".format(
+        reason["reasonId"],
+        reason["requiredBefore"],
+    ))
+print("")
+print("[INFO]  safety     : readOnly=true dataOnly=true runtimeExecution=false modelExecution=false kv260Access=false providerCalls=false")
+'

--- a/scripts/tests/chat_session_contract_test.py
+++ b/scripts/tests/chat_session_contract_test.py
@@ -21,6 +21,7 @@ FIXTURE_PATH = (
     / "chat-session.gemma3n-e4b-kv260-placeholder.json"
 )
 SCRIPT_PATH = ROOT / "scripts" / "chat-session-stub.sh"
+PREVIEW_SCRIPT_PATH = ROOT / "scripts" / "chat-surface-preview.sh"
 DOC_PATH = ROOT / "docs" / "STANDALONE_CHAT_SESSION_CONTRACT.md"
 README_PATH = ROOT / "README.md"
 TEST_PATH = Path(__file__).resolve()
@@ -301,6 +302,7 @@ def test_safety_flags_preserve_data_only_boundary() -> None:
 def test_docs_and_sources_avoid_private_data_runtime_calls_or_overclaims() -> None:
     module_source = read_text(MODULE_PATH)
     script_source = read_text(SCRIPT_PATH)
+    preview_script_source = read_text(PREVIEW_SCRIPT_PATH)
     status = load_module().create_gemma3n_e4b_kv260_chat_session()
     scan_text = "\n".join([
         read_text(FIXTURE_PATH),
@@ -309,10 +311,11 @@ def test_docs_and_sources_avoid_private_data_runtime_calls_or_overclaims() -> No
         flatten(status),
         module_source,
         script_source,
+        preview_script_source,
     ])
-    runtime_source = "\n".join([module_source, script_source])
+    runtime_source = "\n".join([module_source, script_source, preview_script_source])
 
-    assert_no_runtime_implementation_terms(module_source)
+    assert_no_runtime_implementation_terms(runtime_source)
     assert_no_private_or_generated_data(scan_text)
     assert_no_provider_configs(status)
     assert_no_unsupported_claims(scan_text)
@@ -327,6 +330,11 @@ def test_source_headers_for_touched_code_files() -> None:
             "# Copyright 2026 pccxai",
         ],
         SCRIPT_PATH: [
+            "#!/usr/bin/env bash",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        PREVIEW_SCRIPT_PATH: [
             "#!/usr/bin/env bash",
             "# SPDX-License-Identifier: Apache-2.0",
             "# Copyright 2026 pccxai",

--- a/scripts/tests/chat_surface_preview_test.py
+++ b/scripts/tests/chat_surface_preview_test.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Tests for the standalone chat surface preview."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = ROOT / "scripts" / "chat-surface-preview.sh"
+
+
+def run_preview(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(SCRIPT_PATH), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_preview_outputs_blocked_chat_surface() -> None:
+    result = run_preview("--model", "gemma3n-e4b", "--target", "kv260")
+    output = result.stdout
+
+    assert result.stderr == ""
+    assert "=== standalone chat surface preview ===" in output
+    assert "boundary   : read-only local preview; no prompt/model/provider/hardware/lab/IDE execution" in output
+    assert "target     : kv260" in output
+    assert "model      : gemma3n-e4b" in output
+    assert "surface    : blocked" in output
+    assert "chat       : inactive" in output
+    assert "input      : ready_for_inputs" in output
+    assert "send       : disabled" in output
+    assert "model load : not_loaded" in output
+    assert "[CHAT]  system     : local chat is blocked until readiness and session evidence exist" in output
+    assert "[CHAT]  input      : ready for future explicit input; no content is captured here" in output
+    assert "[CHAT]  assistant  : unavailable" in output
+    assert "new_session : placeholder (disabled)" in output
+    assert "model_status : not_loaded (disabled)" in output
+    assert "send_message : disabled (disabled)" in output
+    assert "clear_session : inactive (disabled)" in output
+    assert "export_summary : blocked (disabled)" in output
+    assert "runtime_readiness_blocked -> send_message_enabled" in output
+    assert "chat_runtime_not_implemented -> session_start_enabled" in output
+    assert "readOnly=true dataOnly=true runtimeExecution=false modelExecution=false kv260Access=false providerCalls=false" in output
+
+
+def test_preview_is_deterministic_and_does_not_echo_prompts() -> None:
+    first = run_preview()
+    second = run_preview()
+
+    assert first.stdout == second.stdout
+    assert "hello" not in first.stdout.lower()
+    assert "prompt   :" not in first.stdout
+
+
+def test_preview_avoids_runtime_and_readiness_overclaims() -> None:
+    output = run_preview().stdout.lower()
+
+    forbidden = [
+        "kv260 inference works",
+        "gemma 3n e4b runs on kv260",
+        "20 tok/s achieved",
+        "timing closed",
+        "bitstream ready",
+        "production-ready",
+        "marketplace-ready",
+        "stable api",
+        "stable abi",
+        "model executed",
+        "provider call made",
+    ]
+    for phrase in forbidden:
+        assert phrase not in output, phrase
+
+
+def test_unknown_model_is_rejected() -> None:
+    result = subprocess.run(
+        ["bash", str(SCRIPT_PATH), "--model", "unknown", "--target", "kv260"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert "chat/session stub failed" in result.stderr
+
+
+test_preview_outputs_blocked_chat_surface()
+test_preview_is_deterministic_and_does_not_echo_prompts()
+test_preview_avoids_runtime_and_readiness_overclaims()
+test_unknown_model_is_rejected()
+
+print("chat surface preview tests ok")


### PR DESCRIPTION
## Summary

- Add `scripts/chat-surface-preview.sh` to render the existing `pccx.chatSession.v0` contract as a read-only terminal chat surface preview.
- Document the preview command in the README and standalone chat/session contract note.
- Add focused preview tests and CI coverage for the new command.

Refs #9

## Safety

This is a local preview over checked data. It does not accept or echo prompts, execute a model, load weights, touch KV260 hardware, open serial or network paths, call providers, invoke pccx-lab or systemverilog-ide, write artifacts, or make readiness/performance claims.

## Validation

- `./scripts/chat-surface-preview.sh --model gemma3n-e4b --target kv260`
- `python3 scripts/tests/chat_surface_preview_test.py`
- `python3 scripts/tests/chat_session_contract_test.py`
- `python3 scripts/tests/launcher_ide_contract_test.py`
- `python3 scripts/tests/model_runtime_descriptor_test.py`
- `python3 scripts/tests/diagnostics_handoff_contract_test.py`
- `python3 scripts/tests/device_session_status_contract_test.py`
- `python3 scripts/tests/runtime_readiness_contract_test.py`
- `bash scripts/tests/status-chat-session.sh scripts/status-stub.sh`
- `bash scripts/tests/status-backend.sh scripts/status-stub.sh`
- `bash scripts/tests/status-device-session.sh scripts/status-stub.sh`
- `bash scripts/tests/status-readiness.sh scripts/status-stub.sh`
- `bash scripts/check.sh`
- `bash scripts/check-device-stub.sh`
- `bash scripts/install-stub.sh`
- `bash scripts/launch-stub.sh --dry-run`
- `bash scripts/status-stub.sh --include-chat-session --include-device-session --include-runtime-readiness`
- `find scripts -type f -name "*.sh" -not -name "*.snapshot" -print0 | xargs -0 bash -n`
- `python3 -m py_compile contracts/*.py scripts/tests/*.py`
- local claim-scan matching `.github/workflows/ci.yml`
- `git diff --cached --check`

Local `shellcheck` is not installed on this workstation; GitHub Actions installs and runs it.