### PR TITLE
Add chat model status boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,7 @@ jobs:
                    scripts/status-stub.sh \
                    scripts/device-session-status-stub.sh \
                    scripts/runtime-readiness-stub.sh \
+                   scripts/chat-model-status-stub.sh \
                    scripts/chat-session-stub.sh \
                    scripts/chat-session-lifecycle-stub.sh \
                    scripts/chat-surface-preview.sh \
@@ -154,6 +155,10 @@ jobs:
         run: ./scripts/status-stub.sh --include-runtime-readiness
       - name: run scripts/runtime-readiness-stub.sh
         run: ./scripts/runtime-readiness-stub.sh --model gemma3n-e4b --target kv260
+      - name: run scripts/status-stub.sh with chat model status
+        run: ./scripts/status-stub.sh --include-chat-model-status
+      - name: run scripts/chat-model-status-stub.sh
+        run: ./scripts/chat-model-status-stub.sh --model gemma3n-e4b --target kv260
       - name: run scripts/chat-session-stub.sh
         run: ./scripts/chat-session-stub.sh --model gemma3n-e4b --target kv260
       - name: run scripts/chat-session-lifecycle-stub.sh
@@ -182,6 +187,8 @@ jobs:
         run: python3 scripts/tests/runtime_readiness_contract_test.py
       - name: run chat/session contract tests
         run: python3 scripts/tests/chat_session_contract_test.py
+      - name: run chat model status contract tests
+        run: python3 scripts/tests/chat_model_status_contract_test.py
       - name: run chat/session lifecycle contract tests
         run: python3 scripts/tests/chat_session_lifecycle_contract_test.py
       - name: run chat surface preview tests
@@ -196,12 +203,14 @@ jobs:
         run: |
           chmod +x scripts/status-stub.sh
           chmod +x scripts/chat-stub.sh
+          chmod +x scripts/chat-model-status-stub.sh
           chmod +x scripts/chat-session-stub.sh
           chmod +x scripts/chat-session-lifecycle-stub.sh
           chmod +x scripts/launch-stub.sh
           chmod +x scripts/tests/status-backend.sh
           chmod +x scripts/tests/status-device-session.sh
           chmod +x scripts/tests/status-readiness.sh
+          chmod +x scripts/tests/status-chat-model-status.sh
           chmod +x scripts/tests/status-chat-session.sh
       - name: shellcheck status-stub and test script
         run: |
@@ -210,6 +219,7 @@ jobs:
           shellcheck scripts/tests/status-backend.sh
           shellcheck scripts/tests/status-device-session.sh
           shellcheck scripts/tests/status-readiness.sh
+          shellcheck scripts/tests/status-chat-model-status.sh
           shellcheck scripts/tests/status-chat-session.sh
       - name: run status-backend tests
         run: bash scripts/tests/status-backend.sh scripts/status-stub.sh
@@ -217,5 +227,7 @@ jobs:
         run: bash scripts/tests/status-device-session.sh scripts/status-stub.sh
       - name: run status-readiness tests
         run: bash scripts/tests/status-readiness.sh scripts/status-stub.sh
+      - name: run status-chat-model-status tests
+        run: bash scripts/tests/status-chat-model-status.sh scripts/status-stub.sh
       - name: run status-chat-session tests
         run: bash scripts/tests/status-chat-session.sh scripts/status-stub.sh

--- a/README.md
+++ b/README.md
@@ -87,11 +87,12 @@ and verify host-side prerequisites before the real engine lands.
 | [`scripts/check.sh`](./scripts/check.sh) | Probe host info, tooling availability, edge-device hints. Always exits 0. |
 | [`scripts/check-device-stub.sh`](./scripts/check-device-stub.sh) | Narrowly scoped device-tree / FPGA-node probe (KV260 / Kria detection only). Always exits 0. |
 | [`scripts/install-stub.sh`](./scripts/install-stub.sh) | Preview of the planned install flow; reports which host runtime pieces are present, lists device-side pieces as future deliverables. Always exits 0. |
-| [`scripts/status-stub.sh`](./scripts/status-stub.sh) | Launcher state summary. Default mode: local scaffold output, always exits 0. With `--include-chat-session`, adds read-only blocked chat/session and lifecycle summaries. With `--include-device-session`, adds a read-only device/session status panel. With `--include-runtime-readiness`, adds a read-only runtime readiness summary. With `--backend pccx-lab`, calls `pccx-lab status --format json` and forwards the run-status envelope (exits non-zero if binary is missing or output is invalid). |
+| [`scripts/status-stub.sh`](./scripts/status-stub.sh) | Launcher state summary. Default mode: local scaffold output, always exits 0. With `--include-chat-model-status`, adds read-only blocked chat model-status display data. With `--include-chat-session`, adds read-only blocked chat/session and lifecycle summaries. With `--include-device-session`, adds a read-only device/session status panel. With `--include-runtime-readiness`, adds a read-only runtime readiness summary. With `--backend pccx-lab`, calls `pccx-lab status --format json` and forwards the run-status envelope (exits non-zero if binary is missing or output is invalid). |
 | [`scripts/device-session-status-stub.sh`](./scripts/device-session-status-stub.sh) | Data-only device/session status JSON for the Gemma 3N E4B + KV260 target. Reports connection, model load, session, diagnostics, readiness, discovery paths, flow steps, and error taxonomy as placeholder / blocked. |
 | [`scripts/runtime-readiness-stub.sh`](./scripts/runtime-readiness-stub.sh) | Data-only runtime readiness JSON for the Gemma 3N E4B + KV260 target. Reports blocked / not yet evidence-backed. |
 | [`scripts/chat-session-stub.sh`](./scripts/chat-session-stub.sh) | Data-only standalone chat/session JSON for the Gemma 3N E4B + KV260 target. Reports disabled send controls, inactive session state, no prompt/response persistence, and readiness handoff references. |
 | [`scripts/chat-session-lifecycle-stub.sh`](./scripts/chat-session-lifecycle-stub.sh) | Data-only chat session lifecycle JSON for the Gemma 3N E4B + KV260 target. Reports create, restore, clear, close, and export-summary operations as disabled, blocked, inactive, or unavailable. |
+| [`scripts/chat-model-status-stub.sh`](./scripts/chat-model-status-stub.sh) | Data-only chat model-status JSON for the Gemma 3N E4B + KV260 target. Reports descriptor, asset, load, runtime, context, and response display rows as blocked, disabled, or unavailable. |
 | [`scripts/chat-surface-preview.sh`](./scripts/chat-surface-preview.sh) | Read-only terminal preview of the standalone chat surface. Renders the checked chat/session contract as blocked UI state without accepting prompts, executing a model, or writing artifacts. |
 | [`scripts/launch-stub.sh`](./scripts/launch-stub.sh) | Dry-run preview of the intended launch sequence. Requires `--dry-run`; exits 1 without it. |
 | [`scripts/chat-stub.sh`](./scripts/chat-stub.sh) | Dry-run chat stub. Requires `--dry-run`; exits 1 without it. Accepts `--prompt "..."` or stdin. No model is executed. |
@@ -101,11 +102,13 @@ bash scripts/check.sh
 bash scripts/check-device-stub.sh
 bash scripts/install-stub.sh
 bash scripts/status-stub.sh
+bash scripts/status-stub.sh --include-chat-model-status
 bash scripts/status-stub.sh --include-chat-session
 bash scripts/status-stub.sh --include-device-session
 bash scripts/status-stub.sh --include-runtime-readiness
 bash scripts/device-session-status-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/runtime-readiness-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/chat-model-status-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-session-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-session-lifecycle-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-surface-preview.sh --model gemma3n-e4b --target kv260
@@ -273,22 +276,30 @@ the planned local chat entry point:
 
 ```bash
 python3 contracts/chat_session_contract.py --model gemma3n-e4b --target kv260
+python3 contracts/chat_model_status_contract.py --model gemma3n-e4b --target kv260
+bash scripts/chat-model-status-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-session-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-session-lifecycle-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-surface-preview.sh --model gemma3n-e4b --target kv260
+bash scripts/status-stub.sh --include-chat-model-status
 bash scripts/status-stub.sh --include-chat-session
 python3 scripts/tests/chat_session_contract_test.py
+python3 scripts/tests/chat_model_status_contract_test.py
 python3 scripts/tests/chat_session_lifecycle_contract_test.py
 python3 scripts/tests/chat_surface_preview_test.py
+bash scripts/tests/status-chat-model-status.sh
 bash scripts/tests/status-chat-session.sh
 ```
 
-The checked fixture reports the chat surface as blocked, the model as
-not loaded, the session as inactive, and send controls as disabled. It
-defines a message envelope vocabulary without storing prompts,
-responses, transcripts, model paths, generated artifacts, private paths,
-secrets, or tokens. It references the runtime readiness and
-device/session status fixtures as local data only.
+The checked chat/session fixture reports the chat surface as blocked,
+the session as inactive, and send controls as disabled. The checked chat
+model-status fixture adds descriptor, asset, load, runtime, context, and
+response display rows for the planned model-status panel. Model loading
+stays disabled and blocked. These fixtures define display and message
+envelope shapes without storing prompts, responses, transcripts, model
+paths, generated artifacts, private paths, secrets, or tokens. They
+reference the model/runtime descriptor, runtime readiness,
+device/session status, and chat/session fixtures as local data only.
 
 The lifecycle fixture defines the session-management boundary for create,
 restore, clear, close, and export-summary operations. All operations stay

--- a/contracts/chat_model_status_contract.py
+++ b/contracts/chat_model_status_contract.py
@@ -1,0 +1,375 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Data-only chat model status contract for the planned launcher UI.
+
+The contract describes the model-status display and blocked model-load state
+for the local chat surface without loading weights, starting runtime code,
+touching KV260 hardware, calling providers, invoking pccx-lab, or writing
+artifacts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import sys
+
+
+SCHEMA_VERSION = "pccx.chatModelStatus.v0"
+
+CHAT_MODEL_STATUS_FIELDS = (
+    "schemaVersion",
+    "statusId",
+    "fixtureVersion",
+    "lastUpdatedSource",
+    "targetDevice",
+    "targetBoard",
+    "targetModel",
+    "displayState",
+    "modelSelectionState",
+    "descriptorState",
+    "assetState",
+    "loadState",
+    "runtimeState",
+    "contextState",
+    "responseState",
+    "providerState",
+    "statusRows",
+    "loadActions",
+    "blockedReasons",
+    "handoffRefs",
+    "safetyFlags",
+    "limitations",
+    "issueRefs",
+)
+
+STATUS_ROW_FIELDS = (
+    "rowId",
+    "label",
+    "state",
+    "severity",
+    "summary",
+    "displayPolicy",
+)
+
+LOAD_ACTION_FIELDS = (
+    "actionId",
+    "label",
+    "state",
+    "enabled",
+    "userAction",
+    "launcherAction",
+    "requiredEvidence",
+    "sideEffectPolicy",
+)
+
+BLOCKED_REASON_FIELDS = (
+    "reasonId",
+    "state",
+    "summary",
+    "requiredBefore",
+)
+
+HANDOFF_REF_FIELDS = (
+    "refId",
+    "schemaVersion",
+    "fixturePath",
+    "state",
+    "summary",
+)
+
+CHAT_MODEL_STATUS_STATE_VALUES = (
+    "available_as_data",
+    "blocked",
+    "disabled",
+    "external_not_configured",
+    "inactive",
+    "not_loaded",
+    "not_started",
+    "not_used",
+    "placeholder",
+    "planned",
+    "target_selected",
+    "unavailable",
+)
+
+_CHAT_MODEL_STATUS = {
+    "schemaVersion": SCHEMA_VERSION,
+    "statusId": "chat_model_status_gemma3n_e4b_kv260_placeholder",
+    "fixtureVersion": "chat-model-status.gemma3n-e4b-kv260.2026-05-04",
+    "lastUpdatedSource": "pccx_launcher_issue_9_model_status_boundary_2026-05-04",
+    "targetDevice": "kv260",
+    "targetBoard": "xilinx_kria_kv260",
+    "targetModel": "gemma3n-e4b",
+    "displayState": "blocked",
+    "modelSelectionState": "target_selected",
+    "descriptorState": "available_as_data",
+    "assetState": "external_not_configured",
+    "loadState": "blocked",
+    "runtimeState": "not_started",
+    "contextState": "unavailable",
+    "responseState": "unavailable",
+    "providerState": "not_used",
+    "statusRows": [
+        {
+            "rowId": "model_descriptor",
+            "label": "model descriptor",
+            "state": "available_as_data",
+            "severity": "info",
+            "summary": "Gemma 3N E4B is represented by the checked descriptor fixture only.",
+            "displayPolicy": "show descriptor id and target label without model paths",
+        },
+        {
+            "rowId": "model_assets",
+            "label": "model assets",
+            "state": "external_not_configured",
+            "severity": "blocked",
+            "summary": "Model assets are user-provided future inputs and are not configured here.",
+            "displayPolicy": "show blocked state without local paths or filenames",
+        },
+        {
+            "rowId": "runtime_readiness",
+            "label": "runtime readiness",
+            "state": "blocked",
+            "severity": "blocked",
+            "summary": "Runtime readiness remains blocked and not yet evidence-backed.",
+            "displayPolicy": "show conservative readiness summary only",
+        },
+        {
+            "rowId": "device_session",
+            "label": "device session",
+            "state": "inactive",
+            "severity": "blocked",
+            "summary": "No KV260 target session exists in this fixture.",
+            "displayPolicy": "show inactive target state without probing hardware",
+        },
+        {
+            "rowId": "load_operation",
+            "label": "load operation",
+            "state": "disabled",
+            "severity": "blocked",
+            "summary": "Model load controls stay disabled until readiness evidence exists.",
+            "displayPolicy": "show disabled action state only",
+        },
+        {
+            "rowId": "chat_context",
+            "label": "chat context",
+            "state": "unavailable",
+            "severity": "blocked",
+            "summary": "No runtime context window or token state exists.",
+            "displayPolicy": "show unavailable context state without token data",
+        },
+        {
+            "rowId": "assistant_response",
+            "label": "assistant response",
+            "state": "unavailable",
+            "severity": "blocked",
+            "summary": "No response can be generated because no model runtime is active.",
+            "displayPolicy": "show response unavailable state only",
+        },
+    ],
+    "loadActions": [
+        {
+            "actionId": "select_model_target",
+            "label": "select model target",
+            "state": "target_selected",
+            "enabled": False,
+            "userAction": "Review the target model descriptor in the future chat UI.",
+            "launcherAction": "Render target metadata from checked fixtures only.",
+            "requiredEvidence": [
+                "descriptor_fixture_available",
+            ],
+            "sideEffectPolicy": "local_render_only",
+        },
+        {
+            "actionId": "configure_model_assets",
+            "label": "configure model assets",
+            "state": "blocked",
+            "enabled": False,
+            "userAction": "Provide model assets only after a reviewed local input boundary exists.",
+            "launcherAction": "Do not read or echo local asset paths.",
+            "requiredEvidence": [
+                "local_model_asset_input_boundary_reviewed",
+                "redaction_policy_reviewed",
+            ],
+            "sideEffectPolicy": "no_artifact_read_no_write",
+        },
+        {
+            "actionId": "load_model",
+            "label": "load model",
+            "state": "disabled",
+            "enabled": False,
+            "userAction": "Load only after runtime readiness and model asset checks are evidence-backed.",
+            "launcherAction": "Refuse model load while runtime readiness is blocked.",
+            "requiredEvidence": [
+                "runtime_readiness_available",
+                "model_assets_configured",
+                "kv260_session_available",
+            ],
+            "sideEffectPolicy": "no_runtime_execution",
+        },
+        {
+            "actionId": "refresh_status",
+            "label": "refresh status",
+            "state": "available_as_data",
+            "enabled": False,
+            "userAction": "Refresh the model status display from checked local fixtures.",
+            "launcherAction": "Render deterministic fixture data only.",
+            "requiredEvidence": [
+                "checked_fixture_data_available",
+            ],
+            "sideEffectPolicy": "read_only_data",
+        },
+    ],
+    "blockedReasons": [
+        {
+            "reasonId": "runtime_readiness_blocked",
+            "state": "blocked",
+            "summary": "Runtime readiness remains blocked for the Gemma 3N E4B plus KV260 target.",
+            "requiredBefore": "load_model_enabled",
+        },
+        {
+            "reasonId": "model_assets_external",
+            "state": "external_not_configured",
+            "summary": "Model assets are external and no reviewed local asset input boundary exists.",
+            "requiredBefore": "configure_model_assets_enabled",
+        },
+        {
+            "reasonId": "kv260_session_inactive",
+            "state": "inactive",
+            "summary": "No target device session exists and no board runtime status is measured.",
+            "requiredBefore": "load_model_enabled",
+        },
+        {
+            "reasonId": "chat_runtime_not_started",
+            "state": "not_started",
+            "summary": "The local chat runtime is not implemented or started.",
+            "requiredBefore": "assistant_response_available",
+        },
+    ],
+    "handoffRefs": [
+        {
+            "refId": "model_runtime_descriptor",
+            "schemaVersion": "pccx.modelRuntimeDescriptorBundle.v0",
+            "fixturePath": "contracts/fixtures/model-runtime-descriptor.gemma3n-e4b-kv260-placeholder.json",
+            "state": "available_as_data",
+            "summary": "Model/runtime descriptor data is consumed by reference only.",
+        },
+        {
+            "refId": "runtime_readiness",
+            "schemaVersion": "pccx.runtimeReadiness.v0",
+            "fixturePath": "contracts/fixtures/runtime-readiness.gemma3n-e4b-kv260.json",
+            "state": "blocked",
+            "summary": "Runtime readiness is consumed as local data only.",
+        },
+        {
+            "refId": "device_session_status",
+            "schemaVersion": "pccx.deviceSessionStatus.v0",
+            "fixturePath": "contracts/fixtures/device-session-status.gemma3n-e4b-kv260.json",
+            "state": "available_as_data",
+            "summary": "Device/session status is consumed as local data only.",
+        },
+        {
+            "refId": "chat_session",
+            "schemaVersion": "pccx.chatSession.v0",
+            "fixturePath": "contracts/fixtures/chat-session.gemma3n-e4b-kv260-placeholder.json",
+            "state": "available_as_data",
+            "summary": "Base chat/session state is consumed as local data only.",
+        },
+    ],
+    "safetyFlags": {
+        "dataOnly": True,
+        "readOnly": True,
+        "deterministic": True,
+        "statusDisplayOnly": True,
+        "writesArtifacts": False,
+        "readsArtifacts": False,
+        "modelAssetPathsIncluded": False,
+        "modelWeightPathsIncluded": False,
+        "modelLoadAttempted": False,
+        "modelLoaded": False,
+        "modelExecution": False,
+        "runtimeExecution": False,
+        "responseGenerated": False,
+        "promptContentIncluded": False,
+        "responseContentIncluded": False,
+        "transcriptPersistence": False,
+        "touchesHardware": False,
+        "kv260Access": False,
+        "opensSerialPort": False,
+        "networkCalls": False,
+        "networkScan": False,
+        "providerCalls": False,
+        "cloudCalls": False,
+        "privatePathsIncluded": False,
+        "secretsIncluded": False,
+        "tokensIncluded": False,
+        "generatedBlobsIncluded": False,
+        "hardwareDumpsIncluded": False,
+        "telemetry": False,
+        "automaticUpload": False,
+        "writeBack": False,
+        "executesPccxLab": False,
+        "executesSystemverilogIde": False,
+        "mcpServerImplemented": False,
+        "lspImplemented": False,
+        "stableApiAbiClaim": False,
+    },
+    "limitations": [
+        "Data-only chat model status fixture; no model load is attempted.",
+        "No prompts, responses, transcripts, model paths, generated artifacts, private paths, secrets, or tokens are stored.",
+        "No KV260 hardware access, serial access, network call, provider call, telemetry, upload, or write-back is performed.",
+        "Model load controls remain disabled until runtime readiness, model asset, and device/session evidence are available.",
+        "This is not a release, tag, versioned compatibility commitment, MCP, LSP, IDE, marketplace, or telemetry implementation.",
+    ],
+    "issueRefs": [
+        "pccxai/pccx-llm-launcher#9",
+    ],
+}
+
+
+def create_gemma3n_e4b_kv260_chat_model_status() -> dict:
+    """Return the checked Gemma 3N E4B plus KV260 chat model status fixture."""
+    return copy.deepcopy(_CHAT_MODEL_STATUS)
+
+
+def chat_model_status_json(status: dict | None = None) -> str:
+    """Render a deterministic JSON representation."""
+    return json.dumps(
+        status
+        if status is not None
+        else create_gemma3n_e4b_kv260_chat_model_status(),
+        indent=2,
+        sort_keys=True,
+    ) + "\n"
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Print data-only chat model status JSON.",
+    )
+    parser.add_argument(
+        "--model",
+        default="gemma3n-e4b",
+        choices=("gemma3n-e4b",),
+        help="model descriptor target",
+    )
+    parser.add_argument(
+        "--target",
+        default="kv260",
+        choices=("kv260",),
+        help="target board/device",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parse_args(sys.argv[1:] if argv is None else argv)
+    sys.stdout.write(chat_model_status_json())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contracts/fixtures/chat-model-status.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-model-status.gemma3n-e4b-kv260-placeholder.json
@@ -1,0 +1,233 @@
+{
+  "assetState": "external_not_configured",
+  "blockedReasons": [
+    {
+      "reasonId": "runtime_readiness_blocked",
+      "requiredBefore": "load_model_enabled",
+      "state": "blocked",
+      "summary": "Runtime readiness remains blocked for the Gemma 3N E4B plus KV260 target."
+    },
+    {
+      "reasonId": "model_assets_external",
+      "requiredBefore": "configure_model_assets_enabled",
+      "state": "external_not_configured",
+      "summary": "Model assets are external and no reviewed local asset input boundary exists."
+    },
+    {
+      "reasonId": "kv260_session_inactive",
+      "requiredBefore": "load_model_enabled",
+      "state": "inactive",
+      "summary": "No target device session exists and no board runtime status is measured."
+    },
+    {
+      "reasonId": "chat_runtime_not_started",
+      "requiredBefore": "assistant_response_available",
+      "state": "not_started",
+      "summary": "The local chat runtime is not implemented or started."
+    }
+  ],
+  "contextState": "unavailable",
+  "descriptorState": "available_as_data",
+  "displayState": "blocked",
+  "fixtureVersion": "chat-model-status.gemma3n-e4b-kv260.2026-05-04",
+  "handoffRefs": [
+    {
+      "fixturePath": "contracts/fixtures/model-runtime-descriptor.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "model_runtime_descriptor",
+      "schemaVersion": "pccx.modelRuntimeDescriptorBundle.v0",
+      "state": "available_as_data",
+      "summary": "Model/runtime descriptor data is consumed by reference only."
+    },
+    {
+      "fixturePath": "contracts/fixtures/runtime-readiness.gemma3n-e4b-kv260.json",
+      "refId": "runtime_readiness",
+      "schemaVersion": "pccx.runtimeReadiness.v0",
+      "state": "blocked",
+      "summary": "Runtime readiness is consumed as local data only."
+    },
+    {
+      "fixturePath": "contracts/fixtures/device-session-status.gemma3n-e4b-kv260.json",
+      "refId": "device_session_status",
+      "schemaVersion": "pccx.deviceSessionStatus.v0",
+      "state": "available_as_data",
+      "summary": "Device/session status is consumed as local data only."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-session.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_session",
+      "schemaVersion": "pccx.chatSession.v0",
+      "state": "available_as_data",
+      "summary": "Base chat/session state is consumed as local data only."
+    }
+  ],
+  "issueRefs": [
+    "pccxai/pccx-llm-launcher#9"
+  ],
+  "lastUpdatedSource": "pccx_launcher_issue_9_model_status_boundary_2026-05-04",
+  "limitations": [
+    "Data-only chat model status fixture; no model load is attempted.",
+    "No prompts, responses, transcripts, model paths, generated artifacts, private paths, secrets, or tokens are stored.",
+    "No KV260 hardware access, serial access, network call, provider call, telemetry, upload, or write-back is performed.",
+    "Model load controls remain disabled until runtime readiness, model asset, and device/session evidence are available.",
+    "This is not a release, tag, versioned compatibility commitment, MCP, LSP, IDE, marketplace, or telemetry implementation."
+  ],
+  "loadActions": [
+    {
+      "actionId": "select_model_target",
+      "enabled": false,
+      "label": "select model target",
+      "launcherAction": "Render target metadata from checked fixtures only.",
+      "requiredEvidence": [
+        "descriptor_fixture_available"
+      ],
+      "sideEffectPolicy": "local_render_only",
+      "state": "target_selected",
+      "userAction": "Review the target model descriptor in the future chat UI."
+    },
+    {
+      "actionId": "configure_model_assets",
+      "enabled": false,
+      "label": "configure model assets",
+      "launcherAction": "Do not read or echo local asset paths.",
+      "requiredEvidence": [
+        "local_model_asset_input_boundary_reviewed",
+        "redaction_policy_reviewed"
+      ],
+      "sideEffectPolicy": "no_artifact_read_no_write",
+      "state": "blocked",
+      "userAction": "Provide model assets only after a reviewed local input boundary exists."
+    },
+    {
+      "actionId": "load_model",
+      "enabled": false,
+      "label": "load model",
+      "launcherAction": "Refuse model load while runtime readiness is blocked.",
+      "requiredEvidence": [
+        "runtime_readiness_available",
+        "model_assets_configured",
+        "kv260_session_available"
+      ],
+      "sideEffectPolicy": "no_runtime_execution",
+      "state": "disabled",
+      "userAction": "Load only after runtime readiness and model asset checks are evidence-backed."
+    },
+    {
+      "actionId": "refresh_status",
+      "enabled": false,
+      "label": "refresh status",
+      "launcherAction": "Render deterministic fixture data only.",
+      "requiredEvidence": [
+        "checked_fixture_data_available"
+      ],
+      "sideEffectPolicy": "read_only_data",
+      "state": "available_as_data",
+      "userAction": "Refresh the model status display from checked local fixtures."
+    }
+  ],
+  "loadState": "blocked",
+  "modelSelectionState": "target_selected",
+  "providerState": "not_used",
+  "responseState": "unavailable",
+  "runtimeState": "not_started",
+  "safetyFlags": {
+    "automaticUpload": false,
+    "cloudCalls": false,
+    "dataOnly": true,
+    "deterministic": true,
+    "executesPccxLab": false,
+    "executesSystemverilogIde": false,
+    "generatedBlobsIncluded": false,
+    "hardwareDumpsIncluded": false,
+    "kv260Access": false,
+    "lspImplemented": false,
+    "mcpServerImplemented": false,
+    "modelAssetPathsIncluded": false,
+    "modelExecution": false,
+    "modelLoadAttempted": false,
+    "modelLoaded": false,
+    "modelWeightPathsIncluded": false,
+    "networkCalls": false,
+    "networkScan": false,
+    "opensSerialPort": false,
+    "privatePathsIncluded": false,
+    "promptContentIncluded": false,
+    "providerCalls": false,
+    "readOnly": true,
+    "readsArtifacts": false,
+    "responseContentIncluded": false,
+    "responseGenerated": false,
+    "runtimeExecution": false,
+    "secretsIncluded": false,
+    "stableApiAbiClaim": false,
+    "statusDisplayOnly": true,
+    "telemetry": false,
+    "tokensIncluded": false,
+    "touchesHardware": false,
+    "transcriptPersistence": false,
+    "writeBack": false,
+    "writesArtifacts": false
+  },
+  "schemaVersion": "pccx.chatModelStatus.v0",
+  "statusId": "chat_model_status_gemma3n_e4b_kv260_placeholder",
+  "statusRows": [
+    {
+      "displayPolicy": "show descriptor id and target label without model paths",
+      "label": "model descriptor",
+      "rowId": "model_descriptor",
+      "severity": "info",
+      "state": "available_as_data",
+      "summary": "Gemma 3N E4B is represented by the checked descriptor fixture only."
+    },
+    {
+      "displayPolicy": "show blocked state without local paths or filenames",
+      "label": "model assets",
+      "rowId": "model_assets",
+      "severity": "blocked",
+      "state": "external_not_configured",
+      "summary": "Model assets are user-provided future inputs and are not configured here."
+    },
+    {
+      "displayPolicy": "show conservative readiness summary only",
+      "label": "runtime readiness",
+      "rowId": "runtime_readiness",
+      "severity": "blocked",
+      "state": "blocked",
+      "summary": "Runtime readiness remains blocked and not yet evidence-backed."
+    },
+    {
+      "displayPolicy": "show inactive target state without probing hardware",
+      "label": "device session",
+      "rowId": "device_session",
+      "severity": "blocked",
+      "state": "inactive",
+      "summary": "No KV260 target session exists in this fixture."
+    },
+    {
+      "displayPolicy": "show disabled action state only",
+      "label": "load operation",
+      "rowId": "load_operation",
+      "severity": "blocked",
+      "state": "disabled",
+      "summary": "Model load controls stay disabled until readiness evidence exists."
+    },
+    {
+      "displayPolicy": "show unavailable context state without token data",
+      "label": "chat context",
+      "rowId": "chat_context",
+      "severity": "blocked",
+      "state": "unavailable",
+      "summary": "No runtime context window or token state exists."
+    },
+    {
+      "displayPolicy": "show response unavailable state only",
+      "label": "assistant response",
+      "rowId": "assistant_response",
+      "severity": "blocked",
+      "state": "unavailable",
+      "summary": "No response can be generated because no model runtime is active."
+    }
+  ],
+  "targetBoard": "xilinx_kria_kv260",
+  "targetDevice": "kv260",
+  "targetModel": "gemma3n-e4b"
+}

--- a/docs/STANDALONE_CHAT_SESSION_CONTRACT.md
+++ b/docs/STANDALONE_CHAT_SESSION_CONTRACT.md
@@ -9,15 +9,20 @@ Current answer: **blocked / no local chat runtime is active**.
 The implementation lives in:
 
 - `contracts/chat_session_contract.py`
+- `contracts/chat_model_status_contract.py`
 - `contracts/chat_session_lifecycle_contract.py`
 - `contracts/fixtures/chat-session.gemma3n-e4b-kv260-placeholder.json`
+- `contracts/fixtures/chat-model-status.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-session-lifecycle.gemma3n-e4b-kv260-placeholder.json`
 - `scripts/chat-session-stub.sh`
+- `scripts/chat-model-status-stub.sh`
 - `scripts/chat-session-lifecycle-stub.sh`
 - `scripts/chat-surface-preview.sh`
 - `scripts/tests/chat_session_contract_test.py`
+- `scripts/tests/chat_model_status_contract_test.py`
 - `scripts/tests/chat_session_lifecycle_contract_test.py`
 - `scripts/tests/chat_surface_preview_test.py`
+- `scripts/tests/status-chat-model-status.sh`
 
 ## What Is Implemented
 
@@ -39,6 +44,18 @@ JSON for the supported model and target pair:
 ```bash
 bash scripts/chat-session-stub.sh --model gemma3n-e4b --target kv260
 ```
+
+The chat model-status fixture records the display boundary for model
+descriptor, asset, load, runtime, context, and response rows:
+
+```bash
+bash scripts/chat-model-status-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/status-stub.sh --include-chat-model-status
+```
+
+Model loading stays blocked and disabled. The model-status fixture does
+not read model paths, load weights, start runtimes, generate responses,
+touch hardware, call providers, invoke pccx-lab, or write artifacts.
 
 The lifecycle fixture records the session-management boundary for create,
 restore, clear, close, and export-summary operations:
@@ -81,6 +98,7 @@ The chat/session states are deliberately narrow:
 - `not_configured`: required configuration is absent
 - `not_loaded`: no model assets are loaded
 - `not_started`: no transcript or log stream exists
+- `not_used`: no external provider state is used
 - `unavailable`: output is not available
 - `available_as_data`: local fixture shape is available as data only
 
@@ -100,11 +118,12 @@ content:
 
 ## Coordination Boundary
 
-The standalone chat surface depends on the existing launcher readiness
-and device/session status contracts. The lifecycle contract adds a
-reviewable session-management shape, but it does not add runtime
-execution, model loading, provider calls, persistence, target access,
-artifact reads, or artifact writes.
+The standalone chat surface depends on the existing launcher model
+descriptor, readiness, and device/session status contracts. The
+model-status contract adds reviewable display rows for model-load state.
+The lifecycle contract adds a reviewable session-management shape, but
+these contracts do not add runtime execution, model loading, provider
+calls, persistence, target access, artifact reads, or artifact writes.
 
 pccx-lab remains a separate CLI/core diagnostics and verification
 backend. systemverilog-ide may consume launcher data later as read-only

--- a/scripts/chat-model-status-stub.sh
+++ b/scripts/chat-model-status-stub.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+# scripts/chat-model-status-stub.sh - print data-only chat model status JSON.
+#
+# This script does not load model assets, start runtime code, touch KV260
+# hardware, call providers, read prompts, write artifacts, or invoke pccx-lab.
+
+set -eu
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+
+MODEL="gemma3n-e4b"
+TARGET="kv260"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --model)
+            MODEL="${2:-}"
+            if [ -z "$MODEL" ]; then
+                printf '[ERROR] --model requires an argument\n' >&2
+                exit 2
+            fi
+            shift 2
+            ;;
+        --target)
+            TARGET="${2:-}"
+            if [ -z "$TARGET" ]; then
+                printf '[ERROR] --target requires an argument\n' >&2
+                exit 2
+            fi
+            shift 2
+            ;;
+        *)
+            printf '[ERROR] unknown option: %s\n' "$1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+exec python3 "$ROOT_DIR/contracts/chat_model_status_contract.py" \
+    --model "$MODEL" \
+    --target "$TARGET"

--- a/scripts/status-stub.sh
+++ b/scripts/status-stub.sh
@@ -13,6 +13,9 @@
 # Chat/session status and lifecycle plan (explicit opt-in, read-only local data):
 #   --include-chat-session
 #
+# Chat model status display plan (explicit opt-in, read-only local data):
+#   --include-chat-model-status
+#
 # pccx-lab backend (explicit opt-in):
 #   --backend pccx-lab        call pccx-lab status --format json
 #   PCCX_LAB_BIN              override path to pccx-lab binary (takes priority over PATH)
@@ -31,6 +34,90 @@ BACKEND=""
 INCLUDE_RUNTIME_READINESS="0"
 INCLUDE_DEVICE_SESSION="0"
 INCLUDE_CHAT_SESSION="0"
+INCLUDE_CHAT_MODEL_STATUS="0"
+
+print_chat_model_status_summary() {
+    SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+    ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+    CHAT_MODEL_STATUS_STUB="$ROOT_DIR/scripts/chat-model-status-stub.sh"
+
+    if [ ! -f "$CHAT_MODEL_STATUS_STUB" ]; then
+        ERROR "chat model status stub not found: $CHAT_MODEL_STATUS_STUB"
+        return 1
+    fi
+
+    if ! CHAT_MODEL_STATUS_JSON="$(bash "$CHAT_MODEL_STATUS_STUB" --model gemma3n-e4b --target kv260 2>&1)"; then
+        ERROR "chat model status stub failed"
+        printf '%s\n' "$CHAT_MODEL_STATUS_JSON" >&2
+        return 1
+    fi
+
+    if ! CHAT_MODEL_STATUS_SUMMARY="$(
+        printf '%s\n' "$CHAT_MODEL_STATUS_JSON" | python3 -c '
+import json
+import sys
+
+data = json.load(sys.stdin)
+flags = data["safetyFlags"]
+rows = " ".join(
+    "{}={}".format(row["rowId"], row["state"])
+    for row in data["statusRows"]
+)
+actions = " ".join(
+    "{}={}".format(action["actionId"], action["state"])
+    for action in data["loadActions"]
+)
+
+def b(value):
+    return "true" if value else "false"
+
+print("[INFO]  source     : scripts/chat-model-status-stub.sh --model gemma3n-e4b --target kv260")
+print("[INFO]  boundary   : read-only data; no model load/provider/hardware/lab/IDE execution")
+print("[INFO]  target     : {}".format(data["targetDevice"]))
+print("[INFO]  model      : {}".format(data["targetModel"]))
+print("[INFO]  display    : {}".format(data["displayState"]))
+print("[INFO]  descriptor : {}".format(data["descriptorState"]))
+print("[INFO]  assets     : {}".format(data["assetState"]))
+print("[INFO]  load       : {}".format(data["loadState"]))
+print("[INFO]  runtime    : {}".format(data["runtimeState"]))
+print("[INFO]  context    : {}".format(data["contextState"]))
+print("[INFO]  response   : {}".format(data["responseState"]))
+print("[INFO]  provider   : {}".format(data["providerState"]))
+print("[INFO]  rows       : {}".format(rows))
+print("[INFO]  actions    : {}".format(actions))
+print(
+    "[INFO]  flags      : readOnly={} dataOnly={} deterministic={} "
+    "statusDisplayOnly={} modelLoadAttempted={} modelLoaded={} "
+    "modelExecution={} runtimeExecution={} responseGenerated={} "
+    "kv260Access={} providerCalls={} cloudCalls={} networkCalls={} "
+    "modelAssetPathsIncluded={} modelWeightPathsIncluded={} executesPccxLab={}".format(
+        b(flags["readOnly"]),
+        b(flags["dataOnly"]),
+        b(flags["deterministic"]),
+        b(flags["statusDisplayOnly"]),
+        b(flags["modelLoadAttempted"]),
+        b(flags["modelLoaded"]),
+        b(flags["modelExecution"]),
+        b(flags["runtimeExecution"]),
+        b(flags["responseGenerated"]),
+        b(flags["kv260Access"]),
+        b(flags["providerCalls"]),
+        b(flags["cloudCalls"]),
+        b(flags["networkCalls"]),
+        b(flags["modelAssetPathsIncluded"]),
+        b(flags["modelWeightPathsIncluded"]),
+        b(flags["executesPccxLab"]),
+    )
+)
+'
+    )"; then
+        ERROR "chat model status JSON could not be summarized"
+        return 1
+    fi
+
+    HEAD "chat model status"
+    printf '%s\n' "$CHAT_MODEL_STATUS_SUMMARY"
+}
 
 print_chat_session_summary() {
     SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
@@ -306,6 +393,10 @@ while [ $# -gt 0 ]; do
             INCLUDE_CHAT_SESSION="1"
             shift
             ;;
+        --include-chat-model-status)
+            INCLUDE_CHAT_MODEL_STATUS="1"
+            shift
+            ;;
         --backend)
             BACKEND="${2:-}"
             if [ -z "$BACKEND" ]; then
@@ -321,8 +412,8 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-if [ -n "$BACKEND" ] && { [ "$INCLUDE_RUNTIME_READINESS" = "1" ] || [ "$INCLUDE_DEVICE_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SESSION" = "1" ]; }; then
-    ERROR "--include-runtime-readiness, --include-device-session, and --include-chat-session are only supported in local scaffold mode"
+if [ -n "$BACKEND" ] && { [ "$INCLUDE_RUNTIME_READINESS" = "1" ] || [ "$INCLUDE_DEVICE_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SESSION" = "1" ] || [ "$INCLUDE_CHAT_MODEL_STATUS" = "1" ]; }; then
+    ERROR "--include-runtime-readiness, --include-device-session, --include-chat-session, and --include-chat-model-status are only supported in local scaffold mode"
     exit 1
 fi
 
@@ -338,7 +429,14 @@ if [ -z "$BACKEND" ]; then
     NOTE "runtime ready  : opt-in via --include-runtime-readiness (read-only data)"
     NOTE "device/session: opt-in via --include-device-session (read-only panel data)"
     NOTE "chat/session  : opt-in via --include-chat-session (read-only blocked chat and lifecycle data)"
+    NOTE "chat model    : opt-in via --include-chat-model-status (read-only model status display data)"
     NOTE "editor bridge  : planned (VS Code / other IDEs)"
+
+    if [ "$INCLUDE_CHAT_MODEL_STATUS" = "1" ]; then
+        if ! print_chat_model_status_summary; then
+            exit 1
+        fi
+    fi
 
     if [ "$INCLUDE_CHAT_SESSION" = "1" ]; then
         if ! print_chat_session_summary; then

--- a/scripts/tests/chat_model_status_contract_test.py
+++ b/scripts/tests/chat_model_status_contract_test.py
@@ -1,0 +1,390 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Fixture tests for the standalone chat model-status contract."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "contracts" / "chat_model_status_contract.py"
+FIXTURE_PATH = (
+    ROOT
+    / "contracts"
+    / "fixtures"
+    / "chat-model-status.gemma3n-e4b-kv260-placeholder.json"
+)
+SCRIPT_PATH = ROOT / "scripts" / "chat-model-status-stub.sh"
+STATUS_TEST_PATH = ROOT / "scripts" / "tests" / "status-chat-model-status.sh"
+DOC_PATH = ROOT / "docs" / "STANDALONE_CHAT_SESSION_CONTRACT.md"
+README_PATH = ROOT / "README.md"
+TEST_PATH = Path(__file__).resolve()
+CI_PATH = ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location(
+        "chat_model_status_contract",
+        MODULE_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def flatten(value) -> str:
+    return json.dumps(value, sort_keys=True)
+
+
+def iter_state_values(value):
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            if key == "state" or key.endswith("State") or key.endswith("Status"):
+                yield nested
+            yield from iter_state_values(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            yield from iter_state_values(nested)
+
+
+def iter_keys(value):
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            yield key
+            yield from iter_keys(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            yield from iter_keys(nested)
+
+
+def assert_no_private_or_generated_data(text: str) -> None:
+    forbidden_patterns = [
+        r"/home/[^\s\"']+",
+        r"/Users/[^\s\"']+",
+        r"[A-Za-z]:\\Users\\",
+        r"\b(?:api[_-]?key|authorization|bearer|client[_-]?secret|password|private[_-]?key|secret|token)\b\s*[:=]",
+        r"\.(?:gguf|safetensors|ckpt|pt|pth|onnx)\b",
+        r"(?:weights|model_weights|model-cache)/(?:[^\"'\s]+)",
+        r"(?:raw[_-]?full[_-]?logs|hardware[_-]?dump|generated[_-]?blob)\s*[:=]",
+    ]
+    for pattern in forbidden_patterns:
+        assert not re.search(pattern, text, re.IGNORECASE), pattern
+
+
+def assert_no_runtime_implementation_terms(source: str) -> None:
+    forbidden = [
+        "subprocess",
+        "os.system",
+        "popen",
+        "socket",
+        "urllib",
+        "requests",
+        "http.client",
+        "openai",
+        "anthropic",
+        "gemini",
+        "modelcontextprotocol",
+        "websocket",
+        "xmutil",
+        "xrt-smi",
+        "lsusb",
+        "dmesg",
+    ]
+    lowered = source.lower()
+    for term in forbidden:
+        assert term not in lowered, term
+
+
+def assert_no_provider_configs(value) -> None:
+    forbidden_keys = {
+        "apiKey",
+        "accessToken",
+        "refreshToken",
+        "authorization",
+        "bearerToken",
+        "provider",
+        "providers",
+        "providerConfig",
+        "providerConfigs",
+    }
+    for key in iter_keys(value):
+        assert key not in forbidden_keys, key
+
+
+def assert_no_unsupported_claims(text: str) -> None:
+    literal_claims = [
+        "production-ready",
+        "marketplace-ready",
+        "stable API",
+        "stable ABI",
+        "KV260 inference works",
+        "Gemma 3N E4B runs on KV260",
+        "20 tok/s achieved",
+        "timing closed",
+        "bitstream ready",
+        "launcher executes pccx-lab",
+        "IDE controls launcher",
+        "AI provider integration is live",
+    ]
+    lowered = text.lower()
+    for claim in literal_claims:
+        assert claim.lower() not in lowered, claim
+
+    asserted_claim_patterns = [
+        r"\bMCP\s+(?:server|client)\s+(?:is\s+)?implemented\b",
+        r"\bLSP\s+(?:server|client)\s+(?:is\s+)?implemented\b",
+        r"\bAI\s+provider\s+(?:is\s+)?implemented\b",
+        r"\bKV260\s+run\s+(?:is\s+)?claimed\b",
+    ]
+    for pattern in asserted_claim_patterns:
+        assert not re.search(pattern, text, re.IGNORECASE), pattern
+
+
+def assert_no_chat_invocation_flags(source: str) -> None:
+    forbidden_patterns = [
+        r"--backend\s+pccx-lab",
+        r"\bPCCX_LAB_BIN\b",
+        r"\bpccx-lab\s+(?:status|diagnostics|validate)\b",
+        r"\bsystemverilog-ide\s+--",
+        r"\bsystemverilog-ide\s+(?:open|run|status|validate|launch)\b",
+        r"\b(?:curl|wget)\b",
+        r"\b(?:upload|telemetry|write-back)\s+(?:enabled|true)\b",
+    ]
+    for pattern in forbidden_patterns:
+        assert not re.search(pattern, source, re.IGNORECASE), pattern
+
+
+def test_chat_model_status_matches_fixture_and_is_deterministic() -> None:
+    module = load_module()
+    generated = module.create_gemma3n_e4b_kv260_chat_model_status()
+    fixture = json.loads(read_text(FIXTURE_PATH))
+
+    assert generated == fixture
+    assert module.chat_model_status_json(generated) == module.chat_model_status_json(generated)
+    assert module.chat_model_status_json(generated).endswith("\n")
+    assert json.loads(module.chat_model_status_json(generated)) == fixture
+
+
+def test_cli_stub_outputs_deterministic_json() -> None:
+    fixture = json.loads(read_text(FIXTURE_PATH))
+    command = [
+        "bash",
+        str(SCRIPT_PATH),
+        "--model",
+        "gemma3n-e4b",
+        "--target",
+        "kv260",
+    ]
+    first = subprocess.run(
+        command,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    second = subprocess.run(
+        command,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert first.stderr == ""
+    assert first.stdout == second.stdout
+    assert first.stdout.endswith("\n")
+    assert json.loads(first.stdout) == fixture
+
+
+def test_required_fields_and_allowed_states() -> None:
+    module = load_module()
+    status = module.create_gemma3n_e4b_kv260_chat_model_status()
+    allowed = set(module.CHAT_MODEL_STATUS_STATE_VALUES)
+
+    assert tuple(status.keys()) == module.CHAT_MODEL_STATUS_FIELDS
+    assert status["schemaVersion"] == "pccx.chatModelStatus.v0"
+
+    states = list(iter_state_values(status))
+    assert states
+    for state in states:
+        assert state in allowed, state
+
+    for row in status["statusRows"]:
+        assert tuple(row.keys()) == module.STATUS_ROW_FIELDS
+    for action in status["loadActions"]:
+        assert tuple(action.keys()) == module.LOAD_ACTION_FIELDS
+    for reason in status["blockedReasons"]:
+        assert tuple(reason.keys()) == module.BLOCKED_REASON_FIELDS
+    for ref in status["handoffRefs"]:
+        assert tuple(ref.keys()) == module.HANDOFF_REF_FIELDS
+
+
+def test_chat_model_status_covers_issue_9_display_boundary() -> None:
+    status = load_module().create_gemma3n_e4b_kv260_chat_model_status()
+    rows = {row["rowId"]: row for row in status["statusRows"]}
+    actions = {action["actionId"]: action for action in status["loadActions"]}
+    reasons = {reason["reasonId"]: reason for reason in status["blockedReasons"]}
+    refs = {ref["refId"]: ref for ref in status["handoffRefs"]}
+
+    assert status["displayState"] == "blocked"
+    assert status["modelSelectionState"] == "target_selected"
+    assert status["descriptorState"] == "available_as_data"
+    assert status["assetState"] == "external_not_configured"
+    assert status["loadState"] == "blocked"
+    assert status["runtimeState"] == "not_started"
+    assert status["contextState"] == "unavailable"
+    assert status["responseState"] == "unavailable"
+    assert status["providerState"] == "not_used"
+    assert set(rows) == {
+        "model_descriptor",
+        "model_assets",
+        "runtime_readiness",
+        "device_session",
+        "load_operation",
+        "chat_context",
+        "assistant_response",
+    }
+    assert rows["model_descriptor"]["state"] == "available_as_data"
+    assert rows["model_assets"]["state"] == "external_not_configured"
+    assert rows["load_operation"]["state"] == "disabled"
+    assert set(actions) == {
+        "select_model_target",
+        "configure_model_assets",
+        "load_model",
+        "refresh_status",
+    }
+    for action in actions.values():
+        assert action["enabled"] is False
+    assert actions["load_model"]["state"] == "disabled"
+    assert {
+        "runtime_readiness_blocked",
+        "model_assets_external",
+        "kv260_session_inactive",
+        "chat_runtime_not_started",
+    } <= set(reasons)
+    assert set(refs) == {
+        "model_runtime_descriptor",
+        "runtime_readiness",
+        "device_session_status",
+        "chat_session",
+    }
+
+
+def test_safety_flags_preserve_data_only_boundary() -> None:
+    status = load_module().create_gemma3n_e4b_kv260_chat_model_status()
+    flags = status["safetyFlags"]
+
+    assert flags["dataOnly"] is True
+    assert flags["readOnly"] is True
+    assert flags["deterministic"] is True
+    assert flags["statusDisplayOnly"] is True
+    for name in [
+        "writesArtifacts",
+        "readsArtifacts",
+        "modelAssetPathsIncluded",
+        "modelWeightPathsIncluded",
+        "modelLoadAttempted",
+        "modelLoaded",
+        "modelExecution",
+        "runtimeExecution",
+        "responseGenerated",
+        "promptContentIncluded",
+        "responseContentIncluded",
+        "transcriptPersistence",
+        "touchesHardware",
+        "kv260Access",
+        "opensSerialPort",
+        "networkCalls",
+        "networkScan",
+        "providerCalls",
+        "cloudCalls",
+        "privatePathsIncluded",
+        "secretsIncluded",
+        "tokensIncluded",
+        "generatedBlobsIncluded",
+        "hardwareDumpsIncluded",
+        "telemetry",
+        "automaticUpload",
+        "writeBack",
+        "executesPccxLab",
+        "executesSystemverilogIde",
+        "mcpServerImplemented",
+        "lspImplemented",
+        "stableApiAbiClaim",
+    ]:
+        assert flags[name] is False, name
+
+
+def test_docs_and_sources_avoid_private_data_runtime_calls_or_overclaims() -> None:
+    module_source = read_text(MODULE_PATH)
+    script_source = read_text(SCRIPT_PATH)
+    status_test_source = read_text(STATUS_TEST_PATH)
+    status = load_module().create_gemma3n_e4b_kv260_chat_model_status()
+    scan_text = "\n".join([
+        read_text(FIXTURE_PATH),
+        read_text(DOC_PATH),
+        read_text(README_PATH),
+        flatten(status),
+        module_source,
+        script_source,
+        status_test_source,
+    ])
+    runtime_source = "\n".join([module_source, script_source])
+
+    assert_no_runtime_implementation_terms(runtime_source)
+    assert_no_private_or_generated_data(scan_text)
+    assert_no_provider_configs(status)
+    assert_no_unsupported_claims(scan_text)
+    assert_no_chat_invocation_flags(runtime_source)
+
+
+def test_source_headers_for_touched_code_files() -> None:
+    expected_headers = {
+        MODULE_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        SCRIPT_PATH: [
+            "#!/usr/bin/env bash",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        STATUS_TEST_PATH: [
+            "#!/usr/bin/env bash",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        TEST_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        CI_PATH: [
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+    }
+
+    for path, header in expected_headers.items():
+        assert read_text(path).splitlines()[: len(header)] == header, path
+
+
+test_chat_model_status_matches_fixture_and_is_deterministic()
+test_cli_stub_outputs_deterministic_json()
+test_required_fields_and_allowed_states()
+test_chat_model_status_covers_issue_9_display_boundary()
+test_safety_flags_preserve_data_only_boundary()
+test_docs_and_sources_avoid_private_data_runtime_calls_or_overclaims()
+test_source_headers_for_touched_code_files()
+
+print("chat model status contract tests ok")

--- a/scripts/tests/status-chat-model-status.sh
+++ b/scripts/tests/status-chat-model-status.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+# scripts/tests/status-chat-model-status.sh - status chat model summary tests.
+#
+# Usage: bash scripts/tests/status-chat-model-status.sh [path/to/status-stub.sh]
+
+set -eu
+
+PASS() { printf '[PASS]  %s\n' "$*"; }
+FAIL() { printf '[FAIL]  %s\n' "$*" >&2; }
+HEAD() { printf '\n=== %s ===\n' "$*"; }
+
+STUB="${1:-scripts/status-stub.sh}"
+
+if [ ! -x "$STUB" ]; then
+    chmod +x "$STUB"
+fi
+
+contains() {
+    case "$1" in
+        *"$2"*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+require_contains() {
+    local output="$1"
+    local expected="$2"
+    if ! contains "$output" "$expected"; then
+        FAIL "expected output to contain: $expected"
+        printf '%s\n' "$output" >&2
+        exit 1
+    fi
+}
+
+require_not_contains() {
+    local output="$1"
+    local forbidden="$2"
+    if contains "$output" "$forbidden"; then
+        FAIL "output contained forbidden text: $forbidden"
+        printf '%s\n' "$output" >&2
+        exit 1
+    fi
+}
+
+HEAD "1: status can include chat model status"
+OUTPUT="$("$STUB" --include-chat-model-status)"
+require_contains "$OUTPUT" "=== chat model status ==="
+require_contains "$OUTPUT" "source     : scripts/chat-model-status-stub.sh --model gemma3n-e4b --target kv260"
+require_contains "$OUTPUT" "boundary   : read-only data; no model load/provider/hardware/lab/IDE execution"
+require_contains "$OUTPUT" "target     : kv260"
+require_contains "$OUTPUT" "model      : gemma3n-e4b"
+require_contains "$OUTPUT" "display    : blocked"
+require_contains "$OUTPUT" "descriptor : available_as_data"
+require_contains "$OUTPUT" "assets     : external_not_configured"
+require_contains "$OUTPUT" "load       : blocked"
+require_contains "$OUTPUT" "runtime    : not_started"
+require_contains "$OUTPUT" "context    : unavailable"
+require_contains "$OUTPUT" "response   : unavailable"
+require_contains "$OUTPUT" "provider   : not_used"
+PASS "chat model status section is present and conservative"
+
+HEAD "2: rows and actions stay blocked or non-executing"
+require_contains "$OUTPUT" "rows       : model_descriptor=available_as_data"
+require_contains "$OUTPUT" "model_assets=external_not_configured"
+require_contains "$OUTPUT" "runtime_readiness=blocked"
+require_contains "$OUTPUT" "device_session=inactive"
+require_contains "$OUTPUT" "load_operation=disabled"
+require_contains "$OUTPUT" "chat_context=unavailable"
+require_contains "$OUTPUT" "assistant_response=unavailable"
+require_contains "$OUTPUT" "actions    : select_model_target=target_selected"
+require_contains "$OUTPUT" "configure_model_assets=blocked"
+require_contains "$OUTPUT" "load_model=disabled"
+require_contains "$OUTPUT" "refresh_status=available_as_data"
+PASS "model-status rows and actions are summarized"
+
+HEAD "3: safety flags stay read-only and non-executing"
+require_contains "$OUTPUT" "readOnly=true"
+require_contains "$OUTPUT" "dataOnly=true"
+require_contains "$OUTPUT" "deterministic=true"
+require_contains "$OUTPUT" "statusDisplayOnly=true"
+require_contains "$OUTPUT" "modelLoadAttempted=false"
+require_contains "$OUTPUT" "modelLoaded=false"
+require_contains "$OUTPUT" "modelExecution=false"
+require_contains "$OUTPUT" "runtimeExecution=false"
+require_contains "$OUTPUT" "responseGenerated=false"
+require_contains "$OUTPUT" "kv260Access=false"
+require_contains "$OUTPUT" "providerCalls=false"
+require_contains "$OUTPUT" "cloudCalls=false"
+require_contains "$OUTPUT" "networkCalls=false"
+require_contains "$OUTPUT" "modelAssetPathsIncluded=false"
+require_contains "$OUTPUT" "modelWeightPathsIncluded=false"
+require_contains "$OUTPUT" "executesPccxLab=false"
+PASS "execution-related flags remain false"
+
+HEAD "4: output is deterministic"
+OUTPUT_AGAIN="$("$STUB" --include-chat-model-status)"
+if [ "$OUTPUT" != "$OUTPUT_AGAIN" ]; then
+    FAIL "status chat model output changed between runs"
+    exit 1
+fi
+PASS "status chat model output is deterministic"
+
+HEAD "5: chat model option does not combine with pccx-lab backend"
+if "$STUB" --include-chat-model-status --backend pccx-lab >/dev/null 2>&1; then
+    FAIL "expected combined chat-model/backend mode to fail"
+    exit 1
+fi
+PASS "chat model status remains separate from backend execution"
+
+HEAD "6: output avoids known overclaims"
+FORBIDDEN_PREFIX="KV260 inference"
+FORBIDDEN_CLAIM="${FORBIDDEN_PREFIX} works"
+require_not_contains "$OUTPUT" "$FORBIDDEN_CLAIM"
+THROUGHPUT_PREFIX="20 tok/s"
+THROUGHPUT_CLAIM="${THROUGHPUT_PREFIX} achieved"
+require_not_contains "$OUTPUT" "$THROUGHPUT_CLAIM"
+PASS "no chat model or throughput overclaim in status output"
+
+printf '\n[DONE]  all status-chat-model-status tests passed\n'


### PR DESCRIPTION
## Summary
- Add a data-only chat model-status contract, fixture, and stub for the planned Gemma 3N E4B plus KV260 chat surface.
- Add an opt-in `status-stub.sh --include-chat-model-status` summary with blocked descriptor, asset, load, runtime, context, and response rows.
- Document and test the boundary while keeping model loading, runtime execution, provider calls, hardware access, pccx-lab execution, and IDE execution out of scope.

Refs #9.

## Validation
- `python3 scripts/tests/chat_model_status_contract_test.py`
- `bash scripts/tests/status-chat-model-status.sh scripts/status-stub.sh`
- `python3 scripts/tests/chat_session_contract_test.py`
- `python3 scripts/tests/chat_session_lifecycle_contract_test.py`
- `python3 scripts/tests/chat_surface_preview_test.py`
- `bash scripts/tests/status-chat-session.sh scripts/status-stub.sh`
- `bash scripts/tests/status-backend.sh scripts/status-stub.sh`
- `bash scripts/tests/status-device-session.sh scripts/status-stub.sh`
- `bash scripts/tests/status-readiness.sh scripts/status-stub.sh`
- `python3 scripts/tests/launcher_ide_contract_test.py`
- `python3 scripts/tests/model_runtime_descriptor_test.py`
- `python3 scripts/tests/diagnostics_handoff_contract_test.py`
- `python3 scripts/tests/device_session_status_contract_test.py`
- `python3 scripts/tests/runtime_readiness_contract_test.py`
- `bash scripts/check.sh`
- `git diff --check`
- local claim scan matching CI

Local shellcheck was not run because `shellcheck` is not installed in this environment; the GitHub Actions shell-lint job covers it.
