### PR TITLE
Add chat readiness boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,7 @@ jobs:
                    scripts/chat-model-status-stub.sh \
                    scripts/chat-session-stub.sh \
                    scripts/chat-session-lifecycle-stub.sh \
+                   scripts/chat-readiness-stub.sh \
                    scripts/chat-surface-preview.sh \
                    scripts/chat-stub.sh; do
             [ -f "$f" ] && chmod +x "$f" || true
@@ -163,6 +164,10 @@ jobs:
         run: ./scripts/chat-session-stub.sh --model gemma3n-e4b --target kv260
       - name: run scripts/chat-session-lifecycle-stub.sh
         run: ./scripts/chat-session-lifecycle-stub.sh --model gemma3n-e4b --target kv260
+      - name: run scripts/status-stub.sh with chat readiness
+        run: ./scripts/status-stub.sh --include-chat-readiness
+      - name: run scripts/chat-readiness-stub.sh
+        run: ./scripts/chat-readiness-stub.sh --model gemma3n-e4b --target kv260
       - name: run scripts/chat-surface-preview.sh
         run: ./scripts/chat-surface-preview.sh --model gemma3n-e4b --target kv260
       - name: run scripts/chat-stub.sh --dry-run
@@ -191,6 +196,8 @@ jobs:
         run: python3 scripts/tests/chat_model_status_contract_test.py
       - name: run chat/session lifecycle contract tests
         run: python3 scripts/tests/chat_session_lifecycle_contract_test.py
+      - name: run chat readiness contract tests
+        run: python3 scripts/tests/chat_readiness_contract_test.py
       - name: run chat surface preview tests
         run: python3 scripts/tests/chat_surface_preview_test.py
 
@@ -206,12 +213,14 @@ jobs:
           chmod +x scripts/chat-model-status-stub.sh
           chmod +x scripts/chat-session-stub.sh
           chmod +x scripts/chat-session-lifecycle-stub.sh
+          chmod +x scripts/chat-readiness-stub.sh
           chmod +x scripts/launch-stub.sh
           chmod +x scripts/tests/status-backend.sh
           chmod +x scripts/tests/status-device-session.sh
           chmod +x scripts/tests/status-readiness.sh
           chmod +x scripts/tests/status-chat-model-status.sh
           chmod +x scripts/tests/status-chat-session.sh
+          chmod +x scripts/tests/status-chat-readiness.sh
       - name: shellcheck status-stub and test script
         run: |
           sudo apt-get update -q && sudo apt-get install -y -q shellcheck
@@ -221,6 +230,7 @@ jobs:
           shellcheck scripts/tests/status-readiness.sh
           shellcheck scripts/tests/status-chat-model-status.sh
           shellcheck scripts/tests/status-chat-session.sh
+          shellcheck scripts/tests/status-chat-readiness.sh
       - name: run status-backend tests
         run: bash scripts/tests/status-backend.sh scripts/status-stub.sh
       - name: run status-device-session tests
@@ -231,3 +241,5 @@ jobs:
         run: bash scripts/tests/status-chat-model-status.sh scripts/status-stub.sh
       - name: run status-chat-session tests
         run: bash scripts/tests/status-chat-session.sh scripts/status-stub.sh
+      - name: run status-chat-readiness tests
+        run: bash scripts/tests/status-chat-readiness.sh scripts/status-stub.sh

--- a/README.md
+++ b/README.md
@@ -87,12 +87,13 @@ and verify host-side prerequisites before the real engine lands.
 | [`scripts/check.sh`](./scripts/check.sh) | Probe host info, tooling availability, edge-device hints. Always exits 0. |
 | [`scripts/check-device-stub.sh`](./scripts/check-device-stub.sh) | Narrowly scoped device-tree / FPGA-node probe (KV260 / Kria detection only). Always exits 0. |
 | [`scripts/install-stub.sh`](./scripts/install-stub.sh) | Preview of the planned install flow; reports which host runtime pieces are present, lists device-side pieces as future deliverables. Always exits 0. |
-| [`scripts/status-stub.sh`](./scripts/status-stub.sh) | Launcher state summary. Default mode: local scaffold output, always exits 0. With `--include-chat-model-status`, adds read-only blocked chat model-status display data. With `--include-chat-session`, adds read-only blocked chat/session and lifecycle summaries. With `--include-device-session`, adds a read-only device/session status panel. With `--include-runtime-readiness`, adds a read-only runtime readiness summary. With `--backend pccx-lab`, calls `pccx-lab status --format json` and forwards the run-status envelope (exits non-zero if binary is missing or output is invalid). |
+| [`scripts/status-stub.sh`](./scripts/status-stub.sh) | Launcher state summary. Default mode: local scaffold output, always exits 0. With `--include-chat-model-status`, adds read-only blocked chat model-status display data. With `--include-chat-session`, adds read-only blocked chat/session and lifecycle summaries. With `--include-chat-readiness`, adds read-only chat readiness checks and recovery actions. With `--include-device-session`, adds a read-only device/session status panel. With `--include-runtime-readiness`, adds a read-only runtime readiness summary. With `--backend pccx-lab`, calls `pccx-lab status --format json` and forwards the run-status envelope (exits non-zero if binary is missing or output is invalid). |
 | [`scripts/device-session-status-stub.sh`](./scripts/device-session-status-stub.sh) | Data-only device/session status JSON for the Gemma 3N E4B + KV260 target. Reports connection, model load, session, diagnostics, readiness, discovery paths, flow steps, and error taxonomy as placeholder / blocked. |
 | [`scripts/runtime-readiness-stub.sh`](./scripts/runtime-readiness-stub.sh) | Data-only runtime readiness JSON for the Gemma 3N E4B + KV260 target. Reports blocked / not yet evidence-backed. |
 | [`scripts/chat-session-stub.sh`](./scripts/chat-session-stub.sh) | Data-only standalone chat/session JSON for the Gemma 3N E4B + KV260 target. Reports disabled send controls, inactive session state, no prompt/response persistence, and readiness handoff references. |
 | [`scripts/chat-session-lifecycle-stub.sh`](./scripts/chat-session-lifecycle-stub.sh) | Data-only chat session lifecycle JSON for the Gemma 3N E4B + KV260 target. Reports create, restore, clear, close, and export-summary operations as disabled, blocked, inactive, or unavailable. |
 | [`scripts/chat-model-status-stub.sh`](./scripts/chat-model-status-stub.sh) | Data-only chat model-status JSON for the Gemma 3N E4B + KV260 target. Reports descriptor, asset, load, runtime, context, and response display rows as blocked, disabled, or unavailable. |
+| [`scripts/chat-readiness-stub.sh`](./scripts/chat-readiness-stub.sh) | Data-only chat readiness JSON for the Gemma 3N E4B + KV260 target. Reports readiness checks, error categories, and recovery actions as blocked, disabled, or local data only. |
 | [`scripts/chat-surface-preview.sh`](./scripts/chat-surface-preview.sh) | Read-only terminal preview of the standalone chat surface. Renders the checked chat/session contract as blocked UI state without accepting prompts, executing a model, or writing artifacts. |
 | [`scripts/launch-stub.sh`](./scripts/launch-stub.sh) | Dry-run preview of the intended launch sequence. Requires `--dry-run`; exits 1 without it. |
 | [`scripts/chat-stub.sh`](./scripts/chat-stub.sh) | Dry-run chat stub. Requires `--dry-run`; exits 1 without it. Accepts `--prompt "..."` or stdin. No model is executed. |
@@ -104,6 +105,7 @@ bash scripts/install-stub.sh
 bash scripts/status-stub.sh
 bash scripts/status-stub.sh --include-chat-model-status
 bash scripts/status-stub.sh --include-chat-session
+bash scripts/status-stub.sh --include-chat-readiness
 bash scripts/status-stub.sh --include-device-session
 bash scripts/status-stub.sh --include-runtime-readiness
 bash scripts/device-session-status-stub.sh --model gemma3n-e4b --target kv260
@@ -111,6 +113,7 @@ bash scripts/runtime-readiness-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-model-status-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-session-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-session-lifecycle-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/chat-readiness-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-surface-preview.sh --model gemma3n-e4b --target kv260
 bash scripts/launch-stub.sh --dry-run
 bash scripts/chat-stub.sh --dry-run --prompt "hello"
@@ -277,18 +280,23 @@ the planned local chat entry point:
 ```bash
 python3 contracts/chat_session_contract.py --model gemma3n-e4b --target kv260
 python3 contracts/chat_model_status_contract.py --model gemma3n-e4b --target kv260
+python3 contracts/chat_readiness_contract.py --model gemma3n-e4b --target kv260
 bash scripts/chat-model-status-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-session-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-session-lifecycle-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/chat-readiness-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-surface-preview.sh --model gemma3n-e4b --target kv260
 bash scripts/status-stub.sh --include-chat-model-status
 bash scripts/status-stub.sh --include-chat-session
+bash scripts/status-stub.sh --include-chat-readiness
 python3 scripts/tests/chat_session_contract_test.py
 python3 scripts/tests/chat_model_status_contract_test.py
 python3 scripts/tests/chat_session_lifecycle_contract_test.py
+python3 scripts/tests/chat_readiness_contract_test.py
 python3 scripts/tests/chat_surface_preview_test.py
 bash scripts/tests/status-chat-model-status.sh
 bash scripts/tests/status-chat-session.sh
+bash scripts/tests/status-chat-readiness.sh
 ```
 
 The checked chat/session fixture reports the chat surface as blocked,
@@ -307,6 +315,14 @@ disabled, blocked, inactive, or unavailable until readiness evidence, model
 load evidence, a reviewed local session store, and explicit export/redaction
 rules exist. It does not read or write manifests, transcripts, summaries,
 prompts, responses, or model paths.
+
+The chat readiness fixture defines the readiness checklist and recovery
+action boundary for the standalone chat surface. It records local fixture
+availability, target model display, model assets, runtime readiness, device
+session state, chat runtime state, session-store state, and no-provider
+mode as deterministic data. Recovery actions remain disabled or local data
+only; the fixture does not read prompts, model assets, paths, manifests,
+transcripts, summaries, or logs.
 
 The preview command renders that same contract as a deterministic
 terminal chat surface sketch with disabled controls, blocked reasons, and

--- a/contracts/chat_readiness_contract.py
+++ b/contracts/chat_readiness_contract.py
@@ -1,0 +1,438 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Data-only chat readiness contract for the planned launcher UI.
+
+The contract describes the readiness checks, blocked reasons, and recovery
+actions that gate the standalone chat surface. It does not read prompts, load
+models, start runtime code, touch KV260 hardware, call providers, invoke
+pccx-lab, or read/write artifacts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import sys
+
+
+SCHEMA_VERSION = "pccx.chatReadiness.v0"
+
+CHAT_READINESS_FIELDS = (
+    "schemaVersion",
+    "readinessId",
+    "fixtureVersion",
+    "lastUpdatedSource",
+    "targetDevice",
+    "targetBoard",
+    "targetModel",
+    "overallState",
+    "inputReadinessState",
+    "sendReadinessState",
+    "recoveryState",
+    "evidenceState",
+    "parentChatSessionRef",
+    "chatModelStatusRef",
+    "chatSessionLifecycleRef",
+    "readinessChecks",
+    "errorTaxonomy",
+    "recoveryActions",
+    "handoffRefs",
+    "safetyFlags",
+    "limitations",
+    "issueRefs",
+)
+
+READINESS_CHECK_FIELDS = (
+    "checkId",
+    "label",
+    "state",
+    "severity",
+    "summary",
+    "requiredBefore",
+    "displayPolicy",
+)
+
+ERROR_TAXONOMY_FIELDS = (
+    "errorId",
+    "state",
+    "severity",
+    "userMessage",
+    "diagnosticHint",
+    "recoveryActionId",
+    "contentPolicy",
+)
+
+RECOVERY_ACTION_FIELDS = (
+    "actionId",
+    "label",
+    "state",
+    "enabled",
+    "userAction",
+    "launcherAction",
+    "requiredEvidence",
+    "sideEffectPolicy",
+)
+
+HANDOFF_REF_FIELDS = (
+    "refId",
+    "schemaVersion",
+    "fixturePath",
+    "state",
+    "summary",
+)
+
+CHAT_READINESS_STATE_VALUES = (
+    "available_as_data",
+    "blocked",
+    "disabled",
+    "external_not_configured",
+    "inactive",
+    "not_configured",
+    "not_loaded",
+    "not_started",
+    "not_used",
+    "placeholder",
+    "planned",
+    "requires_evidence",
+    "target_selected",
+    "unavailable",
+)
+
+_CHAT_READINESS = {
+    "schemaVersion": SCHEMA_VERSION,
+    "readinessId": "chat_readiness_gemma3n_e4b_kv260_placeholder",
+    "fixtureVersion": "chat-readiness.gemma3n-e4b-kv260.2026-05-04",
+    "lastUpdatedSource": "pccx_launcher_issue_9_chat_readiness_boundary_2026-05-04",
+    "targetDevice": "kv260",
+    "targetBoard": "xilinx_kria_kv260",
+    "targetModel": "gemma3n-e4b",
+    "overallState": "blocked",
+    "inputReadinessState": "available_as_data",
+    "sendReadinessState": "disabled",
+    "recoveryState": "requires_evidence",
+    "evidenceState": "blocked",
+    "parentChatSessionRef": "chat_session_gemma3n_e4b_kv260_placeholder",
+    "chatModelStatusRef": "chat_model_status_gemma3n_e4b_kv260_placeholder",
+    "chatSessionLifecycleRef": "chat_session_lifecycle_gemma3n_e4b_kv260_placeholder",
+    "readinessChecks": [
+        {
+            "checkId": "chat_surface_fixture",
+            "label": "chat surface fixture",
+            "state": "available_as_data",
+            "severity": "info",
+            "summary": "The checked chat/session fixture can be rendered as local data only.",
+            "requiredBefore": "surface_preview_rendered",
+            "displayPolicy": "show local fixture availability without accepting prompts",
+        },
+        {
+            "checkId": "model_target",
+            "label": "model target",
+            "state": "target_selected",
+            "severity": "info",
+            "summary": "Gemma 3N E4B is selected as a planned target descriptor.",
+            "requiredBefore": "model_status_displayed",
+            "displayPolicy": "show target label without model paths",
+        },
+        {
+            "checkId": "model_assets",
+            "label": "model assets",
+            "state": "external_not_configured",
+            "severity": "blocked",
+            "summary": "Model assets are external and no reviewed local asset input boundary exists.",
+            "requiredBefore": "model_load_enabled",
+            "displayPolicy": "show blocked state without filenames or paths",
+        },
+        {
+            "checkId": "runtime_readiness",
+            "label": "runtime readiness",
+            "state": "blocked",
+            "severity": "blocked",
+            "summary": "Runtime readiness remains blocked and not yet evidence-backed.",
+            "requiredBefore": "send_message_enabled",
+            "displayPolicy": "show conservative readiness summary only",
+        },
+        {
+            "checkId": "device_session",
+            "label": "device session",
+            "state": "inactive",
+            "severity": "blocked",
+            "summary": "No KV260 target session exists in this fixture.",
+            "requiredBefore": "runtime_session_started",
+            "displayPolicy": "show inactive state without probing hardware",
+        },
+        {
+            "checkId": "chat_runtime",
+            "label": "chat runtime",
+            "state": "not_started",
+            "severity": "blocked",
+            "summary": "No local chat runtime has been implemented or started.",
+            "requiredBefore": "assistant_response_available",
+            "displayPolicy": "show blocked state without executing runtime code",
+        },
+        {
+            "checkId": "session_store",
+            "label": "session store",
+            "state": "not_configured",
+            "severity": "blocked",
+            "summary": "No reviewed local session store or retention policy exists.",
+            "requiredBefore": "session_restore_or_export_enabled",
+            "displayPolicy": "show unavailable storage state without reading artifacts",
+        },
+        {
+            "checkId": "provider_mode",
+            "label": "provider mode",
+            "state": "not_used",
+            "severity": "info",
+            "summary": "External provider state is not used for this local launcher boundary.",
+            "requiredBefore": "core_chat_available",
+            "displayPolicy": "show no-provider state without provider configuration",
+        },
+    ],
+    "errorTaxonomy": [
+        {
+            "errorId": "runtime_not_ready",
+            "state": "blocked",
+            "severity": "blocked",
+            "userMessage": "Local chat is blocked until runtime readiness evidence exists.",
+            "diagnosticHint": "Review the runtime readiness data contract before enabling send.",
+            "recoveryActionId": "review_runtime_readiness",
+            "contentPolicy": "no_prompt_response_or_log_content",
+        },
+        {
+            "errorId": "model_assets_missing",
+            "state": "external_not_configured",
+            "severity": "blocked",
+            "userMessage": "Model assets are not configured by this launcher fixture.",
+            "diagnosticHint": "A future reviewed asset input boundary must redact local paths.",
+            "recoveryActionId": "configure_model_assets_future",
+            "contentPolicy": "no_model_paths_or_weight_names",
+        },
+        {
+            "errorId": "device_session_absent",
+            "state": "inactive",
+            "severity": "blocked",
+            "userMessage": "No target device session is active.",
+            "diagnosticHint": "Use device/session status data only; this fixture does not probe hardware.",
+            "recoveryActionId": "review_device_session_status",
+            "contentPolicy": "no_serial_ssh_or_network_output",
+        },
+        {
+            "errorId": "chat_runtime_absent",
+            "state": "not_started",
+            "severity": "blocked",
+            "userMessage": "No local chat runtime is available for assistant responses.",
+            "diagnosticHint": "Runtime execution requires a separate reviewed implementation boundary.",
+            "recoveryActionId": "wait_for_runtime_boundary",
+            "contentPolicy": "no_generated_response_content",
+        },
+        {
+            "errorId": "session_store_absent",
+            "state": "not_configured",
+            "severity": "blocked",
+            "userMessage": "Session restore and export are unavailable.",
+            "diagnosticHint": "A future local session store must define retention and redaction rules.",
+            "recoveryActionId": "review_session_store_policy",
+            "contentPolicy": "no_manifest_transcript_or_summary_content",
+        },
+    ],
+    "recoveryActions": [
+        {
+            "actionId": "review_runtime_readiness",
+            "label": "review runtime readiness",
+            "state": "available_as_data",
+            "enabled": False,
+            "userAction": "Review the checked runtime readiness summary.",
+            "launcherAction": "Render local readiness data only.",
+            "requiredEvidence": [
+                "runtime_readiness_fixture_available",
+            ],
+            "sideEffectPolicy": "read_only_data",
+        },
+        {
+            "actionId": "configure_model_assets_future",
+            "label": "configure model assets",
+            "state": "blocked",
+            "enabled": False,
+            "userAction": "Provide model assets only after a reviewed local input boundary exists.",
+            "launcherAction": "Do not read or echo local asset paths.",
+            "requiredEvidence": [
+                "local_model_asset_input_boundary_reviewed",
+                "redaction_policy_reviewed",
+            ],
+            "sideEffectPolicy": "no_artifact_read_no_write",
+        },
+        {
+            "actionId": "review_device_session_status",
+            "label": "review device session status",
+            "state": "available_as_data",
+            "enabled": False,
+            "userAction": "Review target status as deterministic local fixture data.",
+            "launcherAction": "Render the checked device/session status fixture.",
+            "requiredEvidence": [
+                "device_session_fixture_available",
+            ],
+            "sideEffectPolicy": "read_only_data",
+        },
+        {
+            "actionId": "wait_for_runtime_boundary",
+            "label": "wait for runtime boundary",
+            "state": "requires_evidence",
+            "enabled": False,
+            "userAction": "Keep send disabled until a runtime boundary is reviewed.",
+            "launcherAction": "Refuse runtime execution from this fixture.",
+            "requiredEvidence": [
+                "runtime_boundary_reviewed",
+                "model_load_evidence_available",
+                "device_session_evidence_available",
+            ],
+            "sideEffectPolicy": "no_runtime_execution",
+        },
+        {
+            "actionId": "review_session_store_policy",
+            "label": "review session store policy",
+            "state": "planned",
+            "enabled": False,
+            "userAction": "Enable restore or export only after explicit retention rules exist.",
+            "launcherAction": "Do not read, write, or summarize session artifacts.",
+            "requiredEvidence": [
+                "session_store_boundary_reviewed",
+                "summary_redaction_policy_reviewed",
+            ],
+            "sideEffectPolicy": "no_artifact_read_no_write",
+        },
+    ],
+    "handoffRefs": [
+        {
+            "refId": "chat_session",
+            "schemaVersion": "pccx.chatSession.v0",
+            "fixturePath": "contracts/fixtures/chat-session.gemma3n-e4b-kv260-placeholder.json",
+            "state": "available_as_data",
+            "summary": "Base chat/session state is consumed as local data only.",
+        },
+        {
+            "refId": "chat_model_status",
+            "schemaVersion": "pccx.chatModelStatus.v0",
+            "fixturePath": "contracts/fixtures/chat-model-status.gemma3n-e4b-kv260-placeholder.json",
+            "state": "available_as_data",
+            "summary": "Model display status is consumed as local data only.",
+        },
+        {
+            "refId": "chat_session_lifecycle",
+            "schemaVersion": "pccx.chatSessionLifecycle.v0",
+            "fixturePath": "contracts/fixtures/chat-session-lifecycle.gemma3n-e4b-kv260-placeholder.json",
+            "state": "blocked",
+            "summary": "Session lifecycle state remains disabled or blocked.",
+        },
+        {
+            "refId": "runtime_readiness",
+            "schemaVersion": "pccx.runtimeReadiness.v0",
+            "fixturePath": "contracts/fixtures/runtime-readiness.gemma3n-e4b-kv260.json",
+            "state": "blocked",
+            "summary": "Runtime readiness is consumed as local data only.",
+        },
+        {
+            "refId": "device_session_status",
+            "schemaVersion": "pccx.deviceSessionStatus.v0",
+            "fixturePath": "contracts/fixtures/device-session-status.gemma3n-e4b-kv260.json",
+            "state": "available_as_data",
+            "summary": "Device/session status is consumed as local data only.",
+        },
+    ],
+    "safetyFlags": {
+        "dataOnly": True,
+        "readOnly": True,
+        "deterministic": True,
+        "readinessDisplayOnly": True,
+        "writesArtifacts": False,
+        "readsArtifacts": False,
+        "promptContentIncluded": False,
+        "responseContentIncluded": False,
+        "transcriptPersistence": False,
+        "sessionPersistence": False,
+        "modelAssetPathsIncluded": False,
+        "modelWeightPathsIncluded": False,
+        "modelLoadAttempted": False,
+        "modelLoaded": False,
+        "modelExecution": False,
+        "runtimeExecution": False,
+        "responseGenerated": False,
+        "touchesHardware": False,
+        "kv260Access": False,
+        "opensSerialPort": False,
+        "networkCalls": False,
+        "networkScan": False,
+        "sshExecution": False,
+        "providerCalls": False,
+        "cloudCalls": False,
+        "privatePathsIncluded": False,
+        "secretsIncluded": False,
+        "tokensIncluded": False,
+        "generatedBlobsIncluded": False,
+        "hardwareDumpsIncluded": False,
+        "telemetry": False,
+        "automaticUpload": False,
+        "writeBack": False,
+        "executesPccxLab": False,
+        "executesSystemverilogIde": False,
+        "mcpServerImplemented": False,
+        "lspImplemented": False,
+        "stableApiAbiClaim": False,
+    },
+    "limitations": [
+        "Data-only chat readiness fixture; no readiness check executes runtime code.",
+        "No prompts, responses, transcripts, model paths, generated artifacts, private paths, secrets, or tokens are stored.",
+        "No KV260 hardware access, serial access, SSH execution, network call, provider call, telemetry, upload, or write-back is performed.",
+        "Send controls remain disabled until runtime readiness, model-load, device-session, and local session evidence are available.",
+        "This is not a release, tag, versioned compatibility commitment, MCP, LSP, IDE, marketplace, or telemetry implementation.",
+    ],
+    "issueRefs": [
+        "pccxai/pccx-llm-launcher#9",
+    ],
+}
+
+
+def create_gemma3n_e4b_kv260_chat_readiness() -> dict:
+    """Return the checked Gemma 3N E4B plus KV260 chat readiness fixture."""
+    return copy.deepcopy(_CHAT_READINESS)
+
+
+def chat_readiness_json(status: dict | None = None) -> str:
+    """Render a deterministic JSON representation."""
+    return json.dumps(
+        status
+        if status is not None
+        else create_gemma3n_e4b_kv260_chat_readiness(),
+        indent=2,
+        sort_keys=True,
+    ) + "\n"
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Print data-only chat readiness JSON.",
+    )
+    parser.add_argument(
+        "--model",
+        default="gemma3n-e4b",
+        choices=("gemma3n-e4b",),
+        help="model descriptor target",
+    )
+    parser.add_argument(
+        "--target",
+        default="kv260",
+        choices=("kv260",),
+        help="target board/device",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parse_args(sys.argv[1:] if argv is None else argv)
+    sys.stdout.write(chat_readiness_json())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contracts/fixtures/chat-readiness.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-readiness.gemma3n-e4b-kv260-placeholder.json
@@ -1,0 +1,291 @@
+{
+  "chatModelStatusRef": "chat_model_status_gemma3n_e4b_kv260_placeholder",
+  "chatSessionLifecycleRef": "chat_session_lifecycle_gemma3n_e4b_kv260_placeholder",
+  "errorTaxonomy": [
+    {
+      "contentPolicy": "no_prompt_response_or_log_content",
+      "diagnosticHint": "Review the runtime readiness data contract before enabling send.",
+      "errorId": "runtime_not_ready",
+      "recoveryActionId": "review_runtime_readiness",
+      "severity": "blocked",
+      "state": "blocked",
+      "userMessage": "Local chat is blocked until runtime readiness evidence exists."
+    },
+    {
+      "contentPolicy": "no_model_paths_or_weight_names",
+      "diagnosticHint": "A future reviewed asset input boundary must redact local paths.",
+      "errorId": "model_assets_missing",
+      "recoveryActionId": "configure_model_assets_future",
+      "severity": "blocked",
+      "state": "external_not_configured",
+      "userMessage": "Model assets are not configured by this launcher fixture."
+    },
+    {
+      "contentPolicy": "no_serial_ssh_or_network_output",
+      "diagnosticHint": "Use device/session status data only; this fixture does not probe hardware.",
+      "errorId": "device_session_absent",
+      "recoveryActionId": "review_device_session_status",
+      "severity": "blocked",
+      "state": "inactive",
+      "userMessage": "No target device session is active."
+    },
+    {
+      "contentPolicy": "no_generated_response_content",
+      "diagnosticHint": "Runtime execution requires a separate reviewed implementation boundary.",
+      "errorId": "chat_runtime_absent",
+      "recoveryActionId": "wait_for_runtime_boundary",
+      "severity": "blocked",
+      "state": "not_started",
+      "userMessage": "No local chat runtime is available for assistant responses."
+    },
+    {
+      "contentPolicy": "no_manifest_transcript_or_summary_content",
+      "diagnosticHint": "A future local session store must define retention and redaction rules.",
+      "errorId": "session_store_absent",
+      "recoveryActionId": "review_session_store_policy",
+      "severity": "blocked",
+      "state": "not_configured",
+      "userMessage": "Session restore and export are unavailable."
+    }
+  ],
+  "evidenceState": "blocked",
+  "fixtureVersion": "chat-readiness.gemma3n-e4b-kv260.2026-05-04",
+  "handoffRefs": [
+    {
+      "fixturePath": "contracts/fixtures/chat-session.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_session",
+      "schemaVersion": "pccx.chatSession.v0",
+      "state": "available_as_data",
+      "summary": "Base chat/session state is consumed as local data only."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-model-status.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_model_status",
+      "schemaVersion": "pccx.chatModelStatus.v0",
+      "state": "available_as_data",
+      "summary": "Model display status is consumed as local data only."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-session-lifecycle.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_session_lifecycle",
+      "schemaVersion": "pccx.chatSessionLifecycle.v0",
+      "state": "blocked",
+      "summary": "Session lifecycle state remains disabled or blocked."
+    },
+    {
+      "fixturePath": "contracts/fixtures/runtime-readiness.gemma3n-e4b-kv260.json",
+      "refId": "runtime_readiness",
+      "schemaVersion": "pccx.runtimeReadiness.v0",
+      "state": "blocked",
+      "summary": "Runtime readiness is consumed as local data only."
+    },
+    {
+      "fixturePath": "contracts/fixtures/device-session-status.gemma3n-e4b-kv260.json",
+      "refId": "device_session_status",
+      "schemaVersion": "pccx.deviceSessionStatus.v0",
+      "state": "available_as_data",
+      "summary": "Device/session status is consumed as local data only."
+    }
+  ],
+  "inputReadinessState": "available_as_data",
+  "issueRefs": [
+    "pccxai/pccx-llm-launcher#9"
+  ],
+  "lastUpdatedSource": "pccx_launcher_issue_9_chat_readiness_boundary_2026-05-04",
+  "limitations": [
+    "Data-only chat readiness fixture; no readiness check executes runtime code.",
+    "No prompts, responses, transcripts, model paths, generated artifacts, private paths, secrets, or tokens are stored.",
+    "No KV260 hardware access, serial access, SSH execution, network call, provider call, telemetry, upload, or write-back is performed.",
+    "Send controls remain disabled until runtime readiness, model-load, device-session, and local session evidence are available.",
+    "This is not a release, tag, versioned compatibility commitment, MCP, LSP, IDE, marketplace, or telemetry implementation."
+  ],
+  "overallState": "blocked",
+  "parentChatSessionRef": "chat_session_gemma3n_e4b_kv260_placeholder",
+  "readinessChecks": [
+    {
+      "checkId": "chat_surface_fixture",
+      "displayPolicy": "show local fixture availability without accepting prompts",
+      "label": "chat surface fixture",
+      "requiredBefore": "surface_preview_rendered",
+      "severity": "info",
+      "state": "available_as_data",
+      "summary": "The checked chat/session fixture can be rendered as local data only."
+    },
+    {
+      "checkId": "model_target",
+      "displayPolicy": "show target label without model paths",
+      "label": "model target",
+      "requiredBefore": "model_status_displayed",
+      "severity": "info",
+      "state": "target_selected",
+      "summary": "Gemma 3N E4B is selected as a planned target descriptor."
+    },
+    {
+      "checkId": "model_assets",
+      "displayPolicy": "show blocked state without filenames or paths",
+      "label": "model assets",
+      "requiredBefore": "model_load_enabled",
+      "severity": "blocked",
+      "state": "external_not_configured",
+      "summary": "Model assets are external and no reviewed local asset input boundary exists."
+    },
+    {
+      "checkId": "runtime_readiness",
+      "displayPolicy": "show conservative readiness summary only",
+      "label": "runtime readiness",
+      "requiredBefore": "send_message_enabled",
+      "severity": "blocked",
+      "state": "blocked",
+      "summary": "Runtime readiness remains blocked and not yet evidence-backed."
+    },
+    {
+      "checkId": "device_session",
+      "displayPolicy": "show inactive state without probing hardware",
+      "label": "device session",
+      "requiredBefore": "runtime_session_started",
+      "severity": "blocked",
+      "state": "inactive",
+      "summary": "No KV260 target session exists in this fixture."
+    },
+    {
+      "checkId": "chat_runtime",
+      "displayPolicy": "show blocked state without executing runtime code",
+      "label": "chat runtime",
+      "requiredBefore": "assistant_response_available",
+      "severity": "blocked",
+      "state": "not_started",
+      "summary": "No local chat runtime has been implemented or started."
+    },
+    {
+      "checkId": "session_store",
+      "displayPolicy": "show unavailable storage state without reading artifacts",
+      "label": "session store",
+      "requiredBefore": "session_restore_or_export_enabled",
+      "severity": "blocked",
+      "state": "not_configured",
+      "summary": "No reviewed local session store or retention policy exists."
+    },
+    {
+      "checkId": "provider_mode",
+      "displayPolicy": "show no-provider state without provider configuration",
+      "label": "provider mode",
+      "requiredBefore": "core_chat_available",
+      "severity": "info",
+      "state": "not_used",
+      "summary": "External provider state is not used for this local launcher boundary."
+    }
+  ],
+  "readinessId": "chat_readiness_gemma3n_e4b_kv260_placeholder",
+  "recoveryActions": [
+    {
+      "actionId": "review_runtime_readiness",
+      "enabled": false,
+      "label": "review runtime readiness",
+      "launcherAction": "Render local readiness data only.",
+      "requiredEvidence": [
+        "runtime_readiness_fixture_available"
+      ],
+      "sideEffectPolicy": "read_only_data",
+      "state": "available_as_data",
+      "userAction": "Review the checked runtime readiness summary."
+    },
+    {
+      "actionId": "configure_model_assets_future",
+      "enabled": false,
+      "label": "configure model assets",
+      "launcherAction": "Do not read or echo local asset paths.",
+      "requiredEvidence": [
+        "local_model_asset_input_boundary_reviewed",
+        "redaction_policy_reviewed"
+      ],
+      "sideEffectPolicy": "no_artifact_read_no_write",
+      "state": "blocked",
+      "userAction": "Provide model assets only after a reviewed local input boundary exists."
+    },
+    {
+      "actionId": "review_device_session_status",
+      "enabled": false,
+      "label": "review device session status",
+      "launcherAction": "Render the checked device/session status fixture.",
+      "requiredEvidence": [
+        "device_session_fixture_available"
+      ],
+      "sideEffectPolicy": "read_only_data",
+      "state": "available_as_data",
+      "userAction": "Review target status as deterministic local fixture data."
+    },
+    {
+      "actionId": "wait_for_runtime_boundary",
+      "enabled": false,
+      "label": "wait for runtime boundary",
+      "launcherAction": "Refuse runtime execution from this fixture.",
+      "requiredEvidence": [
+        "runtime_boundary_reviewed",
+        "model_load_evidence_available",
+        "device_session_evidence_available"
+      ],
+      "sideEffectPolicy": "no_runtime_execution",
+      "state": "requires_evidence",
+      "userAction": "Keep send disabled until a runtime boundary is reviewed."
+    },
+    {
+      "actionId": "review_session_store_policy",
+      "enabled": false,
+      "label": "review session store policy",
+      "launcherAction": "Do not read, write, or summarize session artifacts.",
+      "requiredEvidence": [
+        "session_store_boundary_reviewed",
+        "summary_redaction_policy_reviewed"
+      ],
+      "sideEffectPolicy": "no_artifact_read_no_write",
+      "state": "planned",
+      "userAction": "Enable restore or export only after explicit retention rules exist."
+    }
+  ],
+  "recoveryState": "requires_evidence",
+  "safetyFlags": {
+    "automaticUpload": false,
+    "cloudCalls": false,
+    "dataOnly": true,
+    "deterministic": true,
+    "executesPccxLab": false,
+    "executesSystemverilogIde": false,
+    "generatedBlobsIncluded": false,
+    "hardwareDumpsIncluded": false,
+    "kv260Access": false,
+    "lspImplemented": false,
+    "mcpServerImplemented": false,
+    "modelAssetPathsIncluded": false,
+    "modelExecution": false,
+    "modelLoadAttempted": false,
+    "modelLoaded": false,
+    "modelWeightPathsIncluded": false,
+    "networkCalls": false,
+    "networkScan": false,
+    "opensSerialPort": false,
+    "privatePathsIncluded": false,
+    "promptContentIncluded": false,
+    "providerCalls": false,
+    "readOnly": true,
+    "readinessDisplayOnly": true,
+    "readsArtifacts": false,
+    "responseContentIncluded": false,
+    "responseGenerated": false,
+    "runtimeExecution": false,
+    "secretsIncluded": false,
+    "sessionPersistence": false,
+    "sshExecution": false,
+    "stableApiAbiClaim": false,
+    "telemetry": false,
+    "tokensIncluded": false,
+    "touchesHardware": false,
+    "transcriptPersistence": false,
+    "writeBack": false,
+    "writesArtifacts": false
+  },
+  "schemaVersion": "pccx.chatReadiness.v0",
+  "sendReadinessState": "disabled",
+  "targetBoard": "xilinx_kria_kv260",
+  "targetDevice": "kv260",
+  "targetModel": "gemma3n-e4b"
+}

--- a/docs/STANDALONE_CHAT_SESSION_CONTRACT.md
+++ b/docs/STANDALONE_CHAT_SESSION_CONTRACT.md
@@ -11,18 +11,23 @@ The implementation lives in:
 - `contracts/chat_session_contract.py`
 - `contracts/chat_model_status_contract.py`
 - `contracts/chat_session_lifecycle_contract.py`
+- `contracts/chat_readiness_contract.py`
 - `contracts/fixtures/chat-session.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-model-status.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-session-lifecycle.gemma3n-e4b-kv260-placeholder.json`
+- `contracts/fixtures/chat-readiness.gemma3n-e4b-kv260-placeholder.json`
 - `scripts/chat-session-stub.sh`
 - `scripts/chat-model-status-stub.sh`
 - `scripts/chat-session-lifecycle-stub.sh`
+- `scripts/chat-readiness-stub.sh`
 - `scripts/chat-surface-preview.sh`
 - `scripts/tests/chat_session_contract_test.py`
 - `scripts/tests/chat_model_status_contract_test.py`
 - `scripts/tests/chat_session_lifecycle_contract_test.py`
+- `scripts/tests/chat_readiness_contract_test.py`
 - `scripts/tests/chat_surface_preview_test.py`
 - `scripts/tests/status-chat-model-status.sh`
+- `scripts/tests/status-chat-readiness.sh`
 
 ## What Is Implemented
 
@@ -70,6 +75,22 @@ store, and explicit export/redaction rules exist. The fixture does not
 read or write manifests, transcripts, summaries, prompts, responses, or
 model paths.
 
+The chat readiness fixture records the checklist and recovery-action
+boundary used to decide whether the standalone chat surface can move
+beyond preview state:
+
+```bash
+bash scripts/chat-readiness-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/status-stub.sh --include-chat-readiness
+```
+
+It records local fixture availability, target model display, model asset
+state, runtime readiness, device session state, chat runtime state,
+session-store state, and no-provider mode. Recovery actions are disabled,
+blocked, planned, or local data only. The fixture does not read prompts,
+model assets, paths, manifests, transcripts, summaries, logs, device
+state, or provider configuration.
+
 The terminal preview command renders the same checked contract as a
 read-only chat surface sketch:
 
@@ -116,6 +137,24 @@ content:
 - `unavailable`: no prior local session can be restored
 - `available_as_data`: referenced local fixture shape is available as data only
 
+The readiness states keep send-control gating separate from model-status
+display and lifecycle operations:
+
+- `available_as_data`: referenced local fixture data is available without
+  executing anything
+- `blocked`: a required evidence item or reviewed boundary is missing
+- `disabled`: a UI command is intentionally unavailable
+- `external_not_configured`: user-provided model assets are not configured
+- `inactive`: no target device or runtime session exists
+- `not_configured`: no local store or retention policy exists
+- `not_loaded`: model assets are not loaded
+- `not_started`: no local chat runtime has started
+- `not_used`: external provider state is not part of this boundary
+- `planned`: described for a future reviewed boundary
+- `requires_evidence`: future enablement requires evidence first
+- `target_selected`: target descriptor data can be displayed
+- `unavailable`: output or operation state is unavailable
+
 ## Coordination Boundary
 
 The standalone chat surface depends on the existing launcher model
@@ -124,6 +163,9 @@ model-status contract adds reviewable display rows for model-load state.
 The lifecycle contract adds a reviewable session-management shape, but
 these contracts do not add runtime execution, model loading, provider
 calls, persistence, target access, artifact reads, or artifact writes.
+The readiness contract ties those display and lifecycle states into a
+single checklist and recovery-action view without enabling any send,
+load, restore, or export action.
 
 pccx-lab remains a separate CLI/core diagnostics and verification
 backend. systemverilog-ide may consume launcher data later as read-only
@@ -136,6 +178,7 @@ This chat/session surface does not add:
 - model execution or generated responses
 - prompt, response, or transcript persistence
 - session creation, restore, clear, close, or export behavior
+- readiness recovery execution
 - manifest, transcript, summary, or lifecycle artifact reads or writes
 - model loading or model weight paths
 - KV260 runtime execution

--- a/scripts/chat-readiness-stub.sh
+++ b/scripts/chat-readiness-stub.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+# scripts/chat-readiness-stub.sh - print data-only chat readiness JSON.
+#
+# This script does not read prompts, load model assets, start runtime code,
+# touch KV260 hardware, call providers, read/write artifacts, or invoke
+# pccx-lab.
+
+set -eu
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+
+MODEL="gemma3n-e4b"
+TARGET="kv260"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --model)
+            MODEL="${2:-}"
+            if [ -z "$MODEL" ]; then
+                printf '[ERROR] --model requires an argument\n' >&2
+                exit 2
+            fi
+            shift 2
+            ;;
+        --target)
+            TARGET="${2:-}"
+            if [ -z "$TARGET" ]; then
+                printf '[ERROR] --target requires an argument\n' >&2
+                exit 2
+            fi
+            shift 2
+            ;;
+        *)
+            printf '[ERROR] unknown option: %s\n' "$1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+exec python3 "$ROOT_DIR/contracts/chat_readiness_contract.py" \
+    --model "$MODEL" \
+    --target "$TARGET"

--- a/scripts/status-stub.sh
+++ b/scripts/status-stub.sh
@@ -16,6 +16,9 @@
 # Chat model status display plan (explicit opt-in, read-only local data):
 #   --include-chat-model-status
 #
+# Chat readiness checks and recovery actions (explicit opt-in, read-only local data):
+#   --include-chat-readiness
+#
 # pccx-lab backend (explicit opt-in):
 #   --backend pccx-lab        call pccx-lab status --format json
 #   PCCX_LAB_BIN              override path to pccx-lab binary (takes priority over PATH)
@@ -35,6 +38,98 @@ INCLUDE_RUNTIME_READINESS="0"
 INCLUDE_DEVICE_SESSION="0"
 INCLUDE_CHAT_SESSION="0"
 INCLUDE_CHAT_MODEL_STATUS="0"
+INCLUDE_CHAT_READINESS="0"
+
+print_chat_readiness_summary() {
+    SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+    ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+    CHAT_READINESS_STUB="$ROOT_DIR/scripts/chat-readiness-stub.sh"
+
+    if [ ! -f "$CHAT_READINESS_STUB" ]; then
+        ERROR "chat readiness stub not found: $CHAT_READINESS_STUB"
+        return 1
+    fi
+
+    if ! CHAT_READINESS_JSON="$(bash "$CHAT_READINESS_STUB" --model gemma3n-e4b --target kv260 2>&1)"; then
+        ERROR "chat readiness stub failed"
+        printf '%s\n' "$CHAT_READINESS_JSON" >&2
+        return 1
+    fi
+
+    if ! CHAT_READINESS_SUMMARY="$(
+        printf '%s\n' "$CHAT_READINESS_JSON" | python3 -c '
+import json
+import sys
+
+data = json.load(sys.stdin)
+flags = data["safetyFlags"]
+checks = " ".join(
+    "{}={}".format(check["checkId"], check["state"])
+    for check in data["readinessChecks"]
+)
+errors = " ".join(
+    "{}={}".format(error["errorId"], error["state"])
+    for error in data["errorTaxonomy"]
+)
+actions = " ".join(
+    "{}={}".format(action["actionId"], action["state"])
+    for action in data["recoveryActions"]
+)
+
+def b(value):
+    return "true" if value else "false"
+
+print("[INFO]  source     : scripts/chat-readiness-stub.sh --model gemma3n-e4b --target kv260")
+print("[INFO]  boundary   : read-only data; no prompt/model/provider/hardware/lab/IDE execution")
+print("[INFO]  target     : {}".format(data["targetDevice"]))
+print("[INFO]  model      : {}".format(data["targetModel"]))
+print("[INFO]  overall    : {}".format(data["overallState"]))
+print("[INFO]  input      : {}".format(data["inputReadinessState"]))
+print("[INFO]  send       : {}".format(data["sendReadinessState"]))
+print("[INFO]  recovery   : {}".format(data["recoveryState"]))
+print("[INFO]  evidence   : {}".format(data["evidenceState"]))
+print("[INFO]  checks     : {}".format(checks))
+print("[INFO]  errors     : {}".format(errors))
+print("[INFO]  actions    : {}".format(actions))
+print(
+    "[INFO]  flags      : readOnly={} dataOnly={} deterministic={} "
+    "readinessDisplayOnly={} writesArtifacts={} readsArtifacts={} "
+    "promptContentIncluded={} responseContentIncluded={} sessionPersistence={} "
+    "modelLoadAttempted={} modelLoaded={} modelExecution={} runtimeExecution={} "
+    "responseGenerated={} kv260Access={} opensSerialPort={} networkCalls={} "
+    "sshExecution={} providerCalls={} cloudCalls={} executesPccxLab={}".format(
+        b(flags["readOnly"]),
+        b(flags["dataOnly"]),
+        b(flags["deterministic"]),
+        b(flags["readinessDisplayOnly"]),
+        b(flags["writesArtifacts"]),
+        b(flags["readsArtifacts"]),
+        b(flags["promptContentIncluded"]),
+        b(flags["responseContentIncluded"]),
+        b(flags["sessionPersistence"]),
+        b(flags["modelLoadAttempted"]),
+        b(flags["modelLoaded"]),
+        b(flags["modelExecution"]),
+        b(flags["runtimeExecution"]),
+        b(flags["responseGenerated"]),
+        b(flags["kv260Access"]),
+        b(flags["opensSerialPort"]),
+        b(flags["networkCalls"]),
+        b(flags["sshExecution"]),
+        b(flags["providerCalls"]),
+        b(flags["cloudCalls"]),
+        b(flags["executesPccxLab"]),
+    )
+)
+'
+    )"; then
+        ERROR "chat readiness JSON could not be summarized"
+        return 1
+    fi
+
+    HEAD "chat readiness"
+    printf '%s\n' "$CHAT_READINESS_SUMMARY"
+}
 
 print_chat_model_status_summary() {
     SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
@@ -397,6 +492,10 @@ while [ $# -gt 0 ]; do
             INCLUDE_CHAT_MODEL_STATUS="1"
             shift
             ;;
+        --include-chat-readiness)
+            INCLUDE_CHAT_READINESS="1"
+            shift
+            ;;
         --backend)
             BACKEND="${2:-}"
             if [ -z "$BACKEND" ]; then
@@ -412,8 +511,8 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-if [ -n "$BACKEND" ] && { [ "$INCLUDE_RUNTIME_READINESS" = "1" ] || [ "$INCLUDE_DEVICE_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SESSION" = "1" ] || [ "$INCLUDE_CHAT_MODEL_STATUS" = "1" ]; }; then
-    ERROR "--include-runtime-readiness, --include-device-session, --include-chat-session, and --include-chat-model-status are only supported in local scaffold mode"
+if [ -n "$BACKEND" ] && { [ "$INCLUDE_RUNTIME_READINESS" = "1" ] || [ "$INCLUDE_DEVICE_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SESSION" = "1" ] || [ "$INCLUDE_CHAT_MODEL_STATUS" = "1" ] || [ "$INCLUDE_CHAT_READINESS" = "1" ]; }; then
+    ERROR "--include-runtime-readiness, --include-device-session, --include-chat-session, --include-chat-model-status, and --include-chat-readiness are only supported in local scaffold mode"
     exit 1
 fi
 
@@ -430,6 +529,7 @@ if [ -z "$BACKEND" ]; then
     NOTE "device/session: opt-in via --include-device-session (read-only panel data)"
     NOTE "chat/session  : opt-in via --include-chat-session (read-only blocked chat and lifecycle data)"
     NOTE "chat model    : opt-in via --include-chat-model-status (read-only model status display data)"
+    NOTE "chat readiness: opt-in via --include-chat-readiness (read-only readiness and recovery data)"
     NOTE "editor bridge  : planned (VS Code / other IDEs)"
 
     if [ "$INCLUDE_CHAT_MODEL_STATUS" = "1" ]; then
@@ -440,6 +540,12 @@ if [ -z "$BACKEND" ]; then
 
     if [ "$INCLUDE_CHAT_SESSION" = "1" ]; then
         if ! print_chat_session_summary; then
+            exit 1
+        fi
+    fi
+
+    if [ "$INCLUDE_CHAT_READINESS" = "1" ]; then
+        if ! print_chat_readiness_summary; then
             exit 1
         fi
     fi

--- a/scripts/tests/chat_readiness_contract_test.py
+++ b/scripts/tests/chat_readiness_contract_test.py
@@ -1,0 +1,397 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Fixture tests for the standalone chat readiness contract."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "contracts" / "chat_readiness_contract.py"
+FIXTURE_PATH = (
+    ROOT
+    / "contracts"
+    / "fixtures"
+    / "chat-readiness.gemma3n-e4b-kv260-placeholder.json"
+)
+SCRIPT_PATH = ROOT / "scripts" / "chat-readiness-stub.sh"
+STATUS_TEST_PATH = ROOT / "scripts" / "tests" / "status-chat-readiness.sh"
+DOC_PATH = ROOT / "docs" / "STANDALONE_CHAT_SESSION_CONTRACT.md"
+README_PATH = ROOT / "README.md"
+TEST_PATH = Path(__file__).resolve()
+CI_PATH = ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location(
+        "chat_readiness_contract",
+        MODULE_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def flatten(value) -> str:
+    return json.dumps(value, sort_keys=True)
+
+
+def iter_state_values(value):
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            if key == "state" or key.endswith("State") or key.endswith("Status"):
+                yield nested
+            yield from iter_state_values(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            yield from iter_state_values(nested)
+
+
+def iter_keys(value):
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            yield key
+            yield from iter_keys(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            yield from iter_keys(nested)
+
+
+def assert_no_private_or_generated_data(text: str) -> None:
+    forbidden_patterns = [
+        r"/home/[^\s\"']+",
+        r"/Users/[^\s\"']+",
+        r"[A-Za-z]:\\Users\\",
+        r"\b(?:api[_-]?key|authorization|bearer|client[_-]?secret|password|private[_-]?key|secret|token)\b\s*[:=]",
+        r"\.(?:gguf|safetensors|ckpt|pt|pth|onnx)\b",
+        r"(?:weights|model_weights|model-cache)/(?:[^\"'\s]+)",
+        r"(?:raw[_-]?full[_-]?logs|hardware[_-]?dump|generated[_-]?blob)\s*[:=]",
+    ]
+    for pattern in forbidden_patterns:
+        assert not re.search(pattern, text, re.IGNORECASE), pattern
+
+
+def assert_no_runtime_implementation_terms(source: str) -> None:
+    forbidden = [
+        "subprocess",
+        "os.system",
+        "popen",
+        "socket",
+        "urllib",
+        "requests",
+        "http.client",
+        "openai",
+        "anthropic",
+        "gemini",
+        "modelcontextprotocol",
+        "websocket",
+        "xmutil",
+        "xrt-smi",
+        "lsusb",
+        "dmesg",
+    ]
+    lowered = source.lower()
+    for term in forbidden:
+        assert term not in lowered, term
+
+
+def assert_no_provider_configs(value) -> None:
+    forbidden_keys = {
+        "apiKey",
+        "accessToken",
+        "refreshToken",
+        "authorization",
+        "bearerToken",
+        "provider",
+        "providers",
+        "providerConfig",
+        "providerConfigs",
+    }
+    for key in iter_keys(value):
+        assert key not in forbidden_keys, key
+
+
+def assert_no_unsupported_claims(text: str) -> None:
+    literal_claims = [
+        "production-ready",
+        "marketplace-ready",
+        "stable API",
+        "stable ABI",
+        "KV260 inference works",
+        "Gemma 3N E4B runs on KV260",
+        "20 tok/s achieved",
+        "timing closed",
+        "bitstream ready",
+        "launcher executes pccx-lab",
+        "IDE controls launcher",
+        "AI provider integration is live",
+    ]
+    lowered = text.lower()
+    for claim in literal_claims:
+        assert claim.lower() not in lowered, claim
+
+    asserted_claim_patterns = [
+        r"\bMCP\s+(?:server|client)\s+(?:is\s+)?implemented\b",
+        r"\bLSP\s+(?:server|client)\s+(?:is\s+)?implemented\b",
+        r"\bAI\s+provider\s+(?:is\s+)?implemented\b",
+        r"\bKV260\s+run\s+(?:is\s+)?claimed\b",
+    ]
+    for pattern in asserted_claim_patterns:
+        assert not re.search(pattern, text, re.IGNORECASE), pattern
+
+
+def assert_no_chat_invocation_flags(source: str) -> None:
+    forbidden_patterns = [
+        r"--backend\s+pccx-lab",
+        r"\bPCCX_LAB_BIN\b",
+        r"\bpccx-lab\s+(?:status|diagnostics|validate)\b",
+        r"\bsystemverilog-ide\s+--",
+        r"\bsystemverilog-ide\s+(?:open|run|status|validate|launch)\b",
+        r"\b(?:curl|wget)\b",
+        r"\b(?:upload|telemetry|write-back)\s+(?:enabled|true)\b",
+    ]
+    for pattern in forbidden_patterns:
+        assert not re.search(pattern, source, re.IGNORECASE), pattern
+
+
+def test_chat_readiness_matches_fixture_and_is_deterministic() -> None:
+    module = load_module()
+    generated = module.create_gemma3n_e4b_kv260_chat_readiness()
+    fixture = json.loads(read_text(FIXTURE_PATH))
+
+    assert generated == fixture
+    assert module.chat_readiness_json(generated) == module.chat_readiness_json(generated)
+    assert module.chat_readiness_json(generated).endswith("\n")
+    assert json.loads(module.chat_readiness_json(generated)) == fixture
+
+
+def test_cli_stub_outputs_deterministic_json() -> None:
+    fixture = json.loads(read_text(FIXTURE_PATH))
+    command = [
+        "bash",
+        str(SCRIPT_PATH),
+        "--model",
+        "gemma3n-e4b",
+        "--target",
+        "kv260",
+    ]
+    first = subprocess.run(
+        command,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    second = subprocess.run(
+        command,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert first.stderr == ""
+    assert first.stdout == second.stdout
+    assert first.stdout.endswith("\n")
+    assert json.loads(first.stdout) == fixture
+
+
+def test_required_fields_and_allowed_states() -> None:
+    module = load_module()
+    readiness = module.create_gemma3n_e4b_kv260_chat_readiness()
+    allowed = set(module.CHAT_READINESS_STATE_VALUES)
+
+    assert tuple(readiness.keys()) == module.CHAT_READINESS_FIELDS
+    assert readiness["schemaVersion"] == "pccx.chatReadiness.v0"
+
+    states = list(iter_state_values(readiness))
+    assert states
+    for state in states:
+        assert state in allowed, state
+
+    for check in readiness["readinessChecks"]:
+        assert tuple(check.keys()) == module.READINESS_CHECK_FIELDS
+    for error in readiness["errorTaxonomy"]:
+        assert tuple(error.keys()) == module.ERROR_TAXONOMY_FIELDS
+    for action in readiness["recoveryActions"]:
+        assert tuple(action.keys()) == module.RECOVERY_ACTION_FIELDS
+    for ref in readiness["handoffRefs"]:
+        assert tuple(ref.keys()) == module.HANDOFF_REF_FIELDS
+
+
+def test_chat_readiness_covers_issue_9_readiness_boundary() -> None:
+    readiness = load_module().create_gemma3n_e4b_kv260_chat_readiness()
+    checks = {check["checkId"]: check for check in readiness["readinessChecks"]}
+    errors = {error["errorId"]: error for error in readiness["errorTaxonomy"]}
+    actions = {action["actionId"]: action for action in readiness["recoveryActions"]}
+    refs = {ref["refId"]: ref for ref in readiness["handoffRefs"]}
+
+    assert readiness["overallState"] == "blocked"
+    assert readiness["inputReadinessState"] == "available_as_data"
+    assert readiness["sendReadinessState"] == "disabled"
+    assert readiness["recoveryState"] == "requires_evidence"
+    assert readiness["evidenceState"] == "blocked"
+    assert set(checks) == {
+        "chat_surface_fixture",
+        "model_target",
+        "model_assets",
+        "runtime_readiness",
+        "device_session",
+        "chat_runtime",
+        "session_store",
+        "provider_mode",
+    }
+    assert checks["chat_surface_fixture"]["state"] == "available_as_data"
+    assert checks["model_target"]["state"] == "target_selected"
+    assert checks["model_assets"]["state"] == "external_not_configured"
+    assert checks["runtime_readiness"]["state"] == "blocked"
+    assert checks["device_session"]["state"] == "inactive"
+    assert checks["chat_runtime"]["state"] == "not_started"
+    assert checks["session_store"]["state"] == "not_configured"
+    assert checks["provider_mode"]["state"] == "not_used"
+    assert set(errors) == {
+        "runtime_not_ready",
+        "model_assets_missing",
+        "device_session_absent",
+        "chat_runtime_absent",
+        "session_store_absent",
+    }
+    assert set(actions) == {
+        "review_runtime_readiness",
+        "configure_model_assets_future",
+        "review_device_session_status",
+        "wait_for_runtime_boundary",
+        "review_session_store_policy",
+    }
+    for action in actions.values():
+        assert action["enabled"] is False
+    assert actions["wait_for_runtime_boundary"]["state"] == "requires_evidence"
+    assert set(refs) == {
+        "chat_session",
+        "chat_model_status",
+        "chat_session_lifecycle",
+        "runtime_readiness",
+        "device_session_status",
+    }
+
+
+def test_safety_flags_preserve_data_only_boundary() -> None:
+    readiness = load_module().create_gemma3n_e4b_kv260_chat_readiness()
+    flags = readiness["safetyFlags"]
+
+    assert flags["dataOnly"] is True
+    assert flags["readOnly"] is True
+    assert flags["deterministic"] is True
+    assert flags["readinessDisplayOnly"] is True
+    for name in [
+        "writesArtifacts",
+        "readsArtifacts",
+        "promptContentIncluded",
+        "responseContentIncluded",
+        "transcriptPersistence",
+        "sessionPersistence",
+        "modelAssetPathsIncluded",
+        "modelWeightPathsIncluded",
+        "modelLoadAttempted",
+        "modelLoaded",
+        "modelExecution",
+        "runtimeExecution",
+        "responseGenerated",
+        "touchesHardware",
+        "kv260Access",
+        "opensSerialPort",
+        "networkCalls",
+        "networkScan",
+        "sshExecution",
+        "providerCalls",
+        "cloudCalls",
+        "privatePathsIncluded",
+        "secretsIncluded",
+        "tokensIncluded",
+        "generatedBlobsIncluded",
+        "hardwareDumpsIncluded",
+        "telemetry",
+        "automaticUpload",
+        "writeBack",
+        "executesPccxLab",
+        "executesSystemverilogIde",
+        "mcpServerImplemented",
+        "lspImplemented",
+        "stableApiAbiClaim",
+    ]:
+        assert flags[name] is False, name
+
+
+def test_docs_and_sources_avoid_private_data_runtime_calls_or_overclaims() -> None:
+    module_source = read_text(MODULE_PATH)
+    script_source = read_text(SCRIPT_PATH)
+    status_test_source = read_text(STATUS_TEST_PATH)
+    readiness = load_module().create_gemma3n_e4b_kv260_chat_readiness()
+    scan_text = "\n".join([
+        read_text(FIXTURE_PATH),
+        read_text(DOC_PATH),
+        read_text(README_PATH),
+        flatten(readiness),
+        module_source,
+        script_source,
+        status_test_source,
+    ])
+    runtime_source = "\n".join([module_source, script_source])
+
+    assert_no_runtime_implementation_terms(runtime_source)
+    assert_no_private_or_generated_data(scan_text)
+    assert_no_provider_configs(readiness)
+    assert_no_unsupported_claims(scan_text)
+    assert_no_chat_invocation_flags(runtime_source)
+
+
+def test_source_headers_for_touched_code_files() -> None:
+    expected_headers = {
+        MODULE_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        SCRIPT_PATH: [
+            "#!/usr/bin/env bash",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        STATUS_TEST_PATH: [
+            "#!/usr/bin/env bash",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        TEST_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        CI_PATH: [
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+    }
+
+    for path, header in expected_headers.items():
+        assert read_text(path).splitlines()[: len(header)] == header, path
+
+
+test_chat_readiness_matches_fixture_and_is_deterministic()
+test_cli_stub_outputs_deterministic_json()
+test_required_fields_and_allowed_states()
+test_chat_readiness_covers_issue_9_readiness_boundary()
+test_safety_flags_preserve_data_only_boundary()
+test_docs_and_sources_avoid_private_data_runtime_calls_or_overclaims()
+test_source_headers_for_touched_code_files()
+
+print("chat readiness contract tests ok")

--- a/scripts/tests/status-chat-readiness.sh
+++ b/scripts/tests/status-chat-readiness.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+# scripts/tests/status-chat-readiness.sh - status chat readiness summary tests.
+#
+# Usage: bash scripts/tests/status-chat-readiness.sh [path/to/status-stub.sh]
+
+set -eu
+
+PASS() { printf '[PASS]  %s\n' "$*"; }
+FAIL() { printf '[FAIL]  %s\n' "$*" >&2; }
+HEAD() { printf '\n=== %s ===\n' "$*"; }
+
+STUB="${1:-scripts/status-stub.sh}"
+
+if [ ! -x "$STUB" ]; then
+    chmod +x "$STUB"
+fi
+
+contains() {
+    case "$1" in
+        *"$2"*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+require_contains() {
+    local output="$1"
+    local expected="$2"
+    if ! contains "$output" "$expected"; then
+        FAIL "expected output to contain: $expected"
+        printf '%s\n' "$output" >&2
+        exit 1
+    fi
+}
+
+require_not_contains() {
+    local output="$1"
+    local forbidden="$2"
+    if contains "$output" "$forbidden"; then
+        FAIL "output contained forbidden text: $forbidden"
+        printf '%s\n' "$output" >&2
+        exit 1
+    fi
+}
+
+HEAD "1: status can include chat readiness"
+OUTPUT="$("$STUB" --include-chat-readiness)"
+require_contains "$OUTPUT" "=== chat readiness ==="
+require_contains "$OUTPUT" "source     : scripts/chat-readiness-stub.sh --model gemma3n-e4b --target kv260"
+require_contains "$OUTPUT" "boundary   : read-only data; no prompt/model/provider/hardware/lab/IDE execution"
+require_contains "$OUTPUT" "target     : kv260"
+require_contains "$OUTPUT" "model      : gemma3n-e4b"
+require_contains "$OUTPUT" "overall    : blocked"
+require_contains "$OUTPUT" "input      : available_as_data"
+require_contains "$OUTPUT" "send       : disabled"
+require_contains "$OUTPUT" "recovery   : requires_evidence"
+require_contains "$OUTPUT" "evidence   : blocked"
+PASS "chat readiness section is present and conservative"
+
+HEAD "2: readiness checks and recovery actions stay non-executing"
+require_contains "$OUTPUT" "checks     : chat_surface_fixture=available_as_data"
+require_contains "$OUTPUT" "model_target=target_selected"
+require_contains "$OUTPUT" "model_assets=external_not_configured"
+require_contains "$OUTPUT" "runtime_readiness=blocked"
+require_contains "$OUTPUT" "device_session=inactive"
+require_contains "$OUTPUT" "chat_runtime=not_started"
+require_contains "$OUTPUT" "session_store=not_configured"
+require_contains "$OUTPUT" "provider_mode=not_used"
+require_contains "$OUTPUT" "errors     : runtime_not_ready=blocked"
+require_contains "$OUTPUT" "model_assets_missing=external_not_configured"
+require_contains "$OUTPUT" "device_session_absent=inactive"
+require_contains "$OUTPUT" "chat_runtime_absent=not_started"
+require_contains "$OUTPUT" "session_store_absent=not_configured"
+require_contains "$OUTPUT" "actions    : review_runtime_readiness=available_as_data"
+require_contains "$OUTPUT" "configure_model_assets_future=blocked"
+require_contains "$OUTPUT" "review_device_session_status=available_as_data"
+require_contains "$OUTPUT" "wait_for_runtime_boundary=requires_evidence"
+require_contains "$OUTPUT" "review_session_store_policy=planned"
+PASS "readiness checks, errors, and actions are summarized"
+
+HEAD "3: safety flags stay read-only and non-executing"
+require_contains "$OUTPUT" "readOnly=true"
+require_contains "$OUTPUT" "dataOnly=true"
+require_contains "$OUTPUT" "deterministic=true"
+require_contains "$OUTPUT" "readinessDisplayOnly=true"
+require_contains "$OUTPUT" "writesArtifacts=false"
+require_contains "$OUTPUT" "readsArtifacts=false"
+require_contains "$OUTPUT" "promptContentIncluded=false"
+require_contains "$OUTPUT" "responseContentIncluded=false"
+require_contains "$OUTPUT" "sessionPersistence=false"
+require_contains "$OUTPUT" "modelLoadAttempted=false"
+require_contains "$OUTPUT" "modelLoaded=false"
+require_contains "$OUTPUT" "modelExecution=false"
+require_contains "$OUTPUT" "runtimeExecution=false"
+require_contains "$OUTPUT" "responseGenerated=false"
+require_contains "$OUTPUT" "kv260Access=false"
+require_contains "$OUTPUT" "opensSerialPort=false"
+require_contains "$OUTPUT" "networkCalls=false"
+require_contains "$OUTPUT" "sshExecution=false"
+require_contains "$OUTPUT" "providerCalls=false"
+require_contains "$OUTPUT" "cloudCalls=false"
+require_contains "$OUTPUT" "executesPccxLab=false"
+PASS "execution-related flags remain false"
+
+HEAD "4: output is deterministic"
+OUTPUT_AGAIN="$("$STUB" --include-chat-readiness)"
+if [ "$OUTPUT" != "$OUTPUT_AGAIN" ]; then
+    FAIL "status chat readiness output changed between runs"
+    exit 1
+fi
+PASS "status chat readiness output is deterministic"
+
+HEAD "5: chat readiness option does not combine with pccx-lab backend"
+if "$STUB" --include-chat-readiness --backend pccx-lab >/dev/null 2>&1; then
+    FAIL "expected combined chat-readiness/backend mode to fail"
+    exit 1
+fi
+PASS "chat readiness remains separate from backend execution"
+
+HEAD "6: output avoids known overclaims"
+FORBIDDEN_PREFIX="KV260 inference"
+FORBIDDEN_CLAIM="${FORBIDDEN_PREFIX} works"
+require_not_contains "$OUTPUT" "$FORBIDDEN_CLAIM"
+THROUGHPUT_PREFIX="20 tok/s"
+THROUGHPUT_CLAIM="${THROUGHPUT_PREFIX} achieved"
+require_not_contains "$OUTPUT" "$THROUGHPUT_CLAIM"
+PASS "no chat readiness or throughput overclaim in status output"
+
+printf '\n[DONE]  all status-chat-readiness tests passed\n'


### PR DESCRIPTION
## Summary

- add a checked `pccx.chatReadiness.v0` contract and fixture for standalone chat readiness checks, error categories, and recovery actions
- add `chat-readiness-stub.sh` plus opt-in `status-stub.sh --include-chat-readiness` summary output
- document and test the boundary alongside the existing chat/session, lifecycle, and model-status surfaces

Refs #9.

## Validation

- `python3 -m py_compile contracts/*.py scripts/tests/*.py`
- `python3 scripts/tests/launcher_ide_contract_test.py`
- `python3 scripts/tests/model_runtime_descriptor_test.py`
- `python3 scripts/tests/diagnostics_handoff_contract_test.py`
- `python3 scripts/tests/device_session_status_contract_test.py`
- `python3 scripts/tests/runtime_readiness_contract_test.py`
- `python3 scripts/tests/chat_session_contract_test.py`
- `python3 scripts/tests/chat_model_status_contract_test.py`
- `python3 scripts/tests/chat_session_lifecycle_contract_test.py`
- `python3 scripts/tests/chat_readiness_contract_test.py`
- `python3 scripts/tests/chat_surface_preview_test.py`
- `bash scripts/tests/status-backend.sh scripts/status-stub.sh`
- `bash scripts/tests/status-device-session.sh scripts/status-stub.sh`
- `bash scripts/tests/status-readiness.sh scripts/status-stub.sh`
- `bash scripts/tests/status-chat-model-status.sh scripts/status-stub.sh`
- `bash scripts/tests/status-chat-session.sh scripts/status-stub.sh`
- `bash scripts/tests/status-chat-readiness.sh scripts/status-stub.sh`
- `find scripts -type f -name '*.sh' -not -name '*.snapshot' -print0 | xargs -0 bash -n`
- `./scripts/check.sh`
- `./scripts/check-device-stub.sh`
- `./scripts/install-stub.sh`
- `./scripts/status-stub.sh`
- `./scripts/status-stub.sh --include-chat-readiness`
- `./scripts/chat-readiness-stub.sh --model gemma3n-e4b --target kv260`
- `./scripts/launch-stub.sh --dry-run`
- `./scripts/chat-stub.sh --dry-run --prompt hello`
- local claim-scan matching CI
- `git diff --check`
- `git diff --cached --check`

Local note: `shellcheck` is not installed in this environment; the GitHub Actions shell-lint job installs and runs it.

## Scope Boundary

Data-only readiness boundary. This does not capture or echo prompts, persist transcripts, read model assets or local paths, load a model, execute runtime code, generate responses, touch KV260 hardware, open serial or SSH sessions, scan networks, call providers, invoke pccx-lab, invoke systemverilog-ide, read or write artifacts, upload telemetry, write back to repositories, publish releases/tags, or make a stable API/ABI or hardware/runtime claim.
