### PR TITLE
Add other editor bridge plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ publishes a verified end-to-end path.
 
 - Coding-assistant mode (AI-assisted local workflow with a controlled
   tool boundary).
-- VS Code extension bridge for guided launches and log inspection.
+- VS Code and other editor bridge planning for guided launches and log
+  inspection.
 - Additional target models beyond Gemma 3N E4B.
 - Additional edge devices beyond KV260.
 - Integration with `pccx-lab` diagnostics so device / kernel state can be
@@ -159,6 +160,8 @@ It does not execute the launcher, call a provider, contact hardware,
 load a model, implement an editor bridge, or make a compatibility
 promise. See
 [docs/LAUNCHER_IDE_BRIDGE_CONTRACT.md](./docs/LAUNCHER_IDE_BRIDGE_CONTRACT.md).
+The later-track JetBrains and generic editor direction is tracked in
+[docs/OTHER_EDITOR_BRIDGE_PLAN.md](./docs/OTHER_EDITOR_BRIDGE_PLAN.md).
 
 ### Model / runtime descriptor boundary (planned)
 

--- a/docs/LAUNCHER_IDE_BRIDGE_CONTRACT.md
+++ b/docs/LAUNCHER_IDE_BRIDGE_CONTRACT.md
@@ -5,6 +5,9 @@ integrations. It is a data-only status boundary. It does not start the
 launcher, inspect a device, load a model, call a provider, or connect to
 an editor.
 
+The later-track plan for JetBrains and generic editor adapters is tracked in
+[`OTHER_EDITOR_BRIDGE_PLAN.md`](./OTHER_EDITOR_BRIDGE_PLAN.md).
+
 The contract lives in:
 
 - `contracts/launcher_ide_status_contract.py`
@@ -33,10 +36,10 @@ planned unless there is checked evidence for something stronger.
 
 ## Planned Consumers
 
-Future editor integrations may read this status before presenting
-launcher actions to a user. `pccx-systemverilog-ide` is one possible
-consumer, but this repository does not implement that integration in
-this PR.
+Future editor integrations may read this status before presenting launcher
+actions to a user. `pccx-systemverilog-ide`, JetBrains plugin work, and
+generic editor adapters are possible consumers, but this repository does not
+implement those integrations in this PR.
 
 The planned mapping is:
 
@@ -105,6 +108,8 @@ This PR also does not add:
 - LSP implementation
 - editor extension implementation
 - packaging or publisher flow
+- JetBrains plugin implementation
+- generic editor adapter implementation
 - model weights or generated blobs
 
 The purpose is to make future integration work easier to review by

--- a/docs/OTHER_EDITOR_BRIDGE_PLAN.md
+++ b/docs/OTHER_EDITOR_BRIDGE_PLAN.md
@@ -1,0 +1,99 @@
+# Other Editor Bridge Plan
+
+## Status
+
+This is a later-track launcher-side plan for editor integrations beyond the
+local VS Code-oriented path. It records how JetBrains and generic editor
+bridges should consume launcher data without creating a second launcher runtime
+or a single-editor dependency.
+
+This is not a JetBrains plugin, not a generic editor protocol implementation,
+not an LSP or MCP server, not a package distribution flow, and not a stable
+compatibility promise.
+
+## Goal
+
+The launcher should expose the same conservative status and handoff data to
+multiple editor families:
+
+- VS Code and the `systemverilog-ide` prototype
+- future JetBrains plugin work
+- future generic editor adapters or local scripts
+
+Editor-specific UI code should stay thin. It should translate launcher data
+into native editor presentation while leaving model/runtime state, device
+status, readiness, diagnostics handoff, and chat/session state in the launcher
+contracts.
+
+## Launcher-Owned Data
+
+Future editor bridges should consume these launcher-owned surfaces first:
+
+| Surface | Purpose |
+|---|---|
+| `pccx.launcherIdeStatus.v0` | top-level launcher/editor status and future operation list |
+| `pccx.runtimeReadiness.v0` | evidence-aware runtime readiness summary |
+| `pccx.deviceSessionStatus.v0` | device/session rows, flow steps, and error taxonomy |
+| `pccx.chatSession.v0` | blocked standalone chat/session state and disabled controls |
+| `pccx.diagnosticsHandoff.v0` | read-only diagnostics handoff references for pccx-lab |
+
+The shapes are still pre-compatibility and may change before a versioned
+interface is declared.
+
+## Editor Families
+
+### VS Code / SystemVerilog IDE
+
+The VS Code-facing path may consume launcher data through
+`systemverilog-ide` adapters. The launcher remains the owner of the data
+contracts; the editor presents summaries, disabled actions, and future
+handoff state.
+
+### JetBrains
+
+A future JetBrains bridge should map the same launcher data into tool windows,
+status bar entries, and explicit user actions. It should not invent a separate
+device manager, runtime launcher, diagnostics handoff, or chat/session state
+machine.
+
+### Generic Editors
+
+Generic editor adapters should prefer deterministic JSON from explicit local
+commands or checked local files. They should preserve launcher exit codes,
+surface unavailable or blocked states directly, and avoid silent fallback from
+an explicitly requested backend.
+
+## Safety Boundary
+
+Editor bridges must not:
+
+- execute launcher runtime code without a separately reviewed path
+- load model weights or include model weight paths
+- claim KV260 inference works or measured throughput exists
+- probe hardware, open serial ports, scan networks, or attempt authentication
+- invoke pccx-lab except through an explicitly reviewed CLI/core boundary
+- implement MCP, LSP, package publishing, marketplace distribution, telemetry,
+  upload, or write-back flows as part of this plan
+- store prompts, transcripts, private paths, secrets, or tokens
+
+Every write-capable action should be a future explicit user-approved flow with
+bounded inputs, clear failure states, and tests.
+
+## Acceptance Gates Before Implementation
+
+Before adding editor-specific code, the launcher should have:
+
+- a narrowed contract versioning policy for editor-facing JSON
+- checked fixtures for any new fields
+- tests that block private data, unsupported hardware/runtime claims, and
+  accidental provider or network calls
+- documentation for how unavailable, blocked, and evidence-required states map
+  into editor UI
+- a separate issue and PR for each editor family implementation
+
+## Issue Alignment
+
+This plan addresses
+[`pccx-llm-launcher#11`](https://github.com/pccxai/pccx-llm-launcher/issues/11)
+by recording JetBrains and generic editor direction while keeping the current
+launcher work data-only and pre-compatibility.


### PR DESCRIPTION
## Summary

- add a later-track launcher-side plan for JetBrains and generic editor bridges
- link the plan from the launcher README and launcher/IDE bridge contract
- keep editor bridge work on existing data contracts instead of adding editor implementation or runtime behavior

Closes #11.

## Scope / limits

- docs-only
- no JetBrains plugin, generic adapter, LSP/MCP server, package distribution, marketplace flow, or compatibility promise
- no launcher runtime execution, model loading, provider call, hardware access, pccx-lab execution, telemetry, upload, write-back, or hardware/runtime claim

## Validation

- `find scripts -type f -name "*.sh" -not -name "*.snapshot" -print0 | xargs -0 bash -n`
- `python3 -m py_compile contracts/*.py scripts/tests/*.py`
- launcher contract tests: launcher/IDE, model/runtime descriptor, diagnostics handoff, device/session, runtime readiness, chat/session, chat surface preview
- status backend/device/readiness/chat shell tests
- local claim-scan matching CI
- `./scripts/check.sh`
- `./scripts/status-stub.sh`
- `./scripts/launch-stub.sh --dry-run`
- `git diff --check`
- `git diff --cached --check`

Local note: `shellcheck` is not installed in this environment; CI installs and runs it.