### PR TITLE
Add multi-model and device support plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,9 @@ publishes a verified end-to-end path.
   [docs/LOCAL_CODING_ASSISTANT_MODE_PLAN.md](./docs/LOCAL_CODING_ASSISTANT_MODE_PLAN.md).
 - VS Code and other editor bridge planning for guided launches and log
   inspection.
-- Additional target models beyond Gemma 3N E4B.
-- Additional edge devices beyond KV260.
+- Additional target models beyond Gemma 3N E4B and additional edge devices
+  beyond KV260. The later-track plan is tracked in
+  [docs/MULTI_MODEL_DEVICE_SUPPORT_PLAN.md](./docs/MULTI_MODEL_DEVICE_SUPPORT_PLAN.md).
 - Integration with `pccx-lab` diagnostics so device / kernel state can be
   surfaced through the launcher UI.
 
@@ -184,6 +185,8 @@ This boundary does not load weights, execute a runtime, call a provider,
 touch KV260 hardware, report performance, implement MCP/LSP, or make an
 API/ABI compatibility commitment. See
 [docs/MODEL_RUNTIME_DESCRIPTOR_BOUNDARY.md](./docs/MODEL_RUNTIME_DESCRIPTOR_BOUNDARY.md).
+The later-track multi-model and multi-device direction is tracked in
+[docs/MULTI_MODEL_DEVICE_SUPPORT_PLAN.md](./docs/MULTI_MODEL_DEVICE_SUPPORT_PLAN.md).
 
 ### Diagnostics handoff boundary (planned)
 

--- a/docs/LAUNCHER_IDE_BRIDGE_CONTRACT.md
+++ b/docs/LAUNCHER_IDE_BRIDGE_CONTRACT.md
@@ -9,6 +9,8 @@ The later-track plan for JetBrains and generic editor adapters is tracked in
 [`OTHER_EDITOR_BRIDGE_PLAN.md`](./OTHER_EDITOR_BRIDGE_PLAN.md).
 The later-track plan for local coding-assistant mode is tracked in
 [`LOCAL_CODING_ASSISTANT_MODE_PLAN.md`](./LOCAL_CODING_ASSISTANT_MODE_PLAN.md).
+The later-track plan for multi-model and multi-device support is tracked in
+[`MULTI_MODEL_DEVICE_SUPPORT_PLAN.md`](./MULTI_MODEL_DEVICE_SUPPORT_PLAN.md).
 
 The contract lives in:
 
@@ -53,6 +55,10 @@ The planned mapping is:
 | `pccxlab.diagnostics.handoff` | Prepare read-only diagnostics handoff for pccx-lab. |
 | `editor.bridge.consumer` | Prepare editor bridge status. |
 | `local.coding.assistant.consumer` | Prepare local coding-assistant status, disabled by default. |
+
+Future multi-model and multi-device views should consume descriptor and
+readiness data through these boundaries first. This contract does not add a
+model catalog, device manager, runtime adapter, or compatibility guarantee.
 
 These names are a draft bridge sketch, not a compatibility guarantee.
 The shape may change before a versioned interface is declared.
@@ -113,6 +119,7 @@ This PR also does not add:
 - JetBrains plugin implementation
 - generic editor adapter implementation
 - local coding-assistant runtime implementation
+- multi-model selector or device manager implementation
 - model weights or generated blobs
 
 The purpose is to make future integration work easier to review by

--- a/docs/MODEL_RUNTIME_DESCRIPTOR_BOUNDARY.md
+++ b/docs/MODEL_RUNTIME_DESCRIPTOR_BOUNDARY.md
@@ -80,6 +80,12 @@ The model descriptor also names `cpu_reference_placeholder` as an
 expected future runtime kind. That is vocabulary only; this PR does not
 add a CPU runtime descriptor or execution path.
 
+Future multi-model and multi-device support should build catalog-level entries
+over this descriptor vocabulary. The launcher-side plan is tracked in
+[`MULTI_MODEL_DEVICE_SUPPORT_PLAN.md`](./MULTI_MODEL_DEVICE_SUPPORT_PLAN.md).
+That plan does not add a model loader, device manager, hardware probe, runtime
+adapter, or compatibility promise.
+
 ## Lifecycle Vocabulary
 
 The descriptor names the future lifecycle states:

--- a/docs/MULTI_MODEL_DEVICE_SUPPORT_PLAN.md
+++ b/docs/MULTI_MODEL_DEVICE_SUPPORT_PLAN.md
@@ -1,0 +1,130 @@
+# Multi-Model And Device Support Plan
+
+## Status
+
+This is a later-track launcher-side plan for supporting multiple model
+descriptors and multiple target-device descriptors. It records the catalog,
+selection, and readiness boundaries needed before the launcher can expose a
+model picker or device manager.
+
+This plan does not implement a model selector UI, device manager, runtime
+adapter, model loader, hardware probe, provider call, compatibility promise, or
+KV260 inference path.
+
+## Goal
+
+The launcher should eventually let users choose from evidence-backed model and
+device targets without turning the launcher into the owner of lower-level
+runtime, hardware, or verification logic.
+
+The launcher-owned role is to coordinate:
+
+- model descriptor catalog entries
+- runtime descriptor catalog entries
+- target-device descriptor catalog entries
+- selection state and disabled UI reasons
+- readiness and evidence summaries from existing contracts
+- explicit handoff references to pccx-lab or lower runtime evidence
+
+Descriptor data should stay conservative until checked evidence supports a
+stronger state.
+
+## Planned Catalog Shape
+
+The existing `pccx.modelDescriptor.v0`,
+`pccx.runtimeDescriptor.v0`, and
+`pccx.modelRuntimeCompatibility.v0` surfaces are the starting vocabulary.
+Future multi-target work should extend that vocabulary with catalog-level
+records rather than adding executable behavior directly to the status surface.
+
+| Catalog | Purpose |
+|---|---|
+| Model catalog | Names target models, asset policies, quantization states, and evidence state. |
+| Runtime catalog | Names runtime adapter families, lifecycle states, artifact requirements, and evidence requirements. |
+| Device catalog | Names target-device classes, connection status, hardware access policy, and readiness blockers. |
+| Compatibility matrix | Records descriptor-only compatibility results and the evidence still required before enablement. |
+
+Gemma 3N E4B and KV260 remain target descriptors, not current working runtime
+claims. Other model families and device targets should be added only as
+descriptor entries until their evidence gates are satisfied.
+
+## Model Selection Flow
+
+A future model selection UI should:
+
+1. Read model catalog data.
+2. Show target model identity, asset policy, and evidence state.
+3. Filter compatible runtime and device descriptors using descriptor data only.
+4. Keep launch, chat, and coding-assistant controls disabled when readiness or
+   evidence is blocked.
+5. Explain missing evidence without silently falling back to a different model
+   or provider.
+
+The model selector should not read model directories, load weights, infer
+available assets from private paths, contact providers, or execute runtime
+commands as part of selection.
+
+## Device Manager Flow
+
+A future device manager should:
+
+1. Read device/session status data and target-device descriptors.
+2. Show configured, unavailable, blocked, and evidence-required states.
+3. Keep discovery and connection actions behind separately reviewed commands.
+4. Preserve explicit user choice when more than one target is visible.
+5. Keep runtime start controls blocked until readiness evidence allows them.
+
+The device manager should not scan networks, open serial ports, attempt SSH,
+probe KV260 hardware, invoke pccx-lab, or start a runtime as part of this plan.
+
+## Evidence Gates
+
+Before a model/device pair can move beyond placeholder state, the launcher
+should have checked evidence for:
+
+- model asset policy and user-provided asset handling
+- runtime adapter availability and reviewed lifecycle behavior
+- target-device configuration and connection policy
+- hardware and runtime readiness from lower layers
+- compatibility between selected model, runtime, and device descriptors
+- measured performance only after a separate evidence-backed run exists
+
+If any gate is missing, the selected pair should remain unavailable, blocked, or
+provisional in user-facing surfaces.
+
+## Safety Boundary
+
+Multi-model and multi-device support must not add:
+
+- bundled model weights or generated weight artifacts
+- model loading, runtime execution, or provider/network calls
+- KV260 runtime access, serial access, SSH, board probing, or inference claims
+- automatic pccx-lab execution outside an explicitly reviewed CLI/core boundary
+- prompt, response, transcript, private path, secret, token, or model-weight
+  path storage
+- telemetry, upload, write-back, commits, pushes, releases, or tag behavior
+- API/ABI stability, marketplace readiness, or compatibility guarantees
+
+Every future executable action should have a separate issue, bounded inputs,
+clear disabled states, user approval where needed, and tests that block private
+data and unsupported claims.
+
+## Acceptance Gates Before Implementation
+
+Before adding executable model or device behavior, the launcher should have:
+
+- a catalog fixture shape for model, runtime, and target-device descriptors
+- tests for descriptor-only compatibility and missing-evidence states
+- UI mapping for unavailable, blocked, provisional, and evidence-required
+  states
+- a device discovery policy that states which commands may run and when
+- a model asset policy that keeps paths and weights out of checked fixtures
+- separate implementation issues for model selection UI, device management,
+  runtime adapter integration, and any hardware-touching command
+
+## Issue Alignment
+
+This plan addresses
+[`pccx-llm-launcher#13`](https://github.com/pccxai/pccx-llm-launcher/issues/13)
+by recording the multi-model and multi-device support direction while keeping
+the current launcher work descriptor-only and evidence-gated.


### PR DESCRIPTION
## Summary

- add a later-track multi-model and multi-device support plan
- link the plan from the README, launcher/IDE bridge contract, and model/runtime descriptor boundary
- keep the current work descriptor-only and evidence-gated

Closes #13.

## Validation

- `find scripts -type f -name '*.sh' -not -name '*.snapshot' -print0 | xargs -0 bash -n`
- `python3 -m py_compile contracts/*.py scripts/tests/*.py`
- `python3 scripts/tests/launcher_ide_contract_test.py`
- `python3 scripts/tests/model_runtime_descriptor_test.py`
- `python3 scripts/tests/diagnostics_handoff_contract_test.py`
- `python3 scripts/tests/device_session_status_contract_test.py`
- `python3 scripts/tests/runtime_readiness_contract_test.py`
- `python3 scripts/tests/chat_session_contract_test.py`
- `python3 scripts/tests/chat_surface_preview_test.py`
- `bash scripts/tests/status-backend.sh scripts/status-stub.sh`
- `bash scripts/tests/status-device-session.sh scripts/status-stub.sh`
- `bash scripts/tests/status-readiness.sh scripts/status-stub.sh`
- `bash scripts/tests/status-chat-session.sh scripts/status-stub.sh`
- `./scripts/check.sh`
- `./scripts/status-stub.sh`
- `./scripts/launch-stub.sh --dry-run`
- local claim scan matching CI
- `git diff --check`
- `git diff --cached --check`

## Scope Boundary

Docs only. This does not add a model selector UI, device manager, model loading, runtime execution, provider call, hardware probe, pccx-lab execution, telemetry, upload, write-back, compatibility promise, or hardware/runtime claim.
