### PR TITLE
Add chat composer boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,7 @@ jobs:
                    scripts/chat-session-stub.sh \
                    scripts/chat-session-lifecycle-stub.sh \
                    scripts/chat-readiness-stub.sh \
+                   scripts/chat-composer-stub.sh \
                    scripts/chat-surface-preview.sh \
                    scripts/chat-stub.sh; do
             [ -f "$f" ] && chmod +x "$f" || true
@@ -168,6 +169,10 @@ jobs:
         run: ./scripts/status-stub.sh --include-chat-readiness
       - name: run scripts/chat-readiness-stub.sh
         run: ./scripts/chat-readiness-stub.sh --model gemma3n-e4b --target kv260
+      - name: run scripts/status-stub.sh with chat composer
+        run: ./scripts/status-stub.sh --include-chat-composer
+      - name: run scripts/chat-composer-stub.sh
+        run: ./scripts/chat-composer-stub.sh --model gemma3n-e4b --target kv260
       - name: run scripts/chat-surface-preview.sh
         run: ./scripts/chat-surface-preview.sh --model gemma3n-e4b --target kv260
       - name: run scripts/chat-stub.sh --dry-run
@@ -198,6 +203,8 @@ jobs:
         run: python3 scripts/tests/chat_session_lifecycle_contract_test.py
       - name: run chat readiness contract tests
         run: python3 scripts/tests/chat_readiness_contract_test.py
+      - name: run chat composer contract tests
+        run: python3 scripts/tests/chat_composer_contract_test.py
       - name: run chat surface preview tests
         run: python3 scripts/tests/chat_surface_preview_test.py
 
@@ -214,6 +221,7 @@ jobs:
           chmod +x scripts/chat-session-stub.sh
           chmod +x scripts/chat-session-lifecycle-stub.sh
           chmod +x scripts/chat-readiness-stub.sh
+          chmod +x scripts/chat-composer-stub.sh
           chmod +x scripts/launch-stub.sh
           chmod +x scripts/tests/status-backend.sh
           chmod +x scripts/tests/status-device-session.sh
@@ -221,6 +229,7 @@ jobs:
           chmod +x scripts/tests/status-chat-model-status.sh
           chmod +x scripts/tests/status-chat-session.sh
           chmod +x scripts/tests/status-chat-readiness.sh
+          chmod +x scripts/tests/status-chat-composer.sh
       - name: shellcheck status-stub and test script
         run: |
           sudo apt-get update -q && sudo apt-get install -y -q shellcheck
@@ -231,6 +240,7 @@ jobs:
           shellcheck scripts/tests/status-chat-model-status.sh
           shellcheck scripts/tests/status-chat-session.sh
           shellcheck scripts/tests/status-chat-readiness.sh
+          shellcheck scripts/tests/status-chat-composer.sh
       - name: run status-backend tests
         run: bash scripts/tests/status-backend.sh scripts/status-stub.sh
       - name: run status-device-session tests
@@ -243,3 +253,5 @@ jobs:
         run: bash scripts/tests/status-chat-session.sh scripts/status-stub.sh
       - name: run status-chat-readiness tests
         run: bash scripts/tests/status-chat-readiness.sh scripts/status-stub.sh
+      - name: run status-chat-composer tests
+        run: bash scripts/tests/status-chat-composer.sh scripts/status-stub.sh

--- a/README.md
+++ b/README.md
@@ -87,13 +87,14 @@ and verify host-side prerequisites before the real engine lands.
 | [`scripts/check.sh`](./scripts/check.sh) | Probe host info, tooling availability, edge-device hints. Always exits 0. |
 | [`scripts/check-device-stub.sh`](./scripts/check-device-stub.sh) | Narrowly scoped device-tree / FPGA-node probe (KV260 / Kria detection only). Always exits 0. |
 | [`scripts/install-stub.sh`](./scripts/install-stub.sh) | Preview of the planned install flow; reports which host runtime pieces are present, lists device-side pieces as future deliverables. Always exits 0. |
-| [`scripts/status-stub.sh`](./scripts/status-stub.sh) | Launcher state summary. Default mode: local scaffold output, always exits 0. With `--include-chat-model-status`, adds read-only blocked chat model-status display data. With `--include-chat-session`, adds read-only blocked chat/session and lifecycle summaries. With `--include-chat-readiness`, adds read-only chat readiness checks and recovery actions. With `--include-device-session`, adds a read-only device/session status panel. With `--include-runtime-readiness`, adds a read-only runtime readiness summary. With `--backend pccx-lab`, calls `pccx-lab status --format json` and forwards the run-status envelope (exits non-zero if binary is missing or output is invalid). |
+| [`scripts/status-stub.sh`](./scripts/status-stub.sh) | Launcher state summary. Default mode: local scaffold output, always exits 0. With `--include-chat-composer`, adds read-only chat composer/input-control data. With `--include-chat-model-status`, adds read-only blocked chat model-status display data. With `--include-chat-session`, adds read-only blocked chat/session and lifecycle summaries. With `--include-chat-readiness`, adds read-only chat readiness checks and recovery actions. With `--include-device-session`, adds a read-only device/session status panel. With `--include-runtime-readiness`, adds a read-only runtime readiness summary. With `--backend pccx-lab`, calls `pccx-lab status --format json` and forwards the run-status envelope (exits non-zero if binary is missing or output is invalid). |
 | [`scripts/device-session-status-stub.sh`](./scripts/device-session-status-stub.sh) | Data-only device/session status JSON for the Gemma 3N E4B + KV260 target. Reports connection, model load, session, diagnostics, readiness, discovery paths, flow steps, and error taxonomy as placeholder / blocked. |
 | [`scripts/runtime-readiness-stub.sh`](./scripts/runtime-readiness-stub.sh) | Data-only runtime readiness JSON for the Gemma 3N E4B + KV260 target. Reports blocked / not yet evidence-backed. |
 | [`scripts/chat-session-stub.sh`](./scripts/chat-session-stub.sh) | Data-only standalone chat/session JSON for the Gemma 3N E4B + KV260 target. Reports disabled send controls, inactive session state, no prompt/response persistence, and readiness handoff references. |
 | [`scripts/chat-session-lifecycle-stub.sh`](./scripts/chat-session-lifecycle-stub.sh) | Data-only chat session lifecycle JSON for the Gemma 3N E4B + KV260 target. Reports create, restore, clear, close, and export-summary operations as disabled, blocked, inactive, or unavailable. |
 | [`scripts/chat-model-status-stub.sh`](./scripts/chat-model-status-stub.sh) | Data-only chat model-status JSON for the Gemma 3N E4B + KV260 target. Reports descriptor, asset, load, runtime, context, and response display rows as blocked, disabled, or unavailable. |
 | [`scripts/chat-readiness-stub.sh`](./scripts/chat-readiness-stub.sh) | Data-only chat readiness JSON for the Gemma 3N E4B + KV260 target. Reports readiness checks, error categories, and recovery actions as blocked, disabled, or local data only. |
+| [`scripts/chat-composer-stub.sh`](./scripts/chat-composer-stub.sh) | Data-only chat composer JSON for the Gemma 3N E4B + KV260 target. Reports input buffer, send, attachment, validation, and privacy states without reading, echoing, storing, or persisting prompt text. |
 | [`scripts/chat-surface-preview.sh`](./scripts/chat-surface-preview.sh) | Read-only terminal preview of the standalone chat surface. Renders the checked chat/session contract as blocked UI state without accepting prompts, executing a model, or writing artifacts. |
 | [`scripts/launch-stub.sh`](./scripts/launch-stub.sh) | Dry-run preview of the intended launch sequence. Requires `--dry-run`; exits 1 without it. |
 | [`scripts/chat-stub.sh`](./scripts/chat-stub.sh) | Dry-run chat stub. Requires `--dry-run`; exits 1 without it. Accepts `--prompt "..."` or stdin. No model is executed. |
@@ -106,6 +107,7 @@ bash scripts/status-stub.sh
 bash scripts/status-stub.sh --include-chat-model-status
 bash scripts/status-stub.sh --include-chat-session
 bash scripts/status-stub.sh --include-chat-readiness
+bash scripts/status-stub.sh --include-chat-composer
 bash scripts/status-stub.sh --include-device-session
 bash scripts/status-stub.sh --include-runtime-readiness
 bash scripts/device-session-status-stub.sh --model gemma3n-e4b --target kv260
@@ -114,6 +116,7 @@ bash scripts/chat-model-status-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-session-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-session-lifecycle-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-readiness-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/chat-composer-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-surface-preview.sh --model gemma3n-e4b --target kv260
 bash scripts/launch-stub.sh --dry-run
 bash scripts/chat-stub.sh --dry-run --prompt "hello"

--- a/contracts/chat_composer_contract.py
+++ b/contracts/chat_composer_contract.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Data-only chat composer contract for the planned launcher UI.
+
+The contract describes composer controls, input validation state, and send
+gating for the standalone chat surface without reading, echoing, storing, or
+persisting prompt content. It does not load models, start runtime code, touch
+KV260 hardware, call providers, invoke pccx-lab, or read/write artifacts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import sys
+
+
+SCHEMA_VERSION = "pccx.chatComposer.v0"
+
+CHAT_COMPOSER_FIELDS = (
+    "schemaVersion",
+    "composerId",
+    "fixtureVersion",
+    "lastUpdatedSource",
+    "targetDevice",
+    "targetBoard",
+    "targetModel",
+    "composerState",
+    "inputBufferState",
+    "sendControlState",
+    "attachmentState",
+    "privacyState",
+    "validationState",
+    "chatReadinessRef",
+    "parentChatSessionRef",
+    "inputPolicy",
+    "composerControls",
+    "validationRules",
+    "blockedReasons",
+    "handoffRefs",
+    "safetyFlags",
+    "limitations",
+    "issueRefs",
+)
+
+INPUT_POLICY_FIELDS = (
+    "state",
+    "promptCapture",
+    "promptEcho",
+    "promptPersistence",
+    "contentIncluded",
+    "maxDraftChars",
+    "draftStorage",
+    "redactionPolicy",
+    "summary",
+)
+
+COMPOSER_CONTROL_FIELDS = (
+    "controlId",
+    "label",
+    "state",
+    "enabled",
+    "userAction",
+    "launcherAction",
+    "sideEffectPolicy",
+)
+
+VALIDATION_RULE_FIELDS = (
+    "ruleId",
+    "state",
+    "severity",
+    "summary",
+    "requiredBefore",
+)
+
+BLOCKED_REASON_FIELDS = (
+    "reasonId",
+    "state",
+    "summary",
+    "requiredBefore",
+)
+
+HANDOFF_REF_FIELDS = (
+    "refId",
+    "schemaVersion",
+    "fixturePath",
+    "state",
+    "summary",
+)
+
+CHAT_COMPOSER_STATE_VALUES = (
+    "available_as_data",
+    "blocked",
+    "disabled",
+    "empty_not_captured",
+    "inactive",
+    "not_configured",
+    "not_loaded",
+    "not_started",
+    "not_used",
+    "placeholder",
+    "planned",
+    "requires_evidence",
+    "target_selected",
+    "unavailable",
+)
+
+_CHAT_COMPOSER = {
+    "schemaVersion": SCHEMA_VERSION,
+    "composerId": "chat_composer_gemma3n_e4b_kv260_placeholder",
+    "fixtureVersion": "chat-composer.gemma3n-e4b-kv260.2026-05-04",
+    "lastUpdatedSource": "pccx_launcher_issue_9_chat_composer_boundary_2026-05-04",
+    "targetDevice": "kv260",
+    "targetBoard": "xilinx_kria_kv260",
+    "targetModel": "gemma3n-e4b",
+    "composerState": "blocked",
+    "inputBufferState": "empty_not_captured",
+    "sendControlState": "disabled",
+    "attachmentState": "disabled",
+    "privacyState": "available_as_data",
+    "validationState": "blocked",
+    "chatReadinessRef": "chat_readiness_gemma3n_e4b_kv260_placeholder",
+    "parentChatSessionRef": "chat_session_gemma3n_e4b_kv260_placeholder",
+    "inputPolicy": {
+        "state": "planned",
+        "promptCapture": "disabled",
+        "promptEcho": "disabled",
+        "promptPersistence": "disabled",
+        "contentIncluded": False,
+        "maxDraftChars": 0,
+        "draftStorage": "not_configured",
+        "redactionPolicy": "prompt text stays outside checked fixtures and status summaries",
+        "summary": "Composer fixture carries input control state only; no draft text is stored.",
+    },
+    "composerControls": [
+        {
+            "controlId": "focus_input",
+            "label": "focus input",
+            "state": "placeholder",
+            "enabled": False,
+            "userAction": "Focus the composer only after a reviewed local chat UI exists.",
+            "launcherAction": "Render placeholder input state without reading text.",
+            "sideEffectPolicy": "local_render_only",
+        },
+        {
+            "controlId": "attach_context",
+            "label": "attach context",
+            "state": "disabled",
+            "enabled": False,
+            "userAction": "Attach local context only after an explicit artifact input boundary exists.",
+            "launcherAction": "Keep attachments disabled and do not read files.",
+            "sideEffectPolicy": "no_artifact_read",
+        },
+        {
+            "controlId": "send_message",
+            "label": "send message",
+            "state": "disabled",
+            "enabled": False,
+            "userAction": "Send only after runtime, model, session, and retention evidence exists.",
+            "launcherAction": "Keep send disabled while readiness is blocked.",
+            "sideEffectPolicy": "no_runtime_execution",
+        },
+        {
+            "controlId": "clear_draft",
+            "label": "clear draft",
+            "state": "inactive",
+            "enabled": False,
+            "userAction": "Clear only future in-memory draft text owned by the launcher UI.",
+            "launcherAction": "No-op because no draft is captured by this fixture.",
+            "sideEffectPolicy": "no_write",
+        },
+    ],
+    "validationRules": [
+        {
+            "ruleId": "no_prompt_content_in_fixture",
+            "state": "available_as_data",
+            "severity": "info",
+            "summary": "Composer fixtures and status summaries must not include prompt text.",
+            "requiredBefore": "composer_fixture_checked",
+        },
+        {
+            "ruleId": "runtime_readiness_required",
+            "state": "blocked",
+            "severity": "blocked",
+            "summary": "Runtime readiness remains blocked and not yet evidence-backed.",
+            "requiredBefore": "send_message_enabled",
+        },
+        {
+            "ruleId": "model_load_required",
+            "state": "not_loaded",
+            "severity": "blocked",
+            "summary": "Model assets are not configured or loaded by this fixture.",
+            "requiredBefore": "send_message_enabled",
+        },
+        {
+            "ruleId": "session_store_required",
+            "state": "not_configured",
+            "severity": "blocked",
+            "summary": "No reviewed local session store or retention rule exists.",
+            "requiredBefore": "draft_or_transcript_persistence_enabled",
+        },
+        {
+            "ruleId": "attachment_boundary_required",
+            "state": "planned",
+            "severity": "blocked",
+            "summary": "Attachments require a separate reviewed local artifact input boundary.",
+            "requiredBefore": "attach_context_enabled",
+        },
+        {
+            "ruleId": "provider_mode_disabled",
+            "state": "not_used",
+            "severity": "info",
+            "summary": "External provider state is not used by this local launcher boundary.",
+            "requiredBefore": "core_chat_available",
+        },
+    ],
+    "blockedReasons": [
+        {
+            "reasonId": "send_readiness_blocked",
+            "state": "blocked",
+            "summary": "Chat readiness keeps send controls disabled.",
+            "requiredBefore": "send_message_enabled",
+        },
+        {
+            "reasonId": "draft_capture_not_reviewed",
+            "state": "not_configured",
+            "summary": "No prompt capture, echo, persistence, or retention policy exists.",
+            "requiredBefore": "input_capture_enabled",
+        },
+        {
+            "reasonId": "attachment_boundary_absent",
+            "state": "planned",
+            "summary": "No reviewed local artifact input boundary exists for composer attachments.",
+            "requiredBefore": "attach_context_enabled",
+        },
+        {
+            "reasonId": "runtime_not_started",
+            "state": "not_started",
+            "summary": "No local chat runtime has been implemented or started.",
+            "requiredBefore": "assistant_response_available",
+        },
+    ],
+    "handoffRefs": [
+        {
+            "refId": "chat_session",
+            "schemaVersion": "pccx.chatSession.v0",
+            "fixturePath": "contracts/fixtures/chat-session.gemma3n-e4b-kv260-placeholder.json",
+            "state": "available_as_data",
+            "summary": "Base chat/session state is consumed as local data only.",
+        },
+        {
+            "refId": "chat_readiness",
+            "schemaVersion": "pccx.chatReadiness.v0",
+            "fixturePath": "contracts/fixtures/chat-readiness.gemma3n-e4b-kv260-placeholder.json",
+            "state": "blocked",
+            "summary": "Chat readiness keeps send controls disabled.",
+        },
+        {
+            "refId": "chat_model_status",
+            "schemaVersion": "pccx.chatModelStatus.v0",
+            "fixturePath": "contracts/fixtures/chat-model-status.gemma3n-e4b-kv260-placeholder.json",
+            "state": "available_as_data",
+            "summary": "Model status display is consumed as local data only.",
+        },
+        {
+            "refId": "chat_session_lifecycle",
+            "schemaVersion": "pccx.chatSessionLifecycle.v0",
+            "fixturePath": "contracts/fixtures/chat-session-lifecycle.gemma3n-e4b-kv260-placeholder.json",
+            "state": "blocked",
+            "summary": "Session lifecycle remains disabled or blocked.",
+        },
+    ],
+    "safetyFlags": {
+        "dataOnly": True,
+        "readOnly": True,
+        "deterministic": True,
+        "composerDisplayOnly": True,
+        "writesArtifacts": False,
+        "readsArtifacts": False,
+        "attachmentReads": False,
+        "fileUpload": False,
+        "clipboardRead": False,
+        "clipboardWrite": False,
+        "promptContentIncluded": False,
+        "promptEchoed": False,
+        "promptPersistence": False,
+        "responseContentIncluded": False,
+        "responseGenerated": False,
+        "transcriptPersistence": False,
+        "sessionPersistence": False,
+        "modelAssetPathsIncluded": False,
+        "modelWeightPathsIncluded": False,
+        "modelLoadAttempted": False,
+        "modelLoaded": False,
+        "modelExecution": False,
+        "runtimeExecution": False,
+        "touchesHardware": False,
+        "kv260Access": False,
+        "opensSerialPort": False,
+        "networkCalls": False,
+        "networkScan": False,
+        "sshExecution": False,
+        "providerCalls": False,
+        "cloudCalls": False,
+        "privatePathsIncluded": False,
+        "secretsIncluded": False,
+        "tokensIncluded": False,
+        "generatedBlobsIncluded": False,
+        "hardwareDumpsIncluded": False,
+        "telemetry": False,
+        "automaticUpload": False,
+        "writeBack": False,
+        "executesPccxLab": False,
+        "executesSystemverilogIde": False,
+        "mcpServerImplemented": False,
+        "lspImplemented": False,
+        "stableApiAbiClaim": False,
+    },
+    "limitations": [
+        "Data-only chat composer fixture; no prompt text is read, echoed, stored, or persisted.",
+        "No attachments, manifests, transcripts, summaries, model paths, generated artifacts, private paths, secrets, or tokens are read or written.",
+        "No KV260 hardware access, serial access, SSH execution, network call, provider call, telemetry, upload, or write-back is performed.",
+        "Composer send controls remain disabled until chat readiness, runtime, model-load, device-session, and local session evidence are available.",
+        "This is not a release, tag, versioned compatibility commitment, MCP, LSP, IDE, marketplace, or telemetry implementation.",
+    ],
+    "issueRefs": [
+        "pccxai/pccx-llm-launcher#9",
+    ],
+}
+
+
+def create_gemma3n_e4b_kv260_chat_composer() -> dict:
+    """Return the checked Gemma 3N E4B plus KV260 chat composer fixture."""
+    return copy.deepcopy(_CHAT_COMPOSER)
+
+
+def chat_composer_json(composer: dict | None = None) -> str:
+    """Render a deterministic JSON representation."""
+    return json.dumps(
+        composer if composer is not None else create_gemma3n_e4b_kv260_chat_composer(),
+        indent=2,
+        sort_keys=True,
+    ) + "\n"
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Print data-only chat composer JSON.",
+    )
+    parser.add_argument(
+        "--model",
+        default="gemma3n-e4b",
+        choices=("gemma3n-e4b",),
+        help="model descriptor target",
+    )
+    parser.add_argument(
+        "--target",
+        default="kv260",
+        choices=("kv260",),
+        help="target board/device",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parse_args(sys.argv[1:] if argv is None else argv)
+    sys.stdout.write(chat_composer_json())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contracts/fixtures/chat-composer.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-composer.gemma3n-e4b-kv260-placeholder.json
@@ -1,0 +1,222 @@
+{
+  "attachmentState": "disabled",
+  "blockedReasons": [
+    {
+      "reasonId": "send_readiness_blocked",
+      "requiredBefore": "send_message_enabled",
+      "state": "blocked",
+      "summary": "Chat readiness keeps send controls disabled."
+    },
+    {
+      "reasonId": "draft_capture_not_reviewed",
+      "requiredBefore": "input_capture_enabled",
+      "state": "not_configured",
+      "summary": "No prompt capture, echo, persistence, or retention policy exists."
+    },
+    {
+      "reasonId": "attachment_boundary_absent",
+      "requiredBefore": "attach_context_enabled",
+      "state": "planned",
+      "summary": "No reviewed local artifact input boundary exists for composer attachments."
+    },
+    {
+      "reasonId": "runtime_not_started",
+      "requiredBefore": "assistant_response_available",
+      "state": "not_started",
+      "summary": "No local chat runtime has been implemented or started."
+    }
+  ],
+  "chatReadinessRef": "chat_readiness_gemma3n_e4b_kv260_placeholder",
+  "composerControls": [
+    {
+      "controlId": "focus_input",
+      "enabled": false,
+      "label": "focus input",
+      "launcherAction": "Render placeholder input state without reading text.",
+      "sideEffectPolicy": "local_render_only",
+      "state": "placeholder",
+      "userAction": "Focus the composer only after a reviewed local chat UI exists."
+    },
+    {
+      "controlId": "attach_context",
+      "enabled": false,
+      "label": "attach context",
+      "launcherAction": "Keep attachments disabled and do not read files.",
+      "sideEffectPolicy": "no_artifact_read",
+      "state": "disabled",
+      "userAction": "Attach local context only after an explicit artifact input boundary exists."
+    },
+    {
+      "controlId": "send_message",
+      "enabled": false,
+      "label": "send message",
+      "launcherAction": "Keep send disabled while readiness is blocked.",
+      "sideEffectPolicy": "no_runtime_execution",
+      "state": "disabled",
+      "userAction": "Send only after runtime, model, session, and retention evidence exists."
+    },
+    {
+      "controlId": "clear_draft",
+      "enabled": false,
+      "label": "clear draft",
+      "launcherAction": "No-op because no draft is captured by this fixture.",
+      "sideEffectPolicy": "no_write",
+      "state": "inactive",
+      "userAction": "Clear only future in-memory draft text owned by the launcher UI."
+    }
+  ],
+  "composerId": "chat_composer_gemma3n_e4b_kv260_placeholder",
+  "composerState": "blocked",
+  "fixtureVersion": "chat-composer.gemma3n-e4b-kv260.2026-05-04",
+  "handoffRefs": [
+    {
+      "fixturePath": "contracts/fixtures/chat-session.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_session",
+      "schemaVersion": "pccx.chatSession.v0",
+      "state": "available_as_data",
+      "summary": "Base chat/session state is consumed as local data only."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-readiness.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_readiness",
+      "schemaVersion": "pccx.chatReadiness.v0",
+      "state": "blocked",
+      "summary": "Chat readiness keeps send controls disabled."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-model-status.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_model_status",
+      "schemaVersion": "pccx.chatModelStatus.v0",
+      "state": "available_as_data",
+      "summary": "Model status display is consumed as local data only."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-session-lifecycle.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_session_lifecycle",
+      "schemaVersion": "pccx.chatSessionLifecycle.v0",
+      "state": "blocked",
+      "summary": "Session lifecycle remains disabled or blocked."
+    }
+  ],
+  "inputBufferState": "empty_not_captured",
+  "inputPolicy": {
+    "contentIncluded": false,
+    "draftStorage": "not_configured",
+    "maxDraftChars": 0,
+    "promptCapture": "disabled",
+    "promptEcho": "disabled",
+    "promptPersistence": "disabled",
+    "redactionPolicy": "prompt text stays outside checked fixtures and status summaries",
+    "state": "planned",
+    "summary": "Composer fixture carries input control state only; no draft text is stored."
+  },
+  "issueRefs": [
+    "pccxai/pccx-llm-launcher#9"
+  ],
+  "lastUpdatedSource": "pccx_launcher_issue_9_chat_composer_boundary_2026-05-04",
+  "limitations": [
+    "Data-only chat composer fixture; no prompt text is read, echoed, stored, or persisted.",
+    "No attachments, manifests, transcripts, summaries, model paths, generated artifacts, private paths, secrets, or tokens are read or written.",
+    "No KV260 hardware access, serial access, SSH execution, network call, provider call, telemetry, upload, or write-back is performed.",
+    "Composer send controls remain disabled until chat readiness, runtime, model-load, device-session, and local session evidence are available.",
+    "This is not a release, tag, versioned compatibility commitment, MCP, LSP, IDE, marketplace, or telemetry implementation."
+  ],
+  "parentChatSessionRef": "chat_session_gemma3n_e4b_kv260_placeholder",
+  "privacyState": "available_as_data",
+  "safetyFlags": {
+    "attachmentReads": false,
+    "automaticUpload": false,
+    "clipboardRead": false,
+    "clipboardWrite": false,
+    "cloudCalls": false,
+    "composerDisplayOnly": true,
+    "dataOnly": true,
+    "deterministic": true,
+    "executesPccxLab": false,
+    "executesSystemverilogIde": false,
+    "fileUpload": false,
+    "generatedBlobsIncluded": false,
+    "hardwareDumpsIncluded": false,
+    "kv260Access": false,
+    "lspImplemented": false,
+    "mcpServerImplemented": false,
+    "modelAssetPathsIncluded": false,
+    "modelExecution": false,
+    "modelLoadAttempted": false,
+    "modelLoaded": false,
+    "modelWeightPathsIncluded": false,
+    "networkCalls": false,
+    "networkScan": false,
+    "opensSerialPort": false,
+    "privatePathsIncluded": false,
+    "promptContentIncluded": false,
+    "promptEchoed": false,
+    "promptPersistence": false,
+    "providerCalls": false,
+    "readOnly": true,
+    "readsArtifacts": false,
+    "responseContentIncluded": false,
+    "responseGenerated": false,
+    "runtimeExecution": false,
+    "secretsIncluded": false,
+    "sessionPersistence": false,
+    "sshExecution": false,
+    "stableApiAbiClaim": false,
+    "telemetry": false,
+    "tokensIncluded": false,
+    "touchesHardware": false,
+    "transcriptPersistence": false,
+    "writeBack": false,
+    "writesArtifacts": false
+  },
+  "schemaVersion": "pccx.chatComposer.v0",
+  "sendControlState": "disabled",
+  "targetBoard": "xilinx_kria_kv260",
+  "targetDevice": "kv260",
+  "targetModel": "gemma3n-e4b",
+  "validationRules": [
+    {
+      "requiredBefore": "composer_fixture_checked",
+      "ruleId": "no_prompt_content_in_fixture",
+      "severity": "info",
+      "state": "available_as_data",
+      "summary": "Composer fixtures and status summaries must not include prompt text."
+    },
+    {
+      "requiredBefore": "send_message_enabled",
+      "ruleId": "runtime_readiness_required",
+      "severity": "blocked",
+      "state": "blocked",
+      "summary": "Runtime readiness remains blocked and not yet evidence-backed."
+    },
+    {
+      "requiredBefore": "send_message_enabled",
+      "ruleId": "model_load_required",
+      "severity": "blocked",
+      "state": "not_loaded",
+      "summary": "Model assets are not configured or loaded by this fixture."
+    },
+    {
+      "requiredBefore": "draft_or_transcript_persistence_enabled",
+      "ruleId": "session_store_required",
+      "severity": "blocked",
+      "state": "not_configured",
+      "summary": "No reviewed local session store or retention rule exists."
+    },
+    {
+      "requiredBefore": "attach_context_enabled",
+      "ruleId": "attachment_boundary_required",
+      "severity": "blocked",
+      "state": "planned",
+      "summary": "Attachments require a separate reviewed local artifact input boundary."
+    },
+    {
+      "requiredBefore": "core_chat_available",
+      "ruleId": "provider_mode_disabled",
+      "severity": "info",
+      "state": "not_used",
+      "summary": "External provider state is not used by this local launcher boundary."
+    }
+  ],
+  "validationState": "blocked"
+}

--- a/docs/STANDALONE_CHAT_SESSION_CONTRACT.md
+++ b/docs/STANDALONE_CHAT_SESSION_CONTRACT.md
@@ -12,22 +12,27 @@ The implementation lives in:
 - `contracts/chat_model_status_contract.py`
 - `contracts/chat_session_lifecycle_contract.py`
 - `contracts/chat_readiness_contract.py`
+- `contracts/chat_composer_contract.py`
 - `contracts/fixtures/chat-session.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-model-status.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-session-lifecycle.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-readiness.gemma3n-e4b-kv260-placeholder.json`
+- `contracts/fixtures/chat-composer.gemma3n-e4b-kv260-placeholder.json`
 - `scripts/chat-session-stub.sh`
 - `scripts/chat-model-status-stub.sh`
 - `scripts/chat-session-lifecycle-stub.sh`
 - `scripts/chat-readiness-stub.sh`
+- `scripts/chat-composer-stub.sh`
 - `scripts/chat-surface-preview.sh`
 - `scripts/tests/chat_session_contract_test.py`
 - `scripts/tests/chat_model_status_contract_test.py`
 - `scripts/tests/chat_session_lifecycle_contract_test.py`
 - `scripts/tests/chat_readiness_contract_test.py`
+- `scripts/tests/chat_composer_contract_test.py`
 - `scripts/tests/chat_surface_preview_test.py`
 - `scripts/tests/status-chat-model-status.sh`
 - `scripts/tests/status-chat-readiness.sh`
+- `scripts/tests/status-chat-composer.sh`
 
 ## What Is Implemented
 
@@ -91,6 +96,20 @@ blocked, planned, or local data only. The fixture does not read prompts,
 model assets, paths, manifests, transcripts, summaries, logs, device
 state, or provider configuration.
 
+The chat composer fixture records the input-control and validation shape
+for the standalone chat surface:
+
+```bash
+bash scripts/chat-composer-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/status-stub.sh --include-chat-composer
+```
+
+It keeps prompt capture, prompt echo, prompt persistence, attachment
+reads, clipboard access, model execution, runtime startup, provider
+calls, hardware access, pccx-lab invocation, and artifact writes out of
+scope. Send controls remain disabled until the reviewed runtime,
+session-store, model-load, and attachment boundaries exist.
+
 The terminal preview command renders the same checked contract as a
 read-only chat surface sketch:
 
@@ -122,6 +141,7 @@ The chat/session states are deliberately narrow:
 - `not_used`: no external provider state is used
 - `unavailable`: output is not available
 - `available_as_data`: local fixture shape is available as data only
+- `empty_not_captured`: no prompt draft is captured or stored
 
 The lifecycle states keep session management separate from chat message
 content:
@@ -166,6 +186,9 @@ calls, persistence, target access, artifact reads, or artifact writes.
 The readiness contract ties those display and lifecycle states into a
 single checklist and recovery-action view without enabling any send,
 load, restore, or export action.
+The composer contract adds a reviewable input-control and validation
+shape without prompt capture, prompt echo, prompt persistence, attachment
+reads, clipboard access, or send enablement.
 
 pccx-lab remains a separate CLI/core diagnostics and verification
 backend. systemverilog-ide may consume launcher data later as read-only
@@ -177,6 +200,8 @@ This chat/session surface does not add:
 
 - model execution or generated responses
 - prompt, response, or transcript persistence
+- composer prompt capture, echo, persistence, attachment reads, or
+  clipboard access
 - session creation, restore, clear, close, or export behavior
 - readiness recovery execution
 - manifest, transcript, summary, or lifecycle artifact reads or writes

--- a/scripts/chat-composer-stub.sh
+++ b/scripts/chat-composer-stub.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+# scripts/chat-composer-stub.sh - print data-only chat composer JSON.
+#
+# This script does not read prompts, echo input, persist drafts, read
+# attachments, load models, start runtime code, touch KV260 hardware, call
+# providers, read/write artifacts, or invoke pccx-lab.
+
+set -eu
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+
+MODEL="gemma3n-e4b"
+TARGET="kv260"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --model)
+            MODEL="${2:-}"
+            if [ -z "$MODEL" ]; then
+                printf '[ERROR] --model requires an argument\n' >&2
+                exit 2
+            fi
+            shift 2
+            ;;
+        --target)
+            TARGET="${2:-}"
+            if [ -z "$TARGET" ]; then
+                printf '[ERROR] --target requires an argument\n' >&2
+                exit 2
+            fi
+            shift 2
+            ;;
+        *)
+            printf '[ERROR] unknown option: %s\n' "$1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+exec python3 "$ROOT_DIR/contracts/chat_composer_contract.py" \
+    --model "$MODEL" \
+    --target "$TARGET"

--- a/scripts/status-stub.sh
+++ b/scripts/status-stub.sh
@@ -19,6 +19,9 @@
 # Chat readiness checks and recovery actions (explicit opt-in, read-only local data):
 #   --include-chat-readiness
 #
+# Chat composer controls and validation state (explicit opt-in, read-only local data):
+#   --include-chat-composer
+#
 # pccx-lab backend (explicit opt-in):
 #   --backend pccx-lab        call pccx-lab status --format json
 #   PCCX_LAB_BIN              override path to pccx-lab binary (takes priority over PATH)
@@ -39,6 +42,101 @@ INCLUDE_DEVICE_SESSION="0"
 INCLUDE_CHAT_SESSION="0"
 INCLUDE_CHAT_MODEL_STATUS="0"
 INCLUDE_CHAT_READINESS="0"
+INCLUDE_CHAT_COMPOSER="0"
+
+print_chat_composer_summary() {
+    SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+    ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+    CHAT_COMPOSER_STUB="$ROOT_DIR/scripts/chat-composer-stub.sh"
+
+    if [ ! -f "$CHAT_COMPOSER_STUB" ]; then
+        ERROR "chat composer stub not found: $CHAT_COMPOSER_STUB"
+        return 1
+    fi
+
+    if ! CHAT_COMPOSER_JSON="$(bash "$CHAT_COMPOSER_STUB" --model gemma3n-e4b --target kv260 2>&1)"; then
+        ERROR "chat composer stub failed"
+        printf '%s\n' "$CHAT_COMPOSER_JSON" >&2
+        return 1
+    fi
+
+    if ! CHAT_COMPOSER_SUMMARY="$(
+        printf '%s\n' "$CHAT_COMPOSER_JSON" | python3 -c '
+import json
+import sys
+
+data = json.load(sys.stdin)
+flags = data["safetyFlags"]
+controls = " ".join(
+    "{}={}".format(control["controlId"], control["state"])
+    for control in data["composerControls"]
+)
+rules = " ".join(
+    "{}={}".format(rule["ruleId"], rule["state"])
+    for rule in data["validationRules"]
+)
+blocked = " ".join(
+    "{}={}".format(reason["reasonId"], reason["state"])
+    for reason in data["blockedReasons"]
+)
+
+def b(value):
+    return "true" if value else "false"
+
+print("[INFO]  source     : scripts/chat-composer-stub.sh --model gemma3n-e4b --target kv260")
+print("[INFO]  boundary   : read-only data; no prompt/provider/model/hardware/lab/IDE execution")
+print("[INFO]  target     : {}".format(data["targetDevice"]))
+print("[INFO]  model      : {}".format(data["targetModel"]))
+print("[INFO]  composer   : {}".format(data["composerState"]))
+print("[INFO]  input      : {}".format(data["inputBufferState"]))
+print("[INFO]  send       : {}".format(data["sendControlState"]))
+print("[INFO]  attachment : {}".format(data["attachmentState"]))
+print("[INFO]  privacy    : {}".format(data["privacyState"]))
+print("[INFO]  validation : {}".format(data["validationState"]))
+print("[INFO]  controls   : {}".format(controls))
+print("[INFO]  rules      : {}".format(rules))
+print("[INFO]  blocked    : {}".format(blocked))
+print(
+    "[INFO]  flags      : readOnly={} dataOnly={} deterministic={} "
+    "composerDisplayOnly={} writesArtifacts={} readsArtifacts={} "
+    "attachmentReads={} fileUpload={} clipboardRead={} clipboardWrite={} "
+    "promptContentIncluded={} promptEchoed={} promptPersistence={} "
+    "responseContentIncluded={} modelLoadAttempted={} modelLoaded={} "
+    "modelExecution={} runtimeExecution={} kv260Access={} networkCalls={} "
+    "providerCalls={} executesPccxLab={}".format(
+        b(flags["readOnly"]),
+        b(flags["dataOnly"]),
+        b(flags["deterministic"]),
+        b(flags["composerDisplayOnly"]),
+        b(flags["writesArtifacts"]),
+        b(flags["readsArtifacts"]),
+        b(flags["attachmentReads"]),
+        b(flags["fileUpload"]),
+        b(flags["clipboardRead"]),
+        b(flags["clipboardWrite"]),
+        b(flags["promptContentIncluded"]),
+        b(flags["promptEchoed"]),
+        b(flags["promptPersistence"]),
+        b(flags["responseContentIncluded"]),
+        b(flags["modelLoadAttempted"]),
+        b(flags["modelLoaded"]),
+        b(flags["modelExecution"]),
+        b(flags["runtimeExecution"]),
+        b(flags["kv260Access"]),
+        b(flags["networkCalls"]),
+        b(flags["providerCalls"]),
+        b(flags["executesPccxLab"]),
+    )
+)
+'
+    )"; then
+        ERROR "chat composer JSON could not be summarized"
+        return 1
+    fi
+
+    HEAD "chat composer"
+    printf '%s\n' "$CHAT_COMPOSER_SUMMARY"
+}
 
 print_chat_readiness_summary() {
     SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
@@ -496,6 +594,10 @@ while [ $# -gt 0 ]; do
             INCLUDE_CHAT_READINESS="1"
             shift
             ;;
+        --include-chat-composer)
+            INCLUDE_CHAT_COMPOSER="1"
+            shift
+            ;;
         --backend)
             BACKEND="${2:-}"
             if [ -z "$BACKEND" ]; then
@@ -511,8 +613,8 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-if [ -n "$BACKEND" ] && { [ "$INCLUDE_RUNTIME_READINESS" = "1" ] || [ "$INCLUDE_DEVICE_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SESSION" = "1" ] || [ "$INCLUDE_CHAT_MODEL_STATUS" = "1" ] || [ "$INCLUDE_CHAT_READINESS" = "1" ]; }; then
-    ERROR "--include-runtime-readiness, --include-device-session, --include-chat-session, --include-chat-model-status, and --include-chat-readiness are only supported in local scaffold mode"
+if [ -n "$BACKEND" ] && { [ "$INCLUDE_RUNTIME_READINESS" = "1" ] || [ "$INCLUDE_DEVICE_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SESSION" = "1" ] || [ "$INCLUDE_CHAT_MODEL_STATUS" = "1" ] || [ "$INCLUDE_CHAT_READINESS" = "1" ] || [ "$INCLUDE_CHAT_COMPOSER" = "1" ]; }; then
+    ERROR "--include-runtime-readiness, --include-device-session, --include-chat-session, --include-chat-model-status, --include-chat-readiness, and --include-chat-composer are only supported in local scaffold mode"
     exit 1
 fi
 
@@ -530,7 +632,14 @@ if [ -z "$BACKEND" ]; then
     NOTE "chat/session  : opt-in via --include-chat-session (read-only blocked chat and lifecycle data)"
     NOTE "chat model    : opt-in via --include-chat-model-status (read-only model status display data)"
     NOTE "chat readiness: opt-in via --include-chat-readiness (read-only readiness and recovery data)"
+    NOTE "chat composer : opt-in via --include-chat-composer (read-only input control data)"
     NOTE "editor bridge  : planned (VS Code / other IDEs)"
+
+    if [ "$INCLUDE_CHAT_COMPOSER" = "1" ]; then
+        if ! print_chat_composer_summary; then
+            exit 1
+        fi
+    fi
 
     if [ "$INCLUDE_CHAT_MODEL_STATUS" = "1" ]; then
         if ! print_chat_model_status_summary; then

--- a/scripts/tests/chat_composer_contract_test.py
+++ b/scripts/tests/chat_composer_contract_test.py
@@ -1,0 +1,400 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Fixture tests for the standalone chat composer contract."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "contracts" / "chat_composer_contract.py"
+FIXTURE_PATH = (
+    ROOT
+    / "contracts"
+    / "fixtures"
+    / "chat-composer.gemma3n-e4b-kv260-placeholder.json"
+)
+SCRIPT_PATH = ROOT / "scripts" / "chat-composer-stub.sh"
+STATUS_TEST_PATH = ROOT / "scripts" / "tests" / "status-chat-composer.sh"
+DOC_PATH = ROOT / "docs" / "STANDALONE_CHAT_SESSION_CONTRACT.md"
+README_PATH = ROOT / "README.md"
+TEST_PATH = Path(__file__).resolve()
+CI_PATH = ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location(
+        "chat_composer_contract",
+        MODULE_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def flatten(value) -> str:
+    return json.dumps(value, sort_keys=True)
+
+
+def iter_state_values(value):
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            if key == "state" or key.endswith("State") or key.endswith("Status"):
+                yield nested
+            yield from iter_state_values(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            yield from iter_state_values(nested)
+
+
+def iter_keys(value):
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            yield key
+            yield from iter_keys(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            yield from iter_keys(nested)
+
+
+def assert_no_private_or_generated_data(text: str) -> None:
+    forbidden_patterns = [
+        r"/home/[^\s\"']+",
+        r"/Users/[^\s\"']+",
+        r"[A-Za-z]:\\Users\\",
+        r"\b(?:api[_-]?key|authorization|bearer|client[_-]?secret|password|private[_-]?key|secret|token)\b\s*[:=]",
+        r"\.(?:gguf|safetensors|ckpt|pt|pth|onnx)\b",
+        r"(?:weights|model_weights|model-cache)/(?:[^\"'\s]+)",
+        r"(?:raw[_-]?full[_-]?logs|hardware[_-]?dump|generated[_-]?blob)\s*[:=]",
+    ]
+    for pattern in forbidden_patterns:
+        assert not re.search(pattern, text, re.IGNORECASE), pattern
+
+
+def assert_no_runtime_implementation_terms(source: str) -> None:
+    forbidden = [
+        "subprocess",
+        "os.system",
+        "popen",
+        "socket",
+        "urllib",
+        "requests",
+        "http.client",
+        "openai",
+        "anthropic",
+        "gemini",
+        "modelcontextprotocol",
+        "websocket",
+        "xmutil",
+        "xrt-smi",
+        "lsusb",
+        "dmesg",
+    ]
+    lowered = source.lower()
+    for term in forbidden:
+        assert term not in lowered, term
+
+
+def assert_no_provider_configs(value) -> None:
+    forbidden_keys = {
+        "apiKey",
+        "accessToken",
+        "refreshToken",
+        "authorization",
+        "bearerToken",
+        "provider",
+        "providers",
+        "providerConfig",
+        "providerConfigs",
+    }
+    for key in iter_keys(value):
+        assert key not in forbidden_keys, key
+
+
+def assert_no_unsupported_claims(text: str) -> None:
+    literal_claims = [
+        "production-ready",
+        "marketplace-ready",
+        "stable API",
+        "stable ABI",
+        "KV260 inference works",
+        "Gemma 3N E4B runs on KV260",
+        "20 tok/s achieved",
+        "timing closed",
+        "bitstream ready",
+        "launcher executes pccx-lab",
+        "IDE controls launcher",
+        "AI provider integration is live",
+    ]
+    lowered = text.lower()
+    for claim in literal_claims:
+        assert claim.lower() not in lowered, claim
+
+    asserted_claim_patterns = [
+        r"\bMCP\s+(?:server|client)\s+(?:is\s+)?implemented\b",
+        r"\bLSP\s+(?:server|client)\s+(?:is\s+)?implemented\b",
+        r"\bAI\s+provider\s+(?:is\s+)?implemented\b",
+        r"\bKV260\s+run\s+(?:is\s+)?claimed\b",
+    ]
+    for pattern in asserted_claim_patterns:
+        assert not re.search(pattern, text, re.IGNORECASE), pattern
+
+
+def assert_no_chat_invocation_flags(source: str) -> None:
+    forbidden_patterns = [
+        r"--backend\s+pccx-lab",
+        r"\bPCCX_LAB_BIN\b",
+        r"\bpccx-lab\s+(?:status|diagnostics|validate)\b",
+        r"\bsystemverilog-ide\s+--",
+        r"\bsystemverilog-ide\s+(?:open|run|status|validate|launch)\b",
+        r"\b(?:curl|wget)\b",
+        r"\b(?:upload|telemetry|write-back)\s+(?:enabled|true)\b",
+    ]
+    for pattern in forbidden_patterns:
+        assert not re.search(pattern, source, re.IGNORECASE), pattern
+
+
+def test_chat_composer_matches_fixture_and_is_deterministic() -> None:
+    module = load_module()
+    generated = module.create_gemma3n_e4b_kv260_chat_composer()
+    fixture = json.loads(read_text(FIXTURE_PATH))
+
+    assert generated == fixture
+    assert module.chat_composer_json(generated) == module.chat_composer_json(generated)
+    assert module.chat_composer_json(generated).endswith("\n")
+    assert json.loads(module.chat_composer_json(generated)) == fixture
+
+
+def test_cli_stub_outputs_deterministic_json() -> None:
+    fixture = json.loads(read_text(FIXTURE_PATH))
+    command = [
+        "bash",
+        str(SCRIPT_PATH),
+        "--model",
+        "gemma3n-e4b",
+        "--target",
+        "kv260",
+    ]
+    first = subprocess.run(
+        command,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    second = subprocess.run(
+        command,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert first.stderr == ""
+    assert first.stdout == second.stdout
+    assert first.stdout.endswith("\n")
+    assert json.loads(first.stdout) == fixture
+
+
+def test_required_fields_and_allowed_states() -> None:
+    module = load_module()
+    composer = module.create_gemma3n_e4b_kv260_chat_composer()
+    allowed = set(module.CHAT_COMPOSER_STATE_VALUES)
+
+    assert tuple(composer.keys()) == module.CHAT_COMPOSER_FIELDS
+    assert composer["schemaVersion"] == "pccx.chatComposer.v0"
+    assert tuple(composer["inputPolicy"].keys()) == module.INPUT_POLICY_FIELDS
+
+    states = list(iter_state_values(composer))
+    assert states
+    for state in states:
+        assert state in allowed, state
+
+    for control in composer["composerControls"]:
+        assert tuple(control.keys()) == module.COMPOSER_CONTROL_FIELDS
+    for rule in composer["validationRules"]:
+        assert tuple(rule.keys()) == module.VALIDATION_RULE_FIELDS
+    for reason in composer["blockedReasons"]:
+        assert tuple(reason.keys()) == module.BLOCKED_REASON_FIELDS
+    for ref in composer["handoffRefs"]:
+        assert tuple(ref.keys()) == module.HANDOFF_REF_FIELDS
+
+
+def test_chat_composer_covers_issue_9_input_boundary() -> None:
+    composer = load_module().create_gemma3n_e4b_kv260_chat_composer()
+    controls = {control["controlId"]: control for control in composer["composerControls"]}
+    rules = {rule["ruleId"]: rule for rule in composer["validationRules"]}
+    reasons = {reason["reasonId"]: reason for reason in composer["blockedReasons"]}
+    refs = {ref["refId"]: ref for ref in composer["handoffRefs"]}
+
+    assert composer["composerState"] == "blocked"
+    assert composer["inputBufferState"] == "empty_not_captured"
+    assert composer["sendControlState"] == "disabled"
+    assert composer["attachmentState"] == "disabled"
+    assert composer["privacyState"] == "available_as_data"
+    assert composer["validationState"] == "blocked"
+    assert composer["inputPolicy"]["promptCapture"] == "disabled"
+    assert composer["inputPolicy"]["promptEcho"] == "disabled"
+    assert composer["inputPolicy"]["promptPersistence"] == "disabled"
+    assert composer["inputPolicy"]["contentIncluded"] is False
+    assert set(controls) == {
+        "focus_input",
+        "attach_context",
+        "send_message",
+        "clear_draft",
+    }
+    for control in controls.values():
+        assert control["enabled"] is False
+    assert controls["attach_context"]["state"] == "disabled"
+    assert controls["send_message"]["state"] == "disabled"
+    assert set(rules) == {
+        "no_prompt_content_in_fixture",
+        "runtime_readiness_required",
+        "model_load_required",
+        "session_store_required",
+        "attachment_boundary_required",
+        "provider_mode_disabled",
+    }
+    assert rules["no_prompt_content_in_fixture"]["state"] == "available_as_data"
+    assert rules["runtime_readiness_required"]["state"] == "blocked"
+    assert rules["model_load_required"]["state"] == "not_loaded"
+    assert set(reasons) == {
+        "send_readiness_blocked",
+        "draft_capture_not_reviewed",
+        "attachment_boundary_absent",
+        "runtime_not_started",
+    }
+    assert set(refs) == {
+        "chat_session",
+        "chat_readiness",
+        "chat_model_status",
+        "chat_session_lifecycle",
+    }
+
+
+def test_safety_flags_preserve_data_only_boundary() -> None:
+    composer = load_module().create_gemma3n_e4b_kv260_chat_composer()
+    flags = composer["safetyFlags"]
+
+    assert flags["dataOnly"] is True
+    assert flags["readOnly"] is True
+    assert flags["deterministic"] is True
+    assert flags["composerDisplayOnly"] is True
+    for name in [
+        "writesArtifacts",
+        "readsArtifacts",
+        "attachmentReads",
+        "fileUpload",
+        "clipboardRead",
+        "clipboardWrite",
+        "promptContentIncluded",
+        "promptEchoed",
+        "promptPersistence",
+        "responseContentIncluded",
+        "responseGenerated",
+        "transcriptPersistence",
+        "sessionPersistence",
+        "modelAssetPathsIncluded",
+        "modelWeightPathsIncluded",
+        "modelLoadAttempted",
+        "modelLoaded",
+        "modelExecution",
+        "runtimeExecution",
+        "touchesHardware",
+        "kv260Access",
+        "opensSerialPort",
+        "networkCalls",
+        "networkScan",
+        "sshExecution",
+        "providerCalls",
+        "cloudCalls",
+        "privatePathsIncluded",
+        "secretsIncluded",
+        "tokensIncluded",
+        "generatedBlobsIncluded",
+        "hardwareDumpsIncluded",
+        "telemetry",
+        "automaticUpload",
+        "writeBack",
+        "executesPccxLab",
+        "executesSystemverilogIde",
+        "mcpServerImplemented",
+        "lspImplemented",
+        "stableApiAbiClaim",
+    ]:
+        assert flags[name] is False, name
+
+
+def test_docs_and_sources_avoid_private_data_runtime_calls_or_overclaims() -> None:
+    module_source = read_text(MODULE_PATH)
+    script_source = read_text(SCRIPT_PATH)
+    status_test_source = read_text(STATUS_TEST_PATH)
+    composer = load_module().create_gemma3n_e4b_kv260_chat_composer()
+    scan_text = "\n".join([
+        read_text(FIXTURE_PATH),
+        read_text(DOC_PATH),
+        read_text(README_PATH),
+        flatten(composer),
+        module_source,
+        script_source,
+        status_test_source,
+    ])
+    runtime_source = "\n".join([module_source, script_source])
+
+    assert_no_runtime_implementation_terms(runtime_source)
+    assert_no_private_or_generated_data(scan_text)
+    assert_no_provider_configs(composer)
+    assert_no_unsupported_claims(scan_text)
+    assert_no_chat_invocation_flags(runtime_source)
+
+
+def test_source_headers_for_touched_code_files() -> None:
+    expected_headers = {
+        MODULE_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        SCRIPT_PATH: [
+            "#!/usr/bin/env bash",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        STATUS_TEST_PATH: [
+            "#!/usr/bin/env bash",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        TEST_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        CI_PATH: [
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+    }
+
+    for path, header in expected_headers.items():
+        assert read_text(path).splitlines()[: len(header)] == header, path
+
+
+test_chat_composer_matches_fixture_and_is_deterministic()
+test_cli_stub_outputs_deterministic_json()
+test_required_fields_and_allowed_states()
+test_chat_composer_covers_issue_9_input_boundary()
+test_safety_flags_preserve_data_only_boundary()
+test_docs_and_sources_avoid_private_data_runtime_calls_or_overclaims()
+test_source_headers_for_touched_code_files()
+
+print("chat composer contract tests ok")

--- a/scripts/tests/status-chat-composer.sh
+++ b/scripts/tests/status-chat-composer.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+# scripts/tests/status-chat-composer.sh - status chat composer summary tests.
+#
+# Usage: bash scripts/tests/status-chat-composer.sh [path/to/status-stub.sh]
+
+set -eu
+
+PASS() { printf '[PASS]  %s\n' "$*"; }
+FAIL() { printf '[FAIL]  %s\n' "$*" >&2; }
+HEAD() { printf '\n=== %s ===\n' "$*"; }
+
+STUB="${1:-scripts/status-stub.sh}"
+
+if [ ! -x "$STUB" ]; then
+    chmod +x "$STUB"
+fi
+
+contains() {
+    case "$1" in
+        *"$2"*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+require_contains() {
+    local output="$1"
+    local expected="$2"
+    if ! contains "$output" "$expected"; then
+        FAIL "expected output to contain: $expected"
+        printf '%s\n' "$output" >&2
+        exit 1
+    fi
+}
+
+require_not_contains() {
+    local output="$1"
+    local forbidden="$2"
+    if contains "$output" "$forbidden"; then
+        FAIL "output contained forbidden text: $forbidden"
+        printf '%s\n' "$output" >&2
+        exit 1
+    fi
+}
+
+HEAD "1: status can include chat composer"
+OUTPUT="$("$STUB" --include-chat-composer)"
+require_contains "$OUTPUT" "=== chat composer ==="
+require_contains "$OUTPUT" "source     : scripts/chat-composer-stub.sh --model gemma3n-e4b --target kv260"
+require_contains "$OUTPUT" "boundary   : read-only data; no prompt/provider/model/hardware/lab/IDE execution"
+require_contains "$OUTPUT" "target     : kv260"
+require_contains "$OUTPUT" "model      : gemma3n-e4b"
+require_contains "$OUTPUT" "composer   : blocked"
+require_contains "$OUTPUT" "input      : empty_not_captured"
+require_contains "$OUTPUT" "send       : disabled"
+require_contains "$OUTPUT" "attachment : disabled"
+require_contains "$OUTPUT" "privacy    : available_as_data"
+require_contains "$OUTPUT" "validation : blocked"
+PASS "chat composer section is present and conservative"
+
+HEAD "2: composer controls and validation rules stay non-executing"
+require_contains "$OUTPUT" "controls   : focus_input=placeholder"
+require_contains "$OUTPUT" "attach_context=disabled"
+require_contains "$OUTPUT" "send_message=disabled"
+require_contains "$OUTPUT" "clear_draft=inactive"
+require_contains "$OUTPUT" "rules      : no_prompt_content_in_fixture=available_as_data"
+require_contains "$OUTPUT" "runtime_readiness_required=blocked"
+require_contains "$OUTPUT" "model_load_required=not_loaded"
+require_contains "$OUTPUT" "session_store_required=not_configured"
+require_contains "$OUTPUT" "attachment_boundary_required=planned"
+require_contains "$OUTPUT" "provider_mode_disabled=not_used"
+require_contains "$OUTPUT" "blocked    : send_readiness_blocked=blocked"
+require_contains "$OUTPUT" "draft_capture_not_reviewed=not_configured"
+require_contains "$OUTPUT" "attachment_boundary_absent=planned"
+require_contains "$OUTPUT" "runtime_not_started=not_started"
+PASS "composer controls, validation rules, and blocked reasons are summarized"
+
+HEAD "3: safety flags stay read-only and non-executing"
+require_contains "$OUTPUT" "readOnly=true"
+require_contains "$OUTPUT" "dataOnly=true"
+require_contains "$OUTPUT" "deterministic=true"
+require_contains "$OUTPUT" "composerDisplayOnly=true"
+require_contains "$OUTPUT" "writesArtifacts=false"
+require_contains "$OUTPUT" "readsArtifacts=false"
+require_contains "$OUTPUT" "attachmentReads=false"
+require_contains "$OUTPUT" "fileUpload=false"
+require_contains "$OUTPUT" "clipboardRead=false"
+require_contains "$OUTPUT" "clipboardWrite=false"
+require_contains "$OUTPUT" "promptContentIncluded=false"
+require_contains "$OUTPUT" "promptEchoed=false"
+require_contains "$OUTPUT" "promptPersistence=false"
+require_contains "$OUTPUT" "responseContentIncluded=false"
+require_contains "$OUTPUT" "modelLoadAttempted=false"
+require_contains "$OUTPUT" "modelLoaded=false"
+require_contains "$OUTPUT" "modelExecution=false"
+require_contains "$OUTPUT" "runtimeExecution=false"
+require_contains "$OUTPUT" "kv260Access=false"
+require_contains "$OUTPUT" "networkCalls=false"
+require_contains "$OUTPUT" "providerCalls=false"
+require_contains "$OUTPUT" "executesPccxLab=false"
+PASS "execution-related flags remain false"
+
+HEAD "4: output is deterministic"
+OUTPUT_AGAIN="$("$STUB" --include-chat-composer)"
+if [ "$OUTPUT" != "$OUTPUT_AGAIN" ]; then
+    FAIL "status chat composer output changed between runs"
+    exit 1
+fi
+PASS "status chat composer output is deterministic"
+
+HEAD "5: chat composer option does not combine with pccx-lab backend"
+if "$STUB" --include-chat-composer --backend pccx-lab >/dev/null 2>&1; then
+    FAIL "expected combined chat-composer/backend mode to fail"
+    exit 1
+fi
+PASS "chat composer remains separate from backend execution"
+
+HEAD "6: output avoids known overclaims and prompt echo"
+FORBIDDEN_PREFIX="KV260 inference"
+FORBIDDEN_CLAIM="${FORBIDDEN_PREFIX} works"
+require_not_contains "$OUTPUT" "$FORBIDDEN_CLAIM"
+THROUGHPUT_PREFIX="20 tok/s"
+THROUGHPUT_CLAIM="${THROUGHPUT_PREFIX} achieved"
+require_not_contains "$OUTPUT" "$THROUGHPUT_CLAIM"
+require_not_contains "$OUTPUT" "hello"
+PASS "no chat composer overclaim or prompt echo in status output"
+
+printf '\n[DONE]  all status-chat-composer tests passed\n'


### PR DESCRIPTION
Summary:
- Add checked `pccx.chatComposer.v0` fixture and stub for data-only composer/input-control state.
- Wire status summary, tests, README, docs, and CI coverage.
- Keep prompts, attachments, runtime/model/provider/hardware/lab/IDE execution, artifact reads/writes, telemetry, upload, release/tag behavior, and compatibility promises out of scope.

Refs #9.

Validation:
- `git diff --check`
- `python3 scripts/tests/chat_composer_contract_test.py`
- `bash scripts/chat-composer-stub.sh --model gemma3n-e4b --target kv260`
- `bash scripts/status-stub.sh --include-chat-composer`
- `bash scripts/tests/status-chat-composer.sh scripts/status-stub.sh`
- `python3 scripts/tests/chat_session_contract_test.py`
- `python3 scripts/tests/chat_readiness_contract_test.py`
- `bash scripts/check.sh`
- `python3 scripts/tests/chat_model_status_contract_test.py`
- `python3 scripts/tests/chat_session_lifecycle_contract_test.py`
- `python3 scripts/tests/chat_surface_preview_test.py`
- `bash scripts/tests/status-chat-model-status.sh scripts/status-stub.sh`
- `bash scripts/tests/status-chat-readiness.sh scripts/status-stub.sh`