### PR TITLE
Add chat send result boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,7 @@ jobs:
                    scripts/chat-session-lifecycle-stub.sh \
                    scripts/chat-readiness-stub.sh \
                    scripts/chat-composer-stub.sh \
+                   scripts/chat-send-result-stub.sh \
                    scripts/chat-surface-preview.sh \
                    scripts/chat-stub.sh; do
             [ -f "$f" ] && chmod +x "$f" || true
@@ -173,6 +174,10 @@ jobs:
         run: ./scripts/status-stub.sh --include-chat-composer
       - name: run scripts/chat-composer-stub.sh
         run: ./scripts/chat-composer-stub.sh --model gemma3n-e4b --target kv260
+      - name: run scripts/status-stub.sh with chat send result
+        run: ./scripts/status-stub.sh --include-chat-send-result
+      - name: run scripts/chat-send-result-stub.sh
+        run: ./scripts/chat-send-result-stub.sh --model gemma3n-e4b --target kv260
       - name: run scripts/chat-surface-preview.sh
         run: ./scripts/chat-surface-preview.sh --model gemma3n-e4b --target kv260
       - name: run scripts/chat-stub.sh --dry-run
@@ -205,6 +210,8 @@ jobs:
         run: python3 scripts/tests/chat_readiness_contract_test.py
       - name: run chat composer contract tests
         run: python3 scripts/tests/chat_composer_contract_test.py
+      - name: run chat send-result contract tests
+        run: python3 scripts/tests/chat_send_result_contract_test.py
       - name: run chat surface preview tests
         run: python3 scripts/tests/chat_surface_preview_test.py
 
@@ -222,6 +229,7 @@ jobs:
           chmod +x scripts/chat-session-lifecycle-stub.sh
           chmod +x scripts/chat-readiness-stub.sh
           chmod +x scripts/chat-composer-stub.sh
+          chmod +x scripts/chat-send-result-stub.sh
           chmod +x scripts/launch-stub.sh
           chmod +x scripts/tests/status-backend.sh
           chmod +x scripts/tests/status-device-session.sh
@@ -230,6 +238,7 @@ jobs:
           chmod +x scripts/tests/status-chat-session.sh
           chmod +x scripts/tests/status-chat-readiness.sh
           chmod +x scripts/tests/status-chat-composer.sh
+          chmod +x scripts/tests/status-chat-send-result.sh
       - name: shellcheck status-stub and test script
         run: |
           sudo apt-get update -q && sudo apt-get install -y -q shellcheck
@@ -241,6 +250,7 @@ jobs:
           shellcheck scripts/tests/status-chat-session.sh
           shellcheck scripts/tests/status-chat-readiness.sh
           shellcheck scripts/tests/status-chat-composer.sh
+          shellcheck scripts/tests/status-chat-send-result.sh
       - name: run status-backend tests
         run: bash scripts/tests/status-backend.sh scripts/status-stub.sh
       - name: run status-device-session tests
@@ -255,3 +265,5 @@ jobs:
         run: bash scripts/tests/status-chat-readiness.sh scripts/status-stub.sh
       - name: run status-chat-composer tests
         run: bash scripts/tests/status-chat-composer.sh scripts/status-stub.sh
+      - name: run status-chat-send-result tests
+        run: bash scripts/tests/status-chat-send-result.sh scripts/status-stub.sh

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ and verify host-side prerequisites before the real engine lands.
 | [`scripts/check.sh`](./scripts/check.sh) | Probe host info, tooling availability, edge-device hints. Always exits 0. |
 | [`scripts/check-device-stub.sh`](./scripts/check-device-stub.sh) | Narrowly scoped device-tree / FPGA-node probe (KV260 / Kria detection only). Always exits 0. |
 | [`scripts/install-stub.sh`](./scripts/install-stub.sh) | Preview of the planned install flow; reports which host runtime pieces are present, lists device-side pieces as future deliverables. Always exits 0. |
-| [`scripts/status-stub.sh`](./scripts/status-stub.sh) | Launcher state summary. Default mode: local scaffold output, always exits 0. With `--include-chat-composer`, adds read-only chat composer/input-control data. With `--include-chat-model-status`, adds read-only blocked chat model-status display data. With `--include-chat-session`, adds read-only blocked chat/session and lifecycle summaries. With `--include-chat-readiness`, adds read-only chat readiness checks and recovery actions. With `--include-device-session`, adds a read-only device/session status panel. With `--include-runtime-readiness`, adds a read-only runtime readiness summary. With `--backend pccx-lab`, calls `pccx-lab status --format json` and forwards the run-status envelope (exits non-zero if binary is missing or output is invalid). |
+| [`scripts/status-stub.sh`](./scripts/status-stub.sh) | Launcher state summary. Default mode: local scaffold output, always exits 0. With `--include-chat-send-result`, adds read-only blocked chat send-result data. With `--include-chat-composer`, adds read-only chat composer/input-control data. With `--include-chat-model-status`, adds read-only blocked chat model-status display data. With `--include-chat-session`, adds read-only blocked chat/session and lifecycle summaries. With `--include-chat-readiness`, adds read-only chat readiness checks and recovery actions. With `--include-device-session`, adds a read-only device/session status panel. With `--include-runtime-readiness`, adds a read-only runtime readiness summary. With `--backend pccx-lab`, calls `pccx-lab status --format json` and forwards the run-status envelope (exits non-zero if binary is missing or output is invalid). |
 | [`scripts/device-session-status-stub.sh`](./scripts/device-session-status-stub.sh) | Data-only device/session status JSON for the Gemma 3N E4B + KV260 target. Reports connection, model load, session, diagnostics, readiness, discovery paths, flow steps, and error taxonomy as placeholder / blocked. |
 | [`scripts/runtime-readiness-stub.sh`](./scripts/runtime-readiness-stub.sh) | Data-only runtime readiness JSON for the Gemma 3N E4B + KV260 target. Reports blocked / not yet evidence-backed. |
 | [`scripts/chat-session-stub.sh`](./scripts/chat-session-stub.sh) | Data-only standalone chat/session JSON for the Gemma 3N E4B + KV260 target. Reports disabled send controls, inactive session state, no prompt/response persistence, and readiness handoff references. |
@@ -95,6 +95,7 @@ and verify host-side prerequisites before the real engine lands.
 | [`scripts/chat-model-status-stub.sh`](./scripts/chat-model-status-stub.sh) | Data-only chat model-status JSON for the Gemma 3N E4B + KV260 target. Reports descriptor, asset, load, runtime, context, and response display rows as blocked, disabled, or unavailable. |
 | [`scripts/chat-readiness-stub.sh`](./scripts/chat-readiness-stub.sh) | Data-only chat readiness JSON for the Gemma 3N E4B + KV260 target. Reports readiness checks, error categories, and recovery actions as blocked, disabled, or local data only. |
 | [`scripts/chat-composer-stub.sh`](./scripts/chat-composer-stub.sh) | Data-only chat composer JSON for the Gemma 3N E4B + KV260 target. Reports input buffer, send, attachment, validation, and privacy states without reading, echoing, storing, or persisting prompt text. |
+| [`scripts/chat-send-result-stub.sh`](./scripts/chat-send-result-stub.sh) | Data-only blocked chat send-result JSON for the Gemma 3N E4B + KV260 target. Reports disabled send state, no accepted input, no prompt echo, no generated response, and no runtime/model handoff. |
 | [`scripts/chat-surface-preview.sh`](./scripts/chat-surface-preview.sh) | Read-only terminal preview of the standalone chat surface. Renders the checked chat/session contract as blocked UI state without accepting prompts, executing a model, or writing artifacts. |
 | [`scripts/launch-stub.sh`](./scripts/launch-stub.sh) | Dry-run preview of the intended launch sequence. Requires `--dry-run`; exits 1 without it. |
 | [`scripts/chat-stub.sh`](./scripts/chat-stub.sh) | Dry-run chat stub. Requires `--dry-run`; exits 1 without it. Accepts `--prompt "..."` or stdin. No model is executed. |
@@ -108,6 +109,7 @@ bash scripts/status-stub.sh --include-chat-model-status
 bash scripts/status-stub.sh --include-chat-session
 bash scripts/status-stub.sh --include-chat-readiness
 bash scripts/status-stub.sh --include-chat-composer
+bash scripts/status-stub.sh --include-chat-send-result
 bash scripts/status-stub.sh --include-device-session
 bash scripts/status-stub.sh --include-runtime-readiness
 bash scripts/device-session-status-stub.sh --model gemma3n-e4b --target kv260
@@ -117,6 +119,7 @@ bash scripts/chat-session-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-session-lifecycle-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-readiness-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-composer-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/chat-send-result-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-surface-preview.sh --model gemma3n-e4b --target kv260
 bash scripts/launch-stub.sh --dry-run
 bash scripts/chat-stub.sh --dry-run --prompt "hello"

--- a/contracts/chat_send_result_contract.py
+++ b/contracts/chat_send_result_contract.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Data-only chat send-result contract for the planned launcher UI.
+
+The contract describes the conservative result shown when a future chat send
+action remains blocked. It does not read, accept, echo, store, or persist
+prompt content. It also does not generate responses, load models, start runtime
+code, touch KV260 hardware, call providers, invoke pccx-lab, or read/write
+artifacts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import sys
+
+
+SCHEMA_VERSION = "pccx.chatSendResult.v0"
+RESULT_ENVELOPE_SCHEMA_VERSION = "pccx.chatSendResultEnvelope.v0"
+
+CHAT_SEND_RESULT_FIELDS = (
+    "schemaVersion",
+    "sendResultId",
+    "fixtureVersion",
+    "lastUpdatedSource",
+    "targetDevice",
+    "targetBoard",
+    "targetModel",
+    "resultState",
+    "sendAttemptState",
+    "promptHandlingState",
+    "responseState",
+    "runtimeState",
+    "modelState",
+    "sessionState",
+    "errorState",
+    "userVisibleState",
+    "chatComposerRef",
+    "chatReadinessRef",
+    "parentChatSessionRef",
+    "resultEnvelope",
+    "blockedReasons",
+    "displayMessages",
+    "handoffRefs",
+    "safetyFlags",
+    "limitations",
+    "issueRefs",
+)
+
+RESULT_ENVELOPE_FIELDS = (
+    "schemaVersion",
+    "envelopeId",
+    "state",
+    "sendAttempted",
+    "inputAccepted",
+    "promptContentIncluded",
+    "promptEchoed",
+    "responseGenerated",
+    "responseContentIncluded",
+    "exitCode",
+    "contentPolicy",
+    "sideEffectPolicy",
+    "summary",
+)
+
+BLOCKED_REASON_FIELDS = (
+    "reasonId",
+    "state",
+    "summary",
+    "requiredBefore",
+)
+
+DISPLAY_MESSAGE_FIELDS = (
+    "messageId",
+    "state",
+    "severity",
+    "userMessage",
+    "diagnosticHint",
+    "contentPolicy",
+)
+
+HANDOFF_REF_FIELDS = (
+    "refId",
+    "schemaVersion",
+    "fixturePath",
+    "state",
+    "summary",
+)
+
+CHAT_SEND_RESULT_STATE_VALUES = (
+    "available_as_data",
+    "blocked",
+    "disabled",
+    "empty_not_captured",
+    "external_not_configured",
+    "inactive",
+    "not_configured",
+    "not_generated",
+    "not_loaded",
+    "not_started",
+    "not_used",
+    "placeholder",
+    "planned",
+    "requires_evidence",
+    "target_selected",
+    "unavailable",
+)
+
+_CHAT_SEND_RESULT = {
+    "schemaVersion": SCHEMA_VERSION,
+    "sendResultId": "chat_send_result_gemma3n_e4b_kv260_placeholder",
+    "fixtureVersion": "chat-send-result.gemma3n-e4b-kv260.2026-05-04",
+    "lastUpdatedSource": "pccx_launcher_issue_9_chat_send_result_boundary_2026-05-04",
+    "targetDevice": "kv260",
+    "targetBoard": "xilinx_kria_kv260",
+    "targetModel": "gemma3n-e4b",
+    "resultState": "blocked",
+    "sendAttemptState": "disabled",
+    "promptHandlingState": "empty_not_captured",
+    "responseState": "not_generated",
+    "runtimeState": "not_started",
+    "modelState": "not_loaded",
+    "sessionState": "inactive",
+    "errorState": "blocked",
+    "userVisibleState": "available_as_data",
+    "chatComposerRef": "chat_composer_gemma3n_e4b_kv260_placeholder",
+    "chatReadinessRef": "chat_readiness_gemma3n_e4b_kv260_placeholder",
+    "parentChatSessionRef": "chat_session_gemma3n_e4b_kv260_placeholder",
+    "resultEnvelope": {
+        "schemaVersion": RESULT_ENVELOPE_SCHEMA_VERSION,
+        "envelopeId": "blocked_send_result_gemma3n_e4b_kv260_placeholder",
+        "state": "blocked",
+        "sendAttempted": False,
+        "inputAccepted": False,
+        "promptContentIncluded": False,
+        "promptEchoed": False,
+        "responseGenerated": False,
+        "responseContentIncluded": False,
+        "exitCode": None,
+        "contentPolicy": "fixture carries blocked result metadata only; no prompt or response body is stored",
+        "sideEffectPolicy": "no_runtime_execution_no_write",
+        "summary": "Send is disabled because readiness, runtime, model, and session evidence are missing.",
+    },
+    "blockedReasons": [
+        {
+            "reasonId": "composer_send_disabled",
+            "state": "disabled",
+            "summary": "The composer send control remains disabled.",
+            "requiredBefore": "send_attempt_recorded",
+        },
+        {
+            "reasonId": "readiness_blocked",
+            "state": "blocked",
+            "summary": "Chat readiness has not advanced beyond the blocked checklist state.",
+            "requiredBefore": "send_message_enabled",
+        },
+        {
+            "reasonId": "runtime_not_started",
+            "state": "not_started",
+            "summary": "No local chat runtime has been implemented or started.",
+            "requiredBefore": "assistant_response_available",
+        },
+        {
+            "reasonId": "model_not_loaded",
+            "state": "not_loaded",
+            "summary": "Model assets are not configured or loaded by this fixture.",
+            "requiredBefore": "model_execution_enabled",
+        },
+        {
+            "reasonId": "session_store_not_configured",
+            "state": "not_configured",
+            "summary": "No reviewed local session store or retention rule exists.",
+            "requiredBefore": "result_or_transcript_persistence_enabled",
+        },
+    ],
+    "displayMessages": [
+        {
+            "messageId": "send_disabled",
+            "state": "disabled",
+            "severity": "blocked",
+            "userMessage": "Send is disabled until local chat readiness evidence exists.",
+            "diagnosticHint": "Review the chat readiness and composer fixtures before enabling send.",
+            "contentPolicy": "no_prompt_response_or_transcript_content",
+        },
+        {
+            "messageId": "response_unavailable",
+            "state": "not_generated",
+            "severity": "info",
+            "userMessage": "Assistant response output is unavailable in this fixture.",
+            "diagnosticHint": "A future reviewed runtime boundary is required before responses can exist.",
+            "contentPolicy": "no_generated_response_content",
+        },
+    ],
+    "handoffRefs": [
+        {
+            "refId": "chat_session",
+            "schemaVersion": "pccx.chatSession.v0",
+            "fixturePath": "contracts/fixtures/chat-session.gemma3n-e4b-kv260-placeholder.json",
+            "state": "available_as_data",
+            "summary": "Base chat/session state is consumed as local data only.",
+        },
+        {
+            "refId": "chat_composer",
+            "schemaVersion": "pccx.chatComposer.v0",
+            "fixturePath": "contracts/fixtures/chat-composer.gemma3n-e4b-kv260-placeholder.json",
+            "state": "blocked",
+            "summary": "Composer send controls remain disabled.",
+        },
+        {
+            "refId": "chat_readiness",
+            "schemaVersion": "pccx.chatReadiness.v0",
+            "fixturePath": "contracts/fixtures/chat-readiness.gemma3n-e4b-kv260-placeholder.json",
+            "state": "blocked",
+            "summary": "Chat readiness keeps message send unavailable.",
+        },
+        {
+            "refId": "chat_model_status",
+            "schemaVersion": "pccx.chatModelStatus.v0",
+            "fixturePath": "contracts/fixtures/chat-model-status.gemma3n-e4b-kv260-placeholder.json",
+            "state": "available_as_data",
+            "summary": "Model status display is consumed as local data only.",
+        },
+        {
+            "refId": "chat_session_lifecycle",
+            "schemaVersion": "pccx.chatSessionLifecycle.v0",
+            "fixturePath": "contracts/fixtures/chat-session-lifecycle.gemma3n-e4b-kv260-placeholder.json",
+            "state": "blocked",
+            "summary": "Session lifecycle operations remain disabled or blocked.",
+        },
+    ],
+    "safetyFlags": {
+        "dataOnly": True,
+        "readOnly": True,
+        "deterministic": True,
+        "sendResultDisplayOnly": True,
+        "writesArtifacts": False,
+        "readsArtifacts": False,
+        "attachmentReads": False,
+        "fileUpload": False,
+        "clipboardRead": False,
+        "clipboardWrite": False,
+        "promptCapture": False,
+        "promptContentIncluded": False,
+        "promptEchoed": False,
+        "promptPersistence": False,
+        "inputAccepted": False,
+        "sendAttempted": False,
+        "responseContentIncluded": False,
+        "responseGenerated": False,
+        "transcriptPersistence": False,
+        "sessionPersistence": False,
+        "modelAssetPathsIncluded": False,
+        "modelWeightPathsIncluded": False,
+        "modelLoadAttempted": False,
+        "modelLoaded": False,
+        "modelExecution": False,
+        "runtimeExecution": False,
+        "touchesHardware": False,
+        "kv260Access": False,
+        "opensSerialPort": False,
+        "networkCalls": False,
+        "networkScan": False,
+        "sshExecution": False,
+        "providerCalls": False,
+        "cloudCalls": False,
+        "privatePathsIncluded": False,
+        "secretsIncluded": False,
+        "tokensIncluded": False,
+        "generatedBlobsIncluded": False,
+        "hardwareDumpsIncluded": False,
+        "telemetry": False,
+        "automaticUpload": False,
+        "writeBack": False,
+        "executesPccxLab": False,
+        "executesSystemverilogIde": False,
+        "mcpServerImplemented": False,
+        "lspImplemented": False,
+        "stableApiAbiClaim": False,
+    },
+    "limitations": [
+        "Data-only blocked chat send-result fixture; no prompt text is read, accepted, echoed, stored, or persisted.",
+        "No assistant response, transcript, summary, model path, generated artifact, private path, secret, or token is read or written.",
+        "No KV260 hardware access, serial access, SSH execution, network call, provider call, telemetry, upload, or write-back is performed.",
+        "The send result remains blocked until chat readiness, runtime, model-load, device-session, and local session evidence are available.",
+        "This is not a release, tag, versioned compatibility commitment, MCP, LSP, IDE, marketplace, or telemetry implementation.",
+    ],
+    "issueRefs": [
+        "pccxai/pccx-llm-launcher#9",
+    ],
+}
+
+
+def create_gemma3n_e4b_kv260_chat_send_result() -> dict:
+    """Return the checked Gemma 3N E4B plus KV260 chat send-result fixture."""
+    return copy.deepcopy(_CHAT_SEND_RESULT)
+
+
+def chat_send_result_json(result: dict | None = None) -> str:
+    """Render a deterministic JSON representation."""
+    return json.dumps(
+        result if result is not None else create_gemma3n_e4b_kv260_chat_send_result(),
+        indent=2,
+        sort_keys=True,
+    ) + "\n"
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Print data-only chat send-result JSON.",
+    )
+    parser.add_argument(
+        "--model",
+        default="gemma3n-e4b",
+        choices=("gemma3n-e4b",),
+        help="model descriptor target",
+    )
+    parser.add_argument(
+        "--target",
+        default="kv260",
+        choices=("kv260",),
+        help="target board/device",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parse_args(sys.argv[1:] if argv is None else argv)
+    sys.stdout.write(chat_send_result_json())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contracts/fixtures/chat-send-result.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-send-result.gemma3n-e4b-kv260-placeholder.json
@@ -1,0 +1,182 @@
+{
+  "blockedReasons": [
+    {
+      "reasonId": "composer_send_disabled",
+      "requiredBefore": "send_attempt_recorded",
+      "state": "disabled",
+      "summary": "The composer send control remains disabled."
+    },
+    {
+      "reasonId": "readiness_blocked",
+      "requiredBefore": "send_message_enabled",
+      "state": "blocked",
+      "summary": "Chat readiness has not advanced beyond the blocked checklist state."
+    },
+    {
+      "reasonId": "runtime_not_started",
+      "requiredBefore": "assistant_response_available",
+      "state": "not_started",
+      "summary": "No local chat runtime has been implemented or started."
+    },
+    {
+      "reasonId": "model_not_loaded",
+      "requiredBefore": "model_execution_enabled",
+      "state": "not_loaded",
+      "summary": "Model assets are not configured or loaded by this fixture."
+    },
+    {
+      "reasonId": "session_store_not_configured",
+      "requiredBefore": "result_or_transcript_persistence_enabled",
+      "state": "not_configured",
+      "summary": "No reviewed local session store or retention rule exists."
+    }
+  ],
+  "chatComposerRef": "chat_composer_gemma3n_e4b_kv260_placeholder",
+  "chatReadinessRef": "chat_readiness_gemma3n_e4b_kv260_placeholder",
+  "displayMessages": [
+    {
+      "contentPolicy": "no_prompt_response_or_transcript_content",
+      "diagnosticHint": "Review the chat readiness and composer fixtures before enabling send.",
+      "messageId": "send_disabled",
+      "severity": "blocked",
+      "state": "disabled",
+      "userMessage": "Send is disabled until local chat readiness evidence exists."
+    },
+    {
+      "contentPolicy": "no_generated_response_content",
+      "diagnosticHint": "A future reviewed runtime boundary is required before responses can exist.",
+      "messageId": "response_unavailable",
+      "severity": "info",
+      "state": "not_generated",
+      "userMessage": "Assistant response output is unavailable in this fixture."
+    }
+  ],
+  "errorState": "blocked",
+  "fixtureVersion": "chat-send-result.gemma3n-e4b-kv260.2026-05-04",
+  "handoffRefs": [
+    {
+      "fixturePath": "contracts/fixtures/chat-session.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_session",
+      "schemaVersion": "pccx.chatSession.v0",
+      "state": "available_as_data",
+      "summary": "Base chat/session state is consumed as local data only."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-composer.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_composer",
+      "schemaVersion": "pccx.chatComposer.v0",
+      "state": "blocked",
+      "summary": "Composer send controls remain disabled."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-readiness.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_readiness",
+      "schemaVersion": "pccx.chatReadiness.v0",
+      "state": "blocked",
+      "summary": "Chat readiness keeps message send unavailable."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-model-status.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_model_status",
+      "schemaVersion": "pccx.chatModelStatus.v0",
+      "state": "available_as_data",
+      "summary": "Model status display is consumed as local data only."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-session-lifecycle.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_session_lifecycle",
+      "schemaVersion": "pccx.chatSessionLifecycle.v0",
+      "state": "blocked",
+      "summary": "Session lifecycle operations remain disabled or blocked."
+    }
+  ],
+  "issueRefs": [
+    "pccxai/pccx-llm-launcher#9"
+  ],
+  "lastUpdatedSource": "pccx_launcher_issue_9_chat_send_result_boundary_2026-05-04",
+  "limitations": [
+    "Data-only blocked chat send-result fixture; no prompt text is read, accepted, echoed, stored, or persisted.",
+    "No assistant response, transcript, summary, model path, generated artifact, private path, secret, or token is read or written.",
+    "No KV260 hardware access, serial access, SSH execution, network call, provider call, telemetry, upload, or write-back is performed.",
+    "The send result remains blocked until chat readiness, runtime, model-load, device-session, and local session evidence are available.",
+    "This is not a release, tag, versioned compatibility commitment, MCP, LSP, IDE, marketplace, or telemetry implementation."
+  ],
+  "modelState": "not_loaded",
+  "parentChatSessionRef": "chat_session_gemma3n_e4b_kv260_placeholder",
+  "promptHandlingState": "empty_not_captured",
+  "responseState": "not_generated",
+  "resultEnvelope": {
+    "contentPolicy": "fixture carries blocked result metadata only; no prompt or response body is stored",
+    "envelopeId": "blocked_send_result_gemma3n_e4b_kv260_placeholder",
+    "exitCode": null,
+    "inputAccepted": false,
+    "promptContentIncluded": false,
+    "promptEchoed": false,
+    "responseContentIncluded": false,
+    "responseGenerated": false,
+    "schemaVersion": "pccx.chatSendResultEnvelope.v0",
+    "sendAttempted": false,
+    "sideEffectPolicy": "no_runtime_execution_no_write",
+    "state": "blocked",
+    "summary": "Send is disabled because readiness, runtime, model, and session evidence are missing."
+  },
+  "resultState": "blocked",
+  "runtimeState": "not_started",
+  "safetyFlags": {
+    "attachmentReads": false,
+    "automaticUpload": false,
+    "clipboardRead": false,
+    "clipboardWrite": false,
+    "cloudCalls": false,
+    "dataOnly": true,
+    "deterministic": true,
+    "executesPccxLab": false,
+    "executesSystemverilogIde": false,
+    "fileUpload": false,
+    "generatedBlobsIncluded": false,
+    "hardwareDumpsIncluded": false,
+    "inputAccepted": false,
+    "kv260Access": false,
+    "lspImplemented": false,
+    "mcpServerImplemented": false,
+    "modelAssetPathsIncluded": false,
+    "modelExecution": false,
+    "modelLoadAttempted": false,
+    "modelLoaded": false,
+    "modelWeightPathsIncluded": false,
+    "networkCalls": false,
+    "networkScan": false,
+    "opensSerialPort": false,
+    "privatePathsIncluded": false,
+    "promptCapture": false,
+    "promptContentIncluded": false,
+    "promptEchoed": false,
+    "promptPersistence": false,
+    "providerCalls": false,
+    "readOnly": true,
+    "readsArtifacts": false,
+    "responseContentIncluded": false,
+    "responseGenerated": false,
+    "runtimeExecution": false,
+    "secretsIncluded": false,
+    "sendAttempted": false,
+    "sendResultDisplayOnly": true,
+    "sessionPersistence": false,
+    "sshExecution": false,
+    "stableApiAbiClaim": false,
+    "telemetry": false,
+    "tokensIncluded": false,
+    "touchesHardware": false,
+    "transcriptPersistence": false,
+    "writeBack": false,
+    "writesArtifacts": false
+  },
+  "schemaVersion": "pccx.chatSendResult.v0",
+  "sendAttemptState": "disabled",
+  "sendResultId": "chat_send_result_gemma3n_e4b_kv260_placeholder",
+  "sessionState": "inactive",
+  "targetBoard": "xilinx_kria_kv260",
+  "targetDevice": "kv260",
+  "targetModel": "gemma3n-e4b",
+  "userVisibleState": "available_as_data"
+}

--- a/docs/STANDALONE_CHAT_SESSION_CONTRACT.md
+++ b/docs/STANDALONE_CHAT_SESSION_CONTRACT.md
@@ -13,26 +13,31 @@ The implementation lives in:
 - `contracts/chat_session_lifecycle_contract.py`
 - `contracts/chat_readiness_contract.py`
 - `contracts/chat_composer_contract.py`
+- `contracts/chat_send_result_contract.py`
 - `contracts/fixtures/chat-session.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-model-status.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-session-lifecycle.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-readiness.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-composer.gemma3n-e4b-kv260-placeholder.json`
+- `contracts/fixtures/chat-send-result.gemma3n-e4b-kv260-placeholder.json`
 - `scripts/chat-session-stub.sh`
 - `scripts/chat-model-status-stub.sh`
 - `scripts/chat-session-lifecycle-stub.sh`
 - `scripts/chat-readiness-stub.sh`
 - `scripts/chat-composer-stub.sh`
+- `scripts/chat-send-result-stub.sh`
 - `scripts/chat-surface-preview.sh`
 - `scripts/tests/chat_session_contract_test.py`
 - `scripts/tests/chat_model_status_contract_test.py`
 - `scripts/tests/chat_session_lifecycle_contract_test.py`
 - `scripts/tests/chat_readiness_contract_test.py`
 - `scripts/tests/chat_composer_contract_test.py`
+- `scripts/tests/chat_send_result_contract_test.py`
 - `scripts/tests/chat_surface_preview_test.py`
 - `scripts/tests/status-chat-model-status.sh`
 - `scripts/tests/status-chat-readiness.sh`
 - `scripts/tests/status-chat-composer.sh`
+- `scripts/tests/status-chat-send-result.sh`
 
 ## What Is Implemented
 
@@ -110,6 +115,19 @@ calls, hardware access, pccx-lab invocation, and artifact writes out of
 scope. Send controls remain disabled until the reviewed runtime,
 session-store, model-load, and attachment boundaries exist.
 
+The chat send-result fixture records the blocked result shape shown when
+a send action is unavailable:
+
+```bash
+bash scripts/chat-send-result-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/status-stub.sh --include-chat-send-result
+```
+
+It keeps the attempted-send result in blocked local data: no prompt is
+accepted, captured, echoed, stored, or persisted; no assistant response
+is generated; no model/runtime handoff is attempted; and no transcript
+or artifact is written.
+
 The terminal preview command renders the same checked contract as a
 read-only chat surface sketch:
 
@@ -175,6 +193,21 @@ display and lifecycle operations:
 - `target_selected`: target descriptor data can be displayed
 - `unavailable`: output or operation state is unavailable
 
+The send-result states keep blocked UI feedback separate from prompt
+content and assistant output:
+
+- `available_as_data`: checked blocked-result fixture data is available
+  without executing anything
+- `blocked`: a required readiness or execution boundary is missing
+- `disabled`: send controls are intentionally unavailable
+- `empty_not_captured`: no prompt draft is captured or stored
+- `inactive`: no target device, runtime, or launcher-owned chat session
+  exists
+- `not_configured`: no local store or retention policy exists
+- `not_generated`: no assistant response has been produced
+- `not_loaded`: model assets are not loaded
+- `not_started`: no local chat runtime has started
+
 ## Coordination Boundary
 
 The standalone chat surface depends on the existing launcher model
@@ -189,6 +222,9 @@ load, restore, or export action.
 The composer contract adds a reviewable input-control and validation
 shape without prompt capture, prompt echo, prompt persistence, attachment
 reads, clipboard access, or send enablement.
+The send-result contract adds a reviewable blocked-result display shape
+without prompt acceptance, prompt echo, response generation, runtime
+execution, model loading, persistence, or writes.
 
 pccx-lab remains a separate CLI/core diagnostics and verification
 backend. systemverilog-ide may consume launcher data later as read-only
@@ -202,6 +238,8 @@ This chat/session surface does not add:
 - prompt, response, or transcript persistence
 - composer prompt capture, echo, persistence, attachment reads, or
   clipboard access
+- send acceptance, prompt echo, response generation, or send-result
+  persistence
 - session creation, restore, clear, close, or export behavior
 - readiness recovery execution
 - manifest, transcript, summary, or lifecycle artifact reads or writes

--- a/scripts/chat-send-result-stub.sh
+++ b/scripts/chat-send-result-stub.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+# scripts/chat-send-result-stub.sh - print data-only chat send-result JSON.
+#
+# This script does not read, accept, or echo prompts, generate responses,
+# persist transcripts, read attachments, load models, start runtime code, touch
+# KV260 hardware, call providers, read/write artifacts, or invoke pccx-lab.
+
+set -eu
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+
+MODEL="gemma3n-e4b"
+TARGET="kv260"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --model)
+            MODEL="${2:-}"
+            if [ -z "$MODEL" ]; then
+                printf '[ERROR] --model requires an argument\n' >&2
+                exit 2
+            fi
+            shift 2
+            ;;
+        --target)
+            TARGET="${2:-}"
+            if [ -z "$TARGET" ]; then
+                printf '[ERROR] --target requires an argument\n' >&2
+                exit 2
+            fi
+            shift 2
+            ;;
+        *)
+            printf '[ERROR] unknown option: %s\n' "$1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+exec python3 "$ROOT_DIR/contracts/chat_send_result_contract.py" \
+    --model "$MODEL" \
+    --target "$TARGET"

--- a/scripts/status-stub.sh
+++ b/scripts/status-stub.sh
@@ -22,6 +22,9 @@
 # Chat composer controls and validation state (explicit opt-in, read-only local data):
 #   --include-chat-composer
 #
+# Chat send-result display boundary (explicit opt-in, read-only local data):
+#   --include-chat-send-result
+#
 # pccx-lab backend (explicit opt-in):
 #   --backend pccx-lab        call pccx-lab status --format json
 #   PCCX_LAB_BIN              override path to pccx-lab binary (takes priority over PATH)
@@ -43,6 +46,116 @@ INCLUDE_CHAT_SESSION="0"
 INCLUDE_CHAT_MODEL_STATUS="0"
 INCLUDE_CHAT_READINESS="0"
 INCLUDE_CHAT_COMPOSER="0"
+INCLUDE_CHAT_SEND_RESULT="0"
+
+print_chat_send_result_summary() {
+    SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+    ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+    CHAT_SEND_RESULT_STUB="$ROOT_DIR/scripts/chat-send-result-stub.sh"
+
+    if [ ! -f "$CHAT_SEND_RESULT_STUB" ]; then
+        ERROR "chat send-result stub not found: $CHAT_SEND_RESULT_STUB"
+        return 1
+    fi
+
+    if ! CHAT_SEND_RESULT_JSON="$(bash "$CHAT_SEND_RESULT_STUB" --model gemma3n-e4b --target kv260 2>&1)"; then
+        ERROR "chat send-result stub failed"
+        printf '%s\n' "$CHAT_SEND_RESULT_JSON" >&2
+        return 1
+    fi
+
+    if ! CHAT_SEND_RESULT_SUMMARY="$(
+        printf '%s\n' "$CHAT_SEND_RESULT_JSON" | python3 -c '
+import json
+import sys
+
+data = json.load(sys.stdin)
+flags = data["safetyFlags"]
+envelope = data["resultEnvelope"]
+reasons = " ".join(
+    "{}={}".format(reason["reasonId"], reason["state"])
+    for reason in data["blockedReasons"]
+)
+messages = " ".join(
+    "{}={}".format(message["messageId"], message["state"])
+    for message in data["displayMessages"]
+)
+
+def b(value):
+    return "true" if value else "false"
+
+print("[INFO]  source     : scripts/chat-send-result-stub.sh --model gemma3n-e4b --target kv260")
+print("[INFO]  boundary   : read-only data; no prompt/response/model/hardware/lab/IDE execution")
+print("[INFO]  target     : {}".format(data["targetDevice"]))
+print("[INFO]  model      : {}".format(data["targetModel"]))
+print("[INFO]  result     : {}".format(data["resultState"]))
+print("[INFO]  attempt    : {}".format(data["sendAttemptState"]))
+print("[INFO]  prompt     : {}".format(data["promptHandlingState"]))
+print("[INFO]  response   : {}".format(data["responseState"]))
+print("[INFO]  runtime    : {}".format(data["runtimeState"]))
+print("[INFO]  model load : {}".format(data["modelState"]))
+print("[INFO]  session    : {}".format(data["sessionState"]))
+print(
+    "[INFO]  envelope   : {} inputAccepted={} sendAttempted={} "
+    "promptContentIncluded={} promptEchoed={} responseGenerated={} "
+    "responseContentIncluded={}".format(
+        envelope["state"],
+        b(envelope["inputAccepted"]),
+        b(envelope["sendAttempted"]),
+        b(envelope["promptContentIncluded"]),
+        b(envelope["promptEchoed"]),
+        b(envelope["responseGenerated"]),
+        b(envelope["responseContentIncluded"]),
+    )
+)
+print("[INFO]  blocked    : {}".format(reasons))
+print("[INFO]  messages   : {}".format(messages))
+print(
+    "[INFO]  flags      : readOnly={} dataOnly={} deterministic={} "
+    "sendResultDisplayOnly={} writesArtifacts={} readsArtifacts={} "
+    "attachmentReads={} fileUpload={} clipboardRead={} clipboardWrite={} "
+    "promptCapture={} promptContentIncluded={} promptEchoed={} "
+    "promptPersistence={} inputAccepted={} sendAttempted={} "
+    "responseContentIncluded={} responseGenerated={} modelLoadAttempted={} "
+    "modelLoaded={} modelExecution={} runtimeExecution={} kv260Access={} "
+    "networkCalls={} providerCalls={} executesPccxLab={}".format(
+        b(flags["readOnly"]),
+        b(flags["dataOnly"]),
+        b(flags["deterministic"]),
+        b(flags["sendResultDisplayOnly"]),
+        b(flags["writesArtifacts"]),
+        b(flags["readsArtifacts"]),
+        b(flags["attachmentReads"]),
+        b(flags["fileUpload"]),
+        b(flags["clipboardRead"]),
+        b(flags["clipboardWrite"]),
+        b(flags["promptCapture"]),
+        b(flags["promptContentIncluded"]),
+        b(flags["promptEchoed"]),
+        b(flags["promptPersistence"]),
+        b(flags["inputAccepted"]),
+        b(flags["sendAttempted"]),
+        b(flags["responseContentIncluded"]),
+        b(flags["responseGenerated"]),
+        b(flags["modelLoadAttempted"]),
+        b(flags["modelLoaded"]),
+        b(flags["modelExecution"]),
+        b(flags["runtimeExecution"]),
+        b(flags["kv260Access"]),
+        b(flags["networkCalls"]),
+        b(flags["providerCalls"]),
+        b(flags["executesPccxLab"]),
+    )
+)
+'
+    )"; then
+        ERROR "chat send-result JSON could not be summarized"
+        return 1
+    fi
+
+    HEAD "chat send result"
+    printf '%s\n' "$CHAT_SEND_RESULT_SUMMARY"
+}
 
 print_chat_composer_summary() {
     SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
@@ -598,6 +711,10 @@ while [ $# -gt 0 ]; do
             INCLUDE_CHAT_COMPOSER="1"
             shift
             ;;
+        --include-chat-send-result)
+            INCLUDE_CHAT_SEND_RESULT="1"
+            shift
+            ;;
         --backend)
             BACKEND="${2:-}"
             if [ -z "$BACKEND" ]; then
@@ -613,8 +730,8 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-if [ -n "$BACKEND" ] && { [ "$INCLUDE_RUNTIME_READINESS" = "1" ] || [ "$INCLUDE_DEVICE_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SESSION" = "1" ] || [ "$INCLUDE_CHAT_MODEL_STATUS" = "1" ] || [ "$INCLUDE_CHAT_READINESS" = "1" ] || [ "$INCLUDE_CHAT_COMPOSER" = "1" ]; }; then
-    ERROR "--include-runtime-readiness, --include-device-session, --include-chat-session, --include-chat-model-status, --include-chat-readiness, and --include-chat-composer are only supported in local scaffold mode"
+if [ -n "$BACKEND" ] && { [ "$INCLUDE_RUNTIME_READINESS" = "1" ] || [ "$INCLUDE_DEVICE_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SESSION" = "1" ] || [ "$INCLUDE_CHAT_MODEL_STATUS" = "1" ] || [ "$INCLUDE_CHAT_READINESS" = "1" ] || [ "$INCLUDE_CHAT_COMPOSER" = "1" ] || [ "$INCLUDE_CHAT_SEND_RESULT" = "1" ]; }; then
+    ERROR "--include-runtime-readiness, --include-device-session, --include-chat-session, --include-chat-model-status, --include-chat-readiness, --include-chat-composer, and --include-chat-send-result are only supported in local scaffold mode"
     exit 1
 fi
 
@@ -633,7 +750,14 @@ if [ -z "$BACKEND" ]; then
     NOTE "chat model    : opt-in via --include-chat-model-status (read-only model status display data)"
     NOTE "chat readiness: opt-in via --include-chat-readiness (read-only readiness and recovery data)"
     NOTE "chat composer : opt-in via --include-chat-composer (read-only input control data)"
+    NOTE "chat send     : opt-in via --include-chat-send-result (read-only blocked send-result data)"
     NOTE "editor bridge  : planned (VS Code / other IDEs)"
+
+    if [ "$INCLUDE_CHAT_SEND_RESULT" = "1" ]; then
+        if ! print_chat_send_result_summary; then
+            exit 1
+        fi
+    fi
 
     if [ "$INCLUDE_CHAT_COMPOSER" = "1" ]; then
         if ! print_chat_composer_summary; then

--- a/scripts/tests/chat_send_result_contract_test.py
+++ b/scripts/tests/chat_send_result_contract_test.py
@@ -1,0 +1,391 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Fixture tests for the standalone chat send-result contract."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "contracts" / "chat_send_result_contract.py"
+FIXTURE_PATH = (
+    ROOT
+    / "contracts"
+    / "fixtures"
+    / "chat-send-result.gemma3n-e4b-kv260-placeholder.json"
+)
+SCRIPT_PATH = ROOT / "scripts" / "chat-send-result-stub.sh"
+STATUS_TEST_PATH = ROOT / "scripts" / "tests" / "status-chat-send-result.sh"
+DOC_PATH = ROOT / "docs" / "STANDALONE_CHAT_SESSION_CONTRACT.md"
+README_PATH = ROOT / "README.md"
+TEST_PATH = Path(__file__).resolve()
+CI_PATH = ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location(
+        "chat_send_result_contract",
+        MODULE_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def flatten(value) -> str:
+    return json.dumps(value, sort_keys=True)
+
+
+def iter_state_values(value):
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            if key == "state" or key.endswith("State") or key.endswith("Status"):
+                yield nested
+            yield from iter_state_values(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            yield from iter_state_values(nested)
+
+
+def iter_keys(value):
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            yield key
+            yield from iter_keys(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            yield from iter_keys(nested)
+
+
+def assert_no_private_or_generated_data(text: str) -> None:
+    forbidden_patterns = [
+        r"/home/[^\s\"']+",
+        r"/Users/[^\s\"']+",
+        r"[A-Za-z]:\\Users\\",
+        r"\b(?:api[_-]?key|authorization|bearer|client[_-]?secret|password|private[_-]?key|secret|token)\b\s*[:=]",
+        r"\.(?:gguf|safetensors|ckpt|pt|pth|onnx)\b",
+        r"(?:weights|model_weights|model-cache)/(?:[^\"'\s]+)",
+        r"(?:raw[_-]?full[_-]?logs|hardware[_-]?dump|generated[_-]?blob)\s*[:=]",
+    ]
+    for pattern in forbidden_patterns:
+        assert not re.search(pattern, text, re.IGNORECASE), pattern
+
+
+def assert_no_runtime_implementation_terms(source: str) -> None:
+    forbidden = [
+        "subprocess",
+        "os.system",
+        "popen",
+        "socket",
+        "urllib",
+        "requests",
+        "http.client",
+        "openai",
+        "anthropic",
+        "gemini",
+        "modelcontextprotocol",
+        "websocket",
+        "xmutil",
+        "xrt-smi",
+        "lsusb",
+        "dmesg",
+    ]
+    lowered = source.lower()
+    for term in forbidden:
+        assert term not in lowered, term
+
+
+def assert_no_provider_configs(value) -> None:
+    forbidden_keys = {
+        "apiKey",
+        "accessToken",
+        "refreshToken",
+        "authorization",
+        "bearerToken",
+        "provider",
+        "providers",
+        "providerConfig",
+        "providerConfigs",
+    }
+    for key in iter_keys(value):
+        assert key not in forbidden_keys, key
+
+
+def assert_no_unsupported_claims(text: str) -> None:
+    literal_claims = [
+        "production-ready",
+        "marketplace-ready",
+        "stable API",
+        "stable ABI",
+        "KV260 inference works",
+        "Gemma 3N E4B runs on KV260",
+        "20 tok/s achieved",
+        "timing closed",
+        "bitstream ready",
+        "launcher executes pccx-lab",
+        "IDE controls launcher",
+        "AI provider integration is live",
+    ]
+    lowered = text.lower()
+    for claim in literal_claims:
+        assert claim.lower() not in lowered, claim
+
+    asserted_claim_patterns = [
+        r"\bMCP\s+(?:server|client)\s+(?:is\s+)?implemented\b",
+        r"\bLSP\s+(?:server|client)\s+(?:is\s+)?implemented\b",
+        r"\bAI\s+provider\s+(?:is\s+)?implemented\b",
+        r"\bKV260\s+run\s+(?:is\s+)?claimed\b",
+    ]
+    for pattern in asserted_claim_patterns:
+        assert not re.search(pattern, text, re.IGNORECASE), pattern
+
+
+def assert_no_chat_invocation_flags(source: str) -> None:
+    forbidden_patterns = [
+        r"--backend\s+pccx-lab",
+        r"\bPCCX_LAB_BIN\b",
+        r"\bpccx-lab\s+(?:status|diagnostics|validate)\b",
+        r"\bsystemverilog-ide\s+--",
+        r"\bsystemverilog-ide\s+(?:open|run|status|validate|launch)\b",
+        r"\b(?:curl|wget)\b",
+        r"\b(?:upload|telemetry|write-back)\s+(?:enabled|true)\b",
+    ]
+    for pattern in forbidden_patterns:
+        assert not re.search(pattern, source, re.IGNORECASE), pattern
+
+
+def test_chat_send_result_matches_fixture_and_is_deterministic() -> None:
+    module = load_module()
+    generated = module.create_gemma3n_e4b_kv260_chat_send_result()
+    fixture = json.loads(read_text(FIXTURE_PATH))
+
+    assert generated == fixture
+    assert module.chat_send_result_json(generated) == module.chat_send_result_json(generated)
+    assert module.chat_send_result_json(generated).endswith("\n")
+    assert json.loads(module.chat_send_result_json(generated)) == fixture
+
+
+def test_cli_stub_outputs_deterministic_json() -> None:
+    fixture = json.loads(read_text(FIXTURE_PATH))
+    command = [
+        "bash",
+        str(SCRIPT_PATH),
+        "--model",
+        "gemma3n-e4b",
+        "--target",
+        "kv260",
+    ]
+    first = subprocess.run(
+        command,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    second = subprocess.run(
+        command,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert first.stderr == ""
+    assert first.stdout == second.stdout
+    assert first.stdout.endswith("\n")
+    assert json.loads(first.stdout) == fixture
+
+
+def test_required_fields_and_allowed_states() -> None:
+    module = load_module()
+    result = module.create_gemma3n_e4b_kv260_chat_send_result()
+    allowed = set(module.CHAT_SEND_RESULT_STATE_VALUES)
+
+    assert tuple(result.keys()) == module.CHAT_SEND_RESULT_FIELDS
+    assert result["schemaVersion"] == "pccx.chatSendResult.v0"
+    assert tuple(result["resultEnvelope"].keys()) == module.RESULT_ENVELOPE_FIELDS
+
+    states = list(iter_state_values(result))
+    assert states
+    for state in states:
+        assert state in allowed, state
+
+    for reason in result["blockedReasons"]:
+        assert tuple(reason.keys()) == module.BLOCKED_REASON_FIELDS
+    for message in result["displayMessages"]:
+        assert tuple(message.keys()) == module.DISPLAY_MESSAGE_FIELDS
+    for ref in result["handoffRefs"]:
+        assert tuple(ref.keys()) == module.HANDOFF_REF_FIELDS
+
+
+def test_chat_send_result_covers_issue_9_blocked_send_boundary() -> None:
+    result = load_module().create_gemma3n_e4b_kv260_chat_send_result()
+    envelope = result["resultEnvelope"]
+    reasons = {reason["reasonId"]: reason for reason in result["blockedReasons"]}
+    messages = {message["messageId"]: message for message in result["displayMessages"]}
+    refs = {ref["refId"]: ref for ref in result["handoffRefs"]}
+
+    assert result["resultState"] == "blocked"
+    assert result["sendAttemptState"] == "disabled"
+    assert result["promptHandlingState"] == "empty_not_captured"
+    assert result["responseState"] == "not_generated"
+    assert result["runtimeState"] == "not_started"
+    assert result["modelState"] == "not_loaded"
+    assert result["sessionState"] == "inactive"
+    assert result["errorState"] == "blocked"
+    assert envelope["sendAttempted"] is False
+    assert envelope["inputAccepted"] is False
+    assert envelope["promptContentIncluded"] is False
+    assert envelope["promptEchoed"] is False
+    assert envelope["responseGenerated"] is False
+    assert envelope["responseContentIncluded"] is False
+    assert envelope["exitCode"] is None
+    assert set(reasons) == {
+        "composer_send_disabled",
+        "readiness_blocked",
+        "runtime_not_started",
+        "model_not_loaded",
+        "session_store_not_configured",
+    }
+    assert set(messages) == {
+        "send_disabled",
+        "response_unavailable",
+    }
+    assert set(refs) == {
+        "chat_session",
+        "chat_composer",
+        "chat_readiness",
+        "chat_model_status",
+        "chat_session_lifecycle",
+    }
+
+
+def test_safety_flags_preserve_data_only_boundary() -> None:
+    result = load_module().create_gemma3n_e4b_kv260_chat_send_result()
+    flags = result["safetyFlags"]
+
+    assert flags["dataOnly"] is True
+    assert flags["readOnly"] is True
+    assert flags["deterministic"] is True
+    assert flags["sendResultDisplayOnly"] is True
+    for name in [
+        "writesArtifacts",
+        "readsArtifacts",
+        "attachmentReads",
+        "fileUpload",
+        "clipboardRead",
+        "clipboardWrite",
+        "promptCapture",
+        "promptContentIncluded",
+        "promptEchoed",
+        "promptPersistence",
+        "inputAccepted",
+        "sendAttempted",
+        "responseContentIncluded",
+        "responseGenerated",
+        "transcriptPersistence",
+        "sessionPersistence",
+        "modelAssetPathsIncluded",
+        "modelWeightPathsIncluded",
+        "modelLoadAttempted",
+        "modelLoaded",
+        "modelExecution",
+        "runtimeExecution",
+        "touchesHardware",
+        "kv260Access",
+        "opensSerialPort",
+        "networkCalls",
+        "networkScan",
+        "sshExecution",
+        "providerCalls",
+        "cloudCalls",
+        "privatePathsIncluded",
+        "secretsIncluded",
+        "tokensIncluded",
+        "generatedBlobsIncluded",
+        "hardwareDumpsIncluded",
+        "telemetry",
+        "automaticUpload",
+        "writeBack",
+        "executesPccxLab",
+        "executesSystemverilogIde",
+        "mcpServerImplemented",
+        "lspImplemented",
+        "stableApiAbiClaim",
+    ]:
+        assert flags[name] is False, name
+
+
+def test_docs_and_sources_avoid_private_data_runtime_calls_or_overclaims() -> None:
+    module_source = read_text(MODULE_PATH)
+    script_source = read_text(SCRIPT_PATH)
+    status_test_source = read_text(STATUS_TEST_PATH)
+    result = load_module().create_gemma3n_e4b_kv260_chat_send_result()
+    scan_text = "\n".join([
+        read_text(FIXTURE_PATH),
+        read_text(DOC_PATH),
+        read_text(README_PATH),
+        flatten(result),
+        module_source,
+        script_source,
+        status_test_source,
+    ])
+    runtime_source = "\n".join([module_source, script_source])
+
+    assert_no_runtime_implementation_terms(runtime_source)
+    assert_no_private_or_generated_data(scan_text)
+    assert_no_provider_configs(result)
+    assert_no_unsupported_claims(scan_text)
+    assert_no_chat_invocation_flags(runtime_source)
+
+
+def test_source_headers_for_touched_code_files() -> None:
+    expected_headers = {
+        MODULE_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        SCRIPT_PATH: [
+            "#!/usr/bin/env bash",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        STATUS_TEST_PATH: [
+            "#!/usr/bin/env bash",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        TEST_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        CI_PATH: [
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+    }
+
+    for path, header in expected_headers.items():
+        assert read_text(path).splitlines()[: len(header)] == header, path
+
+
+test_chat_send_result_matches_fixture_and_is_deterministic()
+test_cli_stub_outputs_deterministic_json()
+test_required_fields_and_allowed_states()
+test_chat_send_result_covers_issue_9_blocked_send_boundary()
+test_safety_flags_preserve_data_only_boundary()
+test_docs_and_sources_avoid_private_data_runtime_calls_or_overclaims()
+test_source_headers_for_touched_code_files()
+
+print("chat send-result contract tests ok")

--- a/scripts/tests/status-chat-send-result.sh
+++ b/scripts/tests/status-chat-send-result.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+# scripts/tests/status-chat-send-result.sh - status chat send-result tests.
+#
+# Usage: bash scripts/tests/status-chat-send-result.sh [path/to/status-stub.sh]
+
+set -eu
+
+PASS() { printf '[PASS]  %s\n' "$*"; }
+FAIL() { printf '[FAIL]  %s\n' "$*" >&2; }
+HEAD() { printf '\n=== %s ===\n' "$*"; }
+
+STUB="${1:-scripts/status-stub.sh}"
+
+if [ ! -x "$STUB" ]; then
+    chmod +x "$STUB"
+fi
+
+contains() {
+    case "$1" in
+        *"$2"*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+require_contains() {
+    local output="$1"
+    local expected="$2"
+    if ! contains "$output" "$expected"; then
+        FAIL "expected output to contain: $expected"
+        printf '%s\n' "$output" >&2
+        exit 1
+    fi
+}
+
+require_not_contains() {
+    local output="$1"
+    local forbidden="$2"
+    if contains "$output" "$forbidden"; then
+        FAIL "output contained forbidden text: $forbidden"
+        printf '%s\n' "$output" >&2
+        exit 1
+    fi
+}
+
+HEAD "1: status can include chat send result"
+OUTPUT="$("$STUB" --include-chat-send-result)"
+require_contains "$OUTPUT" "=== chat send result ==="
+require_contains "$OUTPUT" "source     : scripts/chat-send-result-stub.sh --model gemma3n-e4b --target kv260"
+require_contains "$OUTPUT" "boundary   : read-only data; no prompt/response/model/hardware/lab/IDE execution"
+require_contains "$OUTPUT" "target     : kv260"
+require_contains "$OUTPUT" "model      : gemma3n-e4b"
+require_contains "$OUTPUT" "result     : blocked"
+require_contains "$OUTPUT" "attempt    : disabled"
+require_contains "$OUTPUT" "prompt     : empty_not_captured"
+require_contains "$OUTPUT" "response   : not_generated"
+require_contains "$OUTPUT" "runtime    : not_started"
+require_contains "$OUTPUT" "model load : not_loaded"
+require_contains "$OUTPUT" "session    : inactive"
+PASS "chat send-result section is present and conservative"
+
+HEAD "2: result envelope and blocked reasons stay non-executing"
+require_contains "$OUTPUT" "envelope   : blocked"
+require_contains "$OUTPUT" "inputAccepted=false"
+require_contains "$OUTPUT" "sendAttempted=false"
+require_contains "$OUTPUT" "promptContentIncluded=false"
+require_contains "$OUTPUT" "responseGenerated=false"
+require_contains "$OUTPUT" "blocked    : composer_send_disabled=disabled"
+require_contains "$OUTPUT" "readiness_blocked=blocked"
+require_contains "$OUTPUT" "runtime_not_started=not_started"
+require_contains "$OUTPUT" "model_not_loaded=not_loaded"
+require_contains "$OUTPUT" "session_store_not_configured=not_configured"
+require_contains "$OUTPUT" "messages   : send_disabled=disabled"
+require_contains "$OUTPUT" "response_unavailable=not_generated"
+PASS "send result metadata is summarized without response content"
+
+HEAD "3: safety flags stay read-only and non-executing"
+require_contains "$OUTPUT" "readOnly=true"
+require_contains "$OUTPUT" "dataOnly=true"
+require_contains "$OUTPUT" "deterministic=true"
+require_contains "$OUTPUT" "sendResultDisplayOnly=true"
+require_contains "$OUTPUT" "writesArtifacts=false"
+require_contains "$OUTPUT" "readsArtifacts=false"
+require_contains "$OUTPUT" "attachmentReads=false"
+require_contains "$OUTPUT" "fileUpload=false"
+require_contains "$OUTPUT" "clipboardRead=false"
+require_contains "$OUTPUT" "clipboardWrite=false"
+require_contains "$OUTPUT" "promptCapture=false"
+require_contains "$OUTPUT" "promptEchoed=false"
+require_contains "$OUTPUT" "promptPersistence=false"
+require_contains "$OUTPUT" "responseContentIncluded=false"
+require_contains "$OUTPUT" "modelLoadAttempted=false"
+require_contains "$OUTPUT" "modelLoaded=false"
+require_contains "$OUTPUT" "modelExecution=false"
+require_contains "$OUTPUT" "runtimeExecution=false"
+require_contains "$OUTPUT" "kv260Access=false"
+require_contains "$OUTPUT" "networkCalls=false"
+require_contains "$OUTPUT" "providerCalls=false"
+require_contains "$OUTPUT" "executesPccxLab=false"
+PASS "execution-related flags remain false"
+
+HEAD "4: output is deterministic"
+OUTPUT_AGAIN="$("$STUB" --include-chat-send-result)"
+if [ "$OUTPUT" != "$OUTPUT_AGAIN" ]; then
+    FAIL "status chat send-result output changed between runs"
+    exit 1
+fi
+PASS "status chat send-result output is deterministic"
+
+HEAD "5: chat send-result option does not combine with pccx-lab backend"
+if "$STUB" --include-chat-send-result --backend pccx-lab >/dev/null 2>&1; then
+    FAIL "expected combined chat-send-result/backend mode to fail"
+    exit 1
+fi
+PASS "chat send result remains separate from backend execution"
+
+HEAD "6: output avoids known overclaims and prompt echo"
+FORBIDDEN_PREFIX="KV260 inference"
+FORBIDDEN_CLAIM="${FORBIDDEN_PREFIX} works"
+require_not_contains "$OUTPUT" "$FORBIDDEN_CLAIM"
+THROUGHPUT_PREFIX="20 tok/s"
+THROUGHPUT_CLAIM="${THROUGHPUT_PREFIX} achieved"
+require_not_contains "$OUTPUT" "$THROUGHPUT_CLAIM"
+require_not_contains "$OUTPUT" "hello"
+PASS "no chat send-result overclaim or prompt echo in status output"
+
+printf '\n[DONE]  all status-chat-send-result tests passed\n'


### PR DESCRIPTION
## Summary

- Add a data-only `pccx.chatSendResult.v0` fixture for blocked chat send results.
- Add a local stub and status opt-in for the blocked send-result display.
- Wire focused fixture/status tests and CI coverage.

## Scope

This is a checked boundary for `pccxai/pccx-llm-launcher#9`. It records disabled send state, no accepted input, no prompt echo, no generated response, and no runtime/model handoff.

## Non-goals

This does not read prompts, persist transcripts, generate assistant responses, load models, execute runtime code, touch KV260 hardware, call providers, invoke pccx-lab, invoke systemverilog-ide, write artifacts, publish a release/tag, or make a stable API/ABI claim.

## Local validation

- `python3 scripts/tests/chat_send_result_contract_test.py`
- `bash scripts/tests/status-chat-send-result.sh scripts/status-stub.sh`
- `python3 -m py_compile contracts/*.py scripts/tests/*.py`
- `find scripts -type f -name '*.sh' -not -name '*.snapshot' -print0 | xargs -0 bash -n`
- `./scripts/check.sh`
- all `scripts/tests/*_test.py`
- all status shell tests
- local claim scan
- `git diff --check`
- `git diff --cached --check`

Local `shellcheck` is not installed on this host; GitHub Actions installs and runs it.

Refs pccxai/pccx-llm-launcher#9
