### PR TITLE
Add chat session index boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,7 @@ jobs:
                    scripts/chat-model-status-stub.sh \
                    scripts/chat-session-stub.sh \
                    scripts/chat-session-lifecycle-stub.sh \
+                   scripts/chat-session-index-stub.sh \
                    scripts/chat-readiness-stub.sh \
                    scripts/chat-composer-stub.sh \
                    scripts/chat-send-result-stub.sh \
@@ -168,6 +169,10 @@ jobs:
         run: ./scripts/chat-session-stub.sh --model gemma3n-e4b --target kv260
       - name: run scripts/chat-session-lifecycle-stub.sh
         run: ./scripts/chat-session-lifecycle-stub.sh --model gemma3n-e4b --target kv260
+      - name: run scripts/status-stub.sh with chat session index
+        run: ./scripts/status-stub.sh --include-chat-session-index
+      - name: run scripts/chat-session-index-stub.sh
+        run: ./scripts/chat-session-index-stub.sh --model gemma3n-e4b --target kv260
       - name: run scripts/status-stub.sh with chat readiness
         run: ./scripts/status-stub.sh --include-chat-readiness
       - name: run scripts/chat-readiness-stub.sh
@@ -216,6 +221,8 @@ jobs:
         run: python3 scripts/tests/chat_model_status_contract_test.py
       - name: run chat/session lifecycle contract tests
         run: python3 scripts/tests/chat_session_lifecycle_contract_test.py
+      - name: run chat session-index contract tests
+        run: python3 scripts/tests/chat_session_index_contract_test.py
       - name: run chat readiness contract tests
         run: python3 scripts/tests/chat_readiness_contract_test.py
       - name: run chat composer contract tests
@@ -241,6 +248,7 @@ jobs:
           chmod +x scripts/chat-model-status-stub.sh
           chmod +x scripts/chat-session-stub.sh
           chmod +x scripts/chat-session-lifecycle-stub.sh
+          chmod +x scripts/chat-session-index-stub.sh
           chmod +x scripts/chat-readiness-stub.sh
           chmod +x scripts/chat-composer-stub.sh
           chmod +x scripts/chat-send-result-stub.sh
@@ -252,6 +260,7 @@ jobs:
           chmod +x scripts/tests/status-readiness.sh
           chmod +x scripts/tests/status-chat-model-status.sh
           chmod +x scripts/tests/status-chat-session.sh
+          chmod +x scripts/tests/status-chat-session-index.sh
           chmod +x scripts/tests/status-chat-readiness.sh
           chmod +x scripts/tests/status-chat-composer.sh
           chmod +x scripts/tests/status-chat-send-result.sh
@@ -266,6 +275,7 @@ jobs:
           shellcheck scripts/tests/status-readiness.sh
           shellcheck scripts/tests/status-chat-model-status.sh
           shellcheck scripts/tests/status-chat-session.sh
+          shellcheck scripts/tests/status-chat-session-index.sh
           shellcheck scripts/tests/status-chat-readiness.sh
           shellcheck scripts/tests/status-chat-composer.sh
           shellcheck scripts/tests/status-chat-send-result.sh
@@ -281,6 +291,8 @@ jobs:
         run: bash scripts/tests/status-chat-model-status.sh scripts/status-stub.sh
       - name: run status-chat-session tests
         run: bash scripts/tests/status-chat-session.sh scripts/status-stub.sh
+      - name: run status-chat-session-index tests
+        run: bash scripts/tests/status-chat-session-index.sh scripts/status-stub.sh
       - name: run status-chat-readiness tests
         run: bash scripts/tests/status-chat-readiness.sh scripts/status-stub.sh
       - name: run status-chat-composer tests

--- a/README.md
+++ b/README.md
@@ -87,11 +87,12 @@ and verify host-side prerequisites before the real engine lands.
 | [`scripts/check.sh`](./scripts/check.sh) | Probe host info, tooling availability, edge-device hints. Always exits 0. |
 | [`scripts/check-device-stub.sh`](./scripts/check-device-stub.sh) | Narrowly scoped device-tree / FPGA-node probe (KV260 / Kria detection only). Always exits 0. |
 | [`scripts/install-stub.sh`](./scripts/install-stub.sh) | Preview of the planned install flow; reports which host runtime pieces are present, lists device-side pieces as future deliverables. Always exits 0. |
-| [`scripts/status-stub.sh`](./scripts/status-stub.sh) | Launcher state summary. Default mode: local scaffold output, always exits 0. With `--include-chat-audit-event`, adds read-only blocked chat audit-event metadata. With `--include-chat-transcript-policy`, adds read-only chat transcript retention/export policy data. With `--include-chat-send-result`, adds read-only blocked chat send-result data. With `--include-chat-composer`, adds read-only chat composer/input-control data. With `--include-chat-model-status`, adds read-only blocked chat model-status display data. With `--include-chat-session`, adds read-only blocked chat/session and lifecycle summaries. With `--include-chat-readiness`, adds read-only chat readiness checks and recovery actions. With `--include-device-session`, adds a read-only device/session status panel. With `--include-runtime-readiness`, adds a read-only runtime readiness summary. With `--backend pccx-lab`, calls `pccx-lab status --format json` and forwards the run-status envelope (exits non-zero if binary is missing or output is invalid). |
+| [`scripts/status-stub.sh`](./scripts/status-stub.sh) | Launcher state summary. Default mode: local scaffold output, always exits 0. With `--include-chat-audit-event`, adds read-only blocked chat audit-event metadata. With `--include-chat-session-index`, adds read-only empty chat session index data. With `--include-chat-transcript-policy`, adds read-only chat transcript retention/export policy data. With `--include-chat-send-result`, adds read-only blocked chat send-result data. With `--include-chat-composer`, adds read-only chat composer/input-control data. With `--include-chat-model-status`, adds read-only blocked chat model-status display data. With `--include-chat-session`, adds read-only blocked chat/session and lifecycle summaries. With `--include-chat-readiness`, adds read-only chat readiness checks and recovery actions. With `--include-device-session`, adds a read-only device/session status panel. With `--include-runtime-readiness`, adds a read-only runtime readiness summary. With `--backend pccx-lab`, calls `pccx-lab status --format json` and forwards the run-status envelope (exits non-zero if binary is missing or output is invalid). |
 | [`scripts/device-session-status-stub.sh`](./scripts/device-session-status-stub.sh) | Data-only device/session status JSON for the Gemma 3N E4B + KV260 target. Reports connection, model load, session, diagnostics, readiness, discovery paths, flow steps, and error taxonomy as placeholder / blocked. |
 | [`scripts/runtime-readiness-stub.sh`](./scripts/runtime-readiness-stub.sh) | Data-only runtime readiness JSON for the Gemma 3N E4B + KV260 target. Reports blocked / not yet evidence-backed. |
 | [`scripts/chat-session-stub.sh`](./scripts/chat-session-stub.sh) | Data-only standalone chat/session JSON for the Gemma 3N E4B + KV260 target. Reports disabled send controls, inactive session state, no prompt/response persistence, and readiness handoff references. |
 | [`scripts/chat-session-lifecycle-stub.sh`](./scripts/chat-session-lifecycle-stub.sh) | Data-only chat session lifecycle JSON for the Gemma 3N E4B + KV260 target. Reports create, restore, clear, close, and export-summary operations as disabled, blocked, inactive, or unavailable. |
+| [`scripts/chat-session-index-stub.sh`](./scripts/chat-session-index-stub.sh) | Data-only chat session index JSON for the Gemma 3N E4B + KV260 target. Reports an empty, not-configured session list/sidebar boundary without reading a store, session titles, prompts, responses, transcripts, or summaries. |
 | [`scripts/chat-model-status-stub.sh`](./scripts/chat-model-status-stub.sh) | Data-only chat model-status JSON for the Gemma 3N E4B + KV260 target. Reports descriptor, asset, load, runtime, context, and response display rows as blocked, disabled, or unavailable. |
 | [`scripts/chat-readiness-stub.sh`](./scripts/chat-readiness-stub.sh) | Data-only chat readiness JSON for the Gemma 3N E4B + KV260 target. Reports readiness checks, error categories, and recovery actions as blocked, disabled, or local data only. |
 | [`scripts/chat-composer-stub.sh`](./scripts/chat-composer-stub.sh) | Data-only chat composer JSON for the Gemma 3N E4B + KV260 target. Reports input buffer, send, attachment, validation, and privacy states without reading, echoing, storing, or persisting prompt text. |
@@ -109,6 +110,7 @@ bash scripts/install-stub.sh
 bash scripts/status-stub.sh
 bash scripts/status-stub.sh --include-chat-model-status
 bash scripts/status-stub.sh --include-chat-session
+bash scripts/status-stub.sh --include-chat-session-index
 bash scripts/status-stub.sh --include-chat-readiness
 bash scripts/status-stub.sh --include-chat-composer
 bash scripts/status-stub.sh --include-chat-send-result
@@ -121,6 +123,7 @@ bash scripts/runtime-readiness-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-model-status-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-session-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-session-lifecycle-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/chat-session-index-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-readiness-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-composer-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-send-result-stub.sh --model gemma3n-e4b --target kv260

--- a/contracts/chat_session_index_contract.py
+++ b/contracts/chat_session_index_contract.py
@@ -1,0 +1,390 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Data-only chat session index contract for the planned launcher UI.
+
+The contract describes the future session list/sidebar boundary while every
+store-backed operation remains disabled or blocked. It does not read session
+manifests, titles, prompts, transcripts, model assets, private paths, or logs;
+it does not write artifacts, load models, touch KV260 hardware, call providers,
+invoke pccx-lab, or start runtime code.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import sys
+
+
+SCHEMA_VERSION = "pccx.chatSessionIndex.v0"
+
+CHAT_SESSION_INDEX_FIELDS = (
+    "schemaVersion",
+    "sessionIndexId",
+    "fixtureVersion",
+    "lastUpdatedSource",
+    "targetDevice",
+    "targetBoard",
+    "targetModel",
+    "indexState",
+    "sessionStoreState",
+    "manifestState",
+    "selectionState",
+    "restoreState",
+    "contentState",
+    "privacyState",
+    "parentChatSessionRef",
+    "chatSessionLifecycleRef",
+    "chatTranscriptPolicyRef",
+    "indexPolicy",
+    "emptyState",
+    "indexControls",
+    "blockedReasons",
+    "handoffRefs",
+    "safetyFlags",
+    "limitations",
+    "issueRefs",
+)
+
+INDEX_POLICY_FIELDS = (
+    "state",
+    "localStoreConfigured",
+    "manifestReadEnabled",
+    "transcriptReadEnabled",
+    "titlePolicy",
+    "pathPolicy",
+    "refreshPolicy",
+    "sideEffectPolicy",
+)
+
+EMPTY_STATE_FIELDS = (
+    "state",
+    "itemCount",
+    "displayKind",
+    "userVisibleSummary",
+    "sideEffectPolicy",
+    "contentPolicy",
+)
+
+INDEX_CONTROL_FIELDS = (
+    "controlId",
+    "label",
+    "state",
+    "enabled",
+    "userAction",
+    "launcherAction",
+    "sideEffectPolicy",
+    "contentPolicy",
+)
+
+BLOCKED_REASON_FIELDS = (
+    "reasonId",
+    "state",
+    "summary",
+    "requiredBefore",
+)
+
+HANDOFF_REF_FIELDS = (
+    "refId",
+    "schemaVersion",
+    "fixturePath",
+    "state",
+    "summary",
+)
+
+CHAT_SESSION_INDEX_STATE_VALUES = (
+    "available_as_data",
+    "blocked",
+    "disabled",
+    "empty_not_captured",
+    "inactive",
+    "not_configured",
+    "not_loaded",
+    "not_started",
+    "placeholder",
+    "planned",
+    "redacted",
+    "requires_evidence",
+    "summary_only",
+    "target_selected",
+    "unavailable",
+)
+
+_CHAT_SESSION_INDEX = {
+    "schemaVersion": SCHEMA_VERSION,
+    "sessionIndexId": "chat_session_index_gemma3n_e4b_kv260_placeholder",
+    "fixtureVersion": "chat-session-index.gemma3n-e4b-kv260.2026-05-04",
+    "lastUpdatedSource": "pccx_launcher_issue_9_chat_session_index_boundary_2026-05-04",
+    "targetDevice": "kv260",
+    "targetBoard": "xilinx_kria_kv260",
+    "targetModel": "gemma3n-e4b",
+    "indexState": "not_configured",
+    "sessionStoreState": "not_configured",
+    "manifestState": "unavailable",
+    "selectionState": "disabled",
+    "restoreState": "unavailable",
+    "contentState": "empty_not_captured",
+    "privacyState": "summary_only",
+    "parentChatSessionRef": "chat_session_gemma3n_e4b_kv260_placeholder",
+    "chatSessionLifecycleRef": "chat_session_lifecycle_gemma3n_e4b_kv260_placeholder",
+    "chatTranscriptPolicyRef": "chat_transcript_policy_gemma3n_e4b_kv260_placeholder",
+    "indexPolicy": {
+        "state": "not_configured",
+        "localStoreConfigured": False,
+        "manifestReadEnabled": False,
+        "transcriptReadEnabled": False,
+        "titlePolicy": "session titles are not read, generated, summarized, or emitted by this fixture",
+        "pathPolicy": "no session-store, transcript, model, user, or workspace paths are configured, read, or emitted",
+        "refreshPolicy": "future refresh requires an explicit reviewed local session-store boundary",
+        "sideEffectPolicy": "local_render_only",
+    },
+    "emptyState": {
+        "state": "placeholder",
+        "itemCount": 0,
+        "displayKind": "no_sessions_available",
+        "userVisibleSummary": "Show an empty local session index without reading a store.",
+        "sideEffectPolicy": "local_render_only",
+        "contentPolicy": "no_session_titles_summaries_prompts_responses_or_transcripts",
+    },
+    "indexControls": [
+        {
+            "controlId": "open_session_index",
+            "label": "open session index",
+            "state": "available_as_data",
+            "enabled": True,
+            "userAction": "Open the local chat session list surface.",
+            "launcherAction": "Render deterministic empty index state from checked fixture data.",
+            "sideEffectPolicy": "local_render_only",
+            "contentPolicy": "metadata_only_no_session_content",
+        },
+        {
+            "controlId": "refresh_session_index",
+            "label": "refresh session index",
+            "state": "blocked",
+            "enabled": False,
+            "userAction": "Refresh only after a reviewed local session-store boundary exists.",
+            "launcherAction": "Refuse refresh because no manifest read boundary exists.",
+            "sideEffectPolicy": "no_artifact_read_no_write",
+            "contentPolicy": "no_manifest_title_or_transcript_content",
+        },
+        {
+            "controlId": "select_session",
+            "label": "select session",
+            "state": "disabled",
+            "enabled": False,
+            "userAction": "Select only a future indexed local session.",
+            "launcherAction": "Keep selection disabled because the index is empty.",
+            "sideEffectPolicy": "local_render_only",
+            "contentPolicy": "no_session_identifier_from_user_store",
+        },
+        {
+            "controlId": "restore_selected_session",
+            "label": "restore selected session",
+            "state": "unavailable",
+            "enabled": False,
+            "userAction": "Restore only after a session manifest boundary exists.",
+            "launcherAction": "Refuse restore because no indexed session exists.",
+            "sideEffectPolicy": "no_artifact_read_no_write",
+            "contentPolicy": "no_session_manifest_or_transcript_content",
+        },
+        {
+            "controlId": "rename_session",
+            "label": "rename session",
+            "state": "disabled",
+            "enabled": False,
+            "userAction": "Rename only after explicit local store and title policy review.",
+            "launcherAction": "Keep rename disabled because no session title exists.",
+            "sideEffectPolicy": "no_write",
+            "contentPolicy": "no_title_capture_or_generation",
+        },
+        {
+            "controlId": "delete_session",
+            "label": "delete session",
+            "state": "inactive",
+            "enabled": False,
+            "userAction": "Delete only a future launcher-owned local session.",
+            "launcherAction": "No-op because no indexed session or local store exists.",
+            "sideEffectPolicy": "no_artifact_delete",
+            "contentPolicy": "no_transcript_mutation",
+        },
+    ],
+    "blockedReasons": [
+        {
+            "reasonId": "session_store_not_configured",
+            "state": "not_configured",
+            "summary": "No reviewed local chat session store exists.",
+            "requiredBefore": "session_index_refresh_enabled",
+        },
+        {
+            "reasonId": "session_manifest_boundary_absent",
+            "state": "planned",
+            "summary": "A checked session manifest shape is required before list items can be read.",
+            "requiredBefore": "session_list_items_available",
+        },
+        {
+            "reasonId": "session_titles_not_captured",
+            "state": "empty_not_captured",
+            "summary": "Session titles, summaries, prompts, and responses remain outside checked fixture data.",
+            "requiredBefore": "session_display_names_available",
+        },
+        {
+            "reasonId": "active_session_absent",
+            "state": "inactive",
+            "summary": "No launcher-owned local chat session is active or selectable.",
+            "requiredBefore": "selection_or_restore_enabled",
+        },
+        {
+            "reasonId": "artifact_read_boundary_absent",
+            "state": "requires_evidence",
+            "summary": "Refreshing a real index requires an explicit artifact-read boundary and tests.",
+            "requiredBefore": "refresh_session_index_enabled",
+        },
+    ],
+    "handoffRefs": [
+        {
+            "refId": "chat_session",
+            "schemaVersion": "pccx.chatSession.v0",
+            "fixturePath": "contracts/fixtures/chat-session.gemma3n-e4b-kv260-placeholder.json",
+            "state": "available_as_data",
+            "summary": "Base chat/session surface is referenced without message content.",
+        },
+        {
+            "refId": "chat_session_lifecycle",
+            "schemaVersion": "pccx.chatSessionLifecycle.v0",
+            "fixturePath": "contracts/fixtures/chat-session-lifecycle.gemma3n-e4b-kv260-placeholder.json",
+            "state": "blocked",
+            "summary": "Lifecycle restore, clear, close, and export actions remain disabled or blocked.",
+        },
+        {
+            "refId": "chat_transcript_policy",
+            "schemaVersion": "pccx.chatTranscriptPolicy.v0",
+            "fixturePath": "contracts/fixtures/chat-transcript-policy.gemma3n-e4b-kv260-placeholder.json",
+            "state": "disabled",
+            "summary": "Transcript persistence and export remain disabled.",
+        },
+        {
+            "refId": "chat_readiness",
+            "schemaVersion": "pccx.chatReadiness.v0",
+            "fixturePath": "contracts/fixtures/chat-readiness.gemma3n-e4b-kv260-placeholder.json",
+            "state": "blocked",
+            "summary": "Readiness gates stay separate from index display state.",
+        },
+    ],
+    "safetyFlags": {
+        "dataOnly": True,
+        "readOnly": True,
+        "deterministic": True,
+        "sessionIndexDisplayOnly": True,
+        "writesArtifacts": False,
+        "readsArtifacts": False,
+        "readsSessionManifest": False,
+        "readsTranscript": False,
+        "sessionPersistence": False,
+        "transcriptPersistence": False,
+        "transcriptExport": False,
+        "sessionRestoreImplemented": False,
+        "sessionDeleteImplemented": False,
+        "sessionRenameImplemented": False,
+        "localStoreConfigured": False,
+        "sessionTitleIncluded": False,
+        "sessionTitleGenerated": False,
+        "messageBodiesIncluded": False,
+        "summaryIncluded": False,
+        "summaryGenerated": False,
+        "promptCapture": False,
+        "promptContentIncluded": False,
+        "promptEchoed": False,
+        "promptPersistence": False,
+        "responseContentIncluded": False,
+        "responseGenerated": False,
+        "attachmentReads": False,
+        "fileUpload": False,
+        "clipboardRead": False,
+        "clipboardWrite": False,
+        "modelAssetPathsIncluded": False,
+        "modelWeightPathsIncluded": False,
+        "modelLoadAttempted": False,
+        "modelLoaded": False,
+        "modelExecution": False,
+        "runtimeExecution": False,
+        "touchesHardware": False,
+        "kv260Access": False,
+        "opensSerialPort": False,
+        "networkCalls": False,
+        "networkScan": False,
+        "sshExecution": False,
+        "providerCalls": False,
+        "cloudCalls": False,
+        "privatePathsIncluded": False,
+        "secretsIncluded": False,
+        "tokensIncluded": False,
+        "generatedBlobsIncluded": False,
+        "hardwareDumpsIncluded": False,
+        "telemetry": False,
+        "automaticUpload": False,
+        "writeBack": False,
+        "executesPccxLab": False,
+        "executesSystemverilogIde": False,
+        "mcpServerImplemented": False,
+        "lspImplemented": False,
+        "stableApiAbiClaim": False,
+    },
+    "limitations": [
+        "Data-only chat session index fixture; no real session store is configured or read.",
+        "No session titles, summaries, prompts, responses, transcripts, manifests, model paths, generated artifacts, private paths, secrets, or tokens are stored.",
+        "No artifacts are read, written, deleted, refreshed, imported, exported, or persisted.",
+        "No KV260 hardware access, serial access, network call, provider call, telemetry, upload, or write-back is performed.",
+        "Selection, restore, rename, delete, and refresh controls remain disabled, unavailable, inactive, or blocked until explicit evidence and reviewed boundaries exist.",
+        "This is not a release, tag, versioned compatibility commitment, MCP, LSP, IDE, marketplace, telemetry, or session-store implementation.",
+    ],
+    "issueRefs": [
+        "pccxai/pccx-llm-launcher#9",
+    ],
+}
+
+
+def create_gemma3n_e4b_kv260_chat_session_index() -> dict:
+    """Return the checked Gemma 3N E4B plus KV260 session-index fixture."""
+    return copy.deepcopy(_CHAT_SESSION_INDEX)
+
+
+def chat_session_index_json(status: dict | None = None) -> str:
+    """Render a deterministic JSON representation."""
+    return json.dumps(
+        status
+        if status is not None
+        else create_gemma3n_e4b_kv260_chat_session_index(),
+        indent=2,
+        sort_keys=True,
+    ) + "\n"
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Print data-only chat session index JSON.",
+    )
+    parser.add_argument(
+        "--model",
+        default="gemma3n-e4b",
+        choices=("gemma3n-e4b",),
+        help="model descriptor target",
+    )
+    parser.add_argument(
+        "--target",
+        default="kv260",
+        choices=("kv260",),
+        help="target board/device",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parse_args(sys.argv[1:] if argv is None else argv)
+    sys.stdout.write(chat_session_index_json())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contracts/fixtures/chat-session-index.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-session-index.gemma3n-e4b-kv260-placeholder.json
@@ -1,0 +1,231 @@
+{
+  "schemaVersion": "pccx.chatSessionIndex.v0",
+  "sessionIndexId": "chat_session_index_gemma3n_e4b_kv260_placeholder",
+  "fixtureVersion": "chat-session-index.gemma3n-e4b-kv260.2026-05-04",
+  "lastUpdatedSource": "pccx_launcher_issue_9_chat_session_index_boundary_2026-05-04",
+  "targetDevice": "kv260",
+  "targetBoard": "xilinx_kria_kv260",
+  "targetModel": "gemma3n-e4b",
+  "indexState": "not_configured",
+  "sessionStoreState": "not_configured",
+  "manifestState": "unavailable",
+  "selectionState": "disabled",
+  "restoreState": "unavailable",
+  "contentState": "empty_not_captured",
+  "privacyState": "summary_only",
+  "parentChatSessionRef": "chat_session_gemma3n_e4b_kv260_placeholder",
+  "chatSessionLifecycleRef": "chat_session_lifecycle_gemma3n_e4b_kv260_placeholder",
+  "chatTranscriptPolicyRef": "chat_transcript_policy_gemma3n_e4b_kv260_placeholder",
+  "indexPolicy": {
+    "state": "not_configured",
+    "localStoreConfigured": false,
+    "manifestReadEnabled": false,
+    "transcriptReadEnabled": false,
+    "titlePolicy": "session titles are not read, generated, summarized, or emitted by this fixture",
+    "pathPolicy": "no session-store, transcript, model, user, or workspace paths are configured, read, or emitted",
+    "refreshPolicy": "future refresh requires an explicit reviewed local session-store boundary",
+    "sideEffectPolicy": "local_render_only"
+  },
+  "emptyState": {
+    "state": "placeholder",
+    "itemCount": 0,
+    "displayKind": "no_sessions_available",
+    "userVisibleSummary": "Show an empty local session index without reading a store.",
+    "sideEffectPolicy": "local_render_only",
+    "contentPolicy": "no_session_titles_summaries_prompts_responses_or_transcripts"
+  },
+  "indexControls": [
+    {
+      "controlId": "open_session_index",
+      "label": "open session index",
+      "state": "available_as_data",
+      "enabled": true,
+      "userAction": "Open the local chat session list surface.",
+      "launcherAction": "Render deterministic empty index state from checked fixture data.",
+      "sideEffectPolicy": "local_render_only",
+      "contentPolicy": "metadata_only_no_session_content"
+    },
+    {
+      "controlId": "refresh_session_index",
+      "label": "refresh session index",
+      "state": "blocked",
+      "enabled": false,
+      "userAction": "Refresh only after a reviewed local session-store boundary exists.",
+      "launcherAction": "Refuse refresh because no manifest read boundary exists.",
+      "sideEffectPolicy": "no_artifact_read_no_write",
+      "contentPolicy": "no_manifest_title_or_transcript_content"
+    },
+    {
+      "controlId": "select_session",
+      "label": "select session",
+      "state": "disabled",
+      "enabled": false,
+      "userAction": "Select only a future indexed local session.",
+      "launcherAction": "Keep selection disabled because the index is empty.",
+      "sideEffectPolicy": "local_render_only",
+      "contentPolicy": "no_session_identifier_from_user_store"
+    },
+    {
+      "controlId": "restore_selected_session",
+      "label": "restore selected session",
+      "state": "unavailable",
+      "enabled": false,
+      "userAction": "Restore only after a session manifest boundary exists.",
+      "launcherAction": "Refuse restore because no indexed session exists.",
+      "sideEffectPolicy": "no_artifact_read_no_write",
+      "contentPolicy": "no_session_manifest_or_transcript_content"
+    },
+    {
+      "controlId": "rename_session",
+      "label": "rename session",
+      "state": "disabled",
+      "enabled": false,
+      "userAction": "Rename only after explicit local store and title policy review.",
+      "launcherAction": "Keep rename disabled because no session title exists.",
+      "sideEffectPolicy": "no_write",
+      "contentPolicy": "no_title_capture_or_generation"
+    },
+    {
+      "controlId": "delete_session",
+      "label": "delete session",
+      "state": "inactive",
+      "enabled": false,
+      "userAction": "Delete only a future launcher-owned local session.",
+      "launcherAction": "No-op because no indexed session or local store exists.",
+      "sideEffectPolicy": "no_artifact_delete",
+      "contentPolicy": "no_transcript_mutation"
+    }
+  ],
+  "blockedReasons": [
+    {
+      "reasonId": "session_store_not_configured",
+      "state": "not_configured",
+      "summary": "No reviewed local chat session store exists.",
+      "requiredBefore": "session_index_refresh_enabled"
+    },
+    {
+      "reasonId": "session_manifest_boundary_absent",
+      "state": "planned",
+      "summary": "A checked session manifest shape is required before list items can be read.",
+      "requiredBefore": "session_list_items_available"
+    },
+    {
+      "reasonId": "session_titles_not_captured",
+      "state": "empty_not_captured",
+      "summary": "Session titles, summaries, prompts, and responses remain outside checked fixture data.",
+      "requiredBefore": "session_display_names_available"
+    },
+    {
+      "reasonId": "active_session_absent",
+      "state": "inactive",
+      "summary": "No launcher-owned local chat session is active or selectable.",
+      "requiredBefore": "selection_or_restore_enabled"
+    },
+    {
+      "reasonId": "artifact_read_boundary_absent",
+      "state": "requires_evidence",
+      "summary": "Refreshing a real index requires an explicit artifact-read boundary and tests.",
+      "requiredBefore": "refresh_session_index_enabled"
+    }
+  ],
+  "handoffRefs": [
+    {
+      "refId": "chat_session",
+      "schemaVersion": "pccx.chatSession.v0",
+      "fixturePath": "contracts/fixtures/chat-session.gemma3n-e4b-kv260-placeholder.json",
+      "state": "available_as_data",
+      "summary": "Base chat/session surface is referenced without message content."
+    },
+    {
+      "refId": "chat_session_lifecycle",
+      "schemaVersion": "pccx.chatSessionLifecycle.v0",
+      "fixturePath": "contracts/fixtures/chat-session-lifecycle.gemma3n-e4b-kv260-placeholder.json",
+      "state": "blocked",
+      "summary": "Lifecycle restore, clear, close, and export actions remain disabled or blocked."
+    },
+    {
+      "refId": "chat_transcript_policy",
+      "schemaVersion": "pccx.chatTranscriptPolicy.v0",
+      "fixturePath": "contracts/fixtures/chat-transcript-policy.gemma3n-e4b-kv260-placeholder.json",
+      "state": "disabled",
+      "summary": "Transcript persistence and export remain disabled."
+    },
+    {
+      "refId": "chat_readiness",
+      "schemaVersion": "pccx.chatReadiness.v0",
+      "fixturePath": "contracts/fixtures/chat-readiness.gemma3n-e4b-kv260-placeholder.json",
+      "state": "blocked",
+      "summary": "Readiness gates stay separate from index display state."
+    }
+  ],
+  "safetyFlags": {
+    "dataOnly": true,
+    "readOnly": true,
+    "deterministic": true,
+    "sessionIndexDisplayOnly": true,
+    "writesArtifacts": false,
+    "readsArtifacts": false,
+    "readsSessionManifest": false,
+    "readsTranscript": false,
+    "sessionPersistence": false,
+    "transcriptPersistence": false,
+    "transcriptExport": false,
+    "sessionRestoreImplemented": false,
+    "sessionDeleteImplemented": false,
+    "sessionRenameImplemented": false,
+    "localStoreConfigured": false,
+    "sessionTitleIncluded": false,
+    "sessionTitleGenerated": false,
+    "messageBodiesIncluded": false,
+    "summaryIncluded": false,
+    "summaryGenerated": false,
+    "promptCapture": false,
+    "promptContentIncluded": false,
+    "promptEchoed": false,
+    "promptPersistence": false,
+    "responseContentIncluded": false,
+    "responseGenerated": false,
+    "attachmentReads": false,
+    "fileUpload": false,
+    "clipboardRead": false,
+    "clipboardWrite": false,
+    "modelAssetPathsIncluded": false,
+    "modelWeightPathsIncluded": false,
+    "modelLoadAttempted": false,
+    "modelLoaded": false,
+    "modelExecution": false,
+    "runtimeExecution": false,
+    "touchesHardware": false,
+    "kv260Access": false,
+    "opensSerialPort": false,
+    "networkCalls": false,
+    "networkScan": false,
+    "sshExecution": false,
+    "providerCalls": false,
+    "cloudCalls": false,
+    "privatePathsIncluded": false,
+    "secretsIncluded": false,
+    "tokensIncluded": false,
+    "generatedBlobsIncluded": false,
+    "hardwareDumpsIncluded": false,
+    "telemetry": false,
+    "automaticUpload": false,
+    "writeBack": false,
+    "executesPccxLab": false,
+    "executesSystemverilogIde": false,
+    "mcpServerImplemented": false,
+    "lspImplemented": false,
+    "stableApiAbiClaim": false
+  },
+  "limitations": [
+    "Data-only chat session index fixture; no real session store is configured or read.",
+    "No session titles, summaries, prompts, responses, transcripts, manifests, model paths, generated artifacts, private paths, secrets, or tokens are stored.",
+    "No artifacts are read, written, deleted, refreshed, imported, exported, or persisted.",
+    "No KV260 hardware access, serial access, network call, provider call, telemetry, upload, or write-back is performed.",
+    "Selection, restore, rename, delete, and refresh controls remain disabled, unavailable, inactive, or blocked until explicit evidence and reviewed boundaries exist.",
+    "This is not a release, tag, versioned compatibility commitment, MCP, LSP, IDE, marketplace, telemetry, or session-store implementation."
+  ],
+  "issueRefs": [
+    "pccxai/pccx-llm-launcher#9"
+  ]
+}

--- a/docs/STANDALONE_CHAT_SESSION_CONTRACT.md
+++ b/docs/STANDALONE_CHAT_SESSION_CONTRACT.md
@@ -11,6 +11,7 @@ The implementation lives in:
 - `contracts/chat_session_contract.py`
 - `contracts/chat_model_status_contract.py`
 - `contracts/chat_session_lifecycle_contract.py`
+- `contracts/chat_session_index_contract.py`
 - `contracts/chat_readiness_contract.py`
 - `contracts/chat_composer_contract.py`
 - `contracts/chat_send_result_contract.py`
@@ -19,6 +20,7 @@ The implementation lives in:
 - `contracts/fixtures/chat-session.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-model-status.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-session-lifecycle.gemma3n-e4b-kv260-placeholder.json`
+- `contracts/fixtures/chat-session-index.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-readiness.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-composer.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-send-result.gemma3n-e4b-kv260-placeholder.json`
@@ -27,6 +29,7 @@ The implementation lives in:
 - `scripts/chat-session-stub.sh`
 - `scripts/chat-model-status-stub.sh`
 - `scripts/chat-session-lifecycle-stub.sh`
+- `scripts/chat-session-index-stub.sh`
 - `scripts/chat-readiness-stub.sh`
 - `scripts/chat-composer-stub.sh`
 - `scripts/chat-send-result-stub.sh`
@@ -36,6 +39,7 @@ The implementation lives in:
 - `scripts/tests/chat_session_contract_test.py`
 - `scripts/tests/chat_model_status_contract_test.py`
 - `scripts/tests/chat_session_lifecycle_contract_test.py`
+- `scripts/tests/chat_session_index_contract_test.py`
 - `scripts/tests/chat_readiness_contract_test.py`
 - `scripts/tests/chat_composer_contract_test.py`
 - `scripts/tests/chat_send_result_contract_test.py`
@@ -43,6 +47,7 @@ The implementation lives in:
 - `scripts/tests/chat_audit_event_contract_test.py`
 - `scripts/tests/chat_surface_preview_test.py`
 - `scripts/tests/status-chat-model-status.sh`
+- `scripts/tests/status-chat-session-index.sh`
 - `scripts/tests/status-chat-readiness.sh`
 - `scripts/tests/status-chat-composer.sh`
 - `scripts/tests/status-chat-send-result.sh`
@@ -57,6 +62,8 @@ The chat/session contract records:
 - chat surface, model-load, input, send, and session states
 - disabled session controls for new session, model status, send,
   clear, and export actions
+- an empty session index/list surface with disabled refresh, selection,
+  restore, rename, and delete controls
 - a message envelope vocabulary without prompt or response content
 - links to the runtime readiness and device/session status fixtures
 - blocked reasons that explain what must exist before send controls can
@@ -94,6 +101,21 @@ until runtime readiness, model-load evidence, a reviewed local session
 store, and explicit export/redaction rules exist. The fixture does not
 read or write manifests, transcripts, summaries, prompts, responses, or
 model paths.
+
+The chat session index fixture records the list/sidebar boundary for
+future local chat sessions:
+
+```bash
+bash scripts/chat-session-index-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/status-stub.sh --include-chat-session-index
+```
+
+It reports an empty, not-configured session index and keeps refresh,
+selection, restore, rename, and delete actions disabled, inactive,
+unavailable, or blocked. The fixture does not read a session store,
+session manifest, session title, transcript, summary, prompt, response,
+model path, private path, or raw log, and it does not write, delete,
+refresh, import, export, or persist artifacts.
 
 The chat readiness fixture records the checklist and recovery-action
 boundary used to decide whether the standalone chat surface can move
@@ -214,6 +236,26 @@ content:
 - `unavailable`: no prior local session can be restored
 - `available_as_data`: referenced local fixture shape is available as data only
 
+The session-index states keep list/sidebar display separate from local
+session storage and transcript content:
+
+- `available_as_data`: the empty index surface can be rendered from
+  checked fixture data
+- `blocked`: a required local store or manifest boundary is missing
+- `disabled`: selection or title-changing controls are intentionally
+  unavailable
+- `empty_not_captured`: no session titles, summaries, prompts, or
+  responses are captured
+- `inactive`: no launcher-owned local chat session is active or
+  selectable
+- `not_configured`: no local session store or index refresh source
+  exists
+- `planned`: described for a future reviewed boundary
+- `requires_evidence`: a future artifact-read path needs evidence and
+  tests first
+- `summary_only`: privacy state contains metadata only
+- `unavailable`: restore output or indexed sessions are unavailable
+
 The readiness states keep send-control gating separate from model-status
 display and lifecycle operations:
 
@@ -295,6 +337,9 @@ calls, persistence, target access, artifact reads, or artifact writes.
 The readiness contract ties those display and lifecycle states into a
 single checklist and recovery-action view without enabling any send,
 load, restore, or export action.
+The session-index contract adds a reviewable empty list/sidebar boundary
+without enabling manifest reads, transcript reads, title capture,
+restore, rename, delete, refresh, persistence, or artifact writes.
 The composer contract adds a reviewable input-control and validation
 shape without prompt capture, prompt echo, prompt persistence, attachment
 reads, clipboard access, or send enablement.

--- a/scripts/chat-session-index-stub.sh
+++ b/scripts/chat-session-index-stub.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+# Print the data-only chat session index contract.
+
+set -eu
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+
+python3 "$ROOT_DIR/contracts/chat_session_index_contract.py" "$@"

--- a/scripts/status-stub.sh
+++ b/scripts/status-stub.sh
@@ -13,6 +13,9 @@
 # Chat/session status and lifecycle plan (explicit opt-in, read-only local data):
 #   --include-chat-session
 #
+# Chat session index/sidebar plan (explicit opt-in, read-only local data):
+#   --include-chat-session-index
+#
 # Chat model status display plan (explicit opt-in, read-only local data):
 #   --include-chat-model-status
 #
@@ -49,12 +52,120 @@ BACKEND=""
 INCLUDE_RUNTIME_READINESS="0"
 INCLUDE_DEVICE_SESSION="0"
 INCLUDE_CHAT_SESSION="0"
+INCLUDE_CHAT_SESSION_INDEX="0"
 INCLUDE_CHAT_MODEL_STATUS="0"
 INCLUDE_CHAT_READINESS="0"
 INCLUDE_CHAT_COMPOSER="0"
 INCLUDE_CHAT_SEND_RESULT="0"
 INCLUDE_CHAT_TRANSCRIPT_POLICY="0"
 INCLUDE_CHAT_AUDIT_EVENT="0"
+
+print_chat_session_index_summary() {
+    SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+    ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+    CHAT_SESSION_INDEX_STUB="$ROOT_DIR/scripts/chat-session-index-stub.sh"
+
+    if [ ! -f "$CHAT_SESSION_INDEX_STUB" ]; then
+        ERROR "chat session index stub not found: $CHAT_SESSION_INDEX_STUB"
+        return 1
+    fi
+
+    if ! CHAT_SESSION_INDEX_JSON="$(bash "$CHAT_SESSION_INDEX_STUB" --model gemma3n-e4b --target kv260 2>&1)"; then
+        ERROR "chat session index stub failed"
+        printf '%s\n' "$CHAT_SESSION_INDEX_JSON" >&2
+        return 1
+    fi
+
+    if ! CHAT_SESSION_INDEX_SUMMARY="$(
+        printf '%s\n' "$CHAT_SESSION_INDEX_JSON" | python3 -c '
+import json
+import sys
+
+data = json.load(sys.stdin)
+flags = data["safetyFlags"]
+policy = data["indexPolicy"]
+empty = data["emptyState"]
+controls = " ".join(
+    "{}={}".format(control["controlId"], control["state"])
+    for control in data["indexControls"]
+)
+blocked = " ".join(
+    "{}={}".format(reason["reasonId"], reason["state"])
+    for reason in data["blockedReasons"]
+)
+
+def b(value):
+    return "true" if value else "false"
+
+print("[INFO]  source     : scripts/chat-session-index-stub.sh --model gemma3n-e4b --target kv260")
+print("[INFO]  boundary   : read-only data; no session-store/transcript/prompt/model/hardware/lab/IDE execution")
+print("[INFO]  target     : {}".format(data["targetDevice"]))
+print("[INFO]  model      : {}".format(data["targetModel"]))
+print("[INFO]  index      : {}".format(data["indexState"]))
+print("[INFO]  store      : {}".format(data["sessionStoreState"]))
+print("[INFO]  manifest   : {}".format(data["manifestState"]))
+print("[INFO]  selection  : {}".format(data["selectionState"]))
+print("[INFO]  restore    : {}".format(data["restoreState"]))
+print("[INFO]  content    : {}".format(data["contentState"]))
+print("[INFO]  privacy    : {}".format(data["privacyState"]))
+print(
+    "[INFO]  index-policy : {} localStoreConfigured={} "
+    "manifestReadEnabled={} transcriptReadEnabled={}".format(
+        policy["state"],
+        b(policy["localStoreConfigured"]),
+        b(policy["manifestReadEnabled"]),
+        b(policy["transcriptReadEnabled"]),
+    )
+)
+print(
+    "[INFO]  empty      : {} itemCount={} displayKind={}".format(
+        empty["state"],
+        empty["itemCount"],
+        empty["displayKind"],
+    )
+)
+print("[INFO]  controls   : {}".format(controls))
+print("[INFO]  blocked    : {}".format(blocked))
+print(
+    "[INFO]  flags      : readOnly={} dataOnly={} deterministic={} "
+    "sessionIndexDisplayOnly={} writesArtifacts={} readsArtifacts={} "
+    "readsSessionManifest={} readsTranscript={} sessionPersistence={} "
+    "transcriptPersistence={} promptContentIncluded={} "
+    "responseContentIncluded={} messageBodiesIncluded={} summaryIncluded={} "
+    "sessionTitleIncluded={} modelExecution={} runtimeExecution={} "
+    "kv260Access={} networkCalls={} providerCalls={} executesPccxLab={}".format(
+        b(flags["readOnly"]),
+        b(flags["dataOnly"]),
+        b(flags["deterministic"]),
+        b(flags["sessionIndexDisplayOnly"]),
+        b(flags["writesArtifacts"]),
+        b(flags["readsArtifacts"]),
+        b(flags["readsSessionManifest"]),
+        b(flags["readsTranscript"]),
+        b(flags["sessionPersistence"]),
+        b(flags["transcriptPersistence"]),
+        b(flags["promptContentIncluded"]),
+        b(flags["responseContentIncluded"]),
+        b(flags["messageBodiesIncluded"]),
+        b(flags["summaryIncluded"]),
+        b(flags["sessionTitleIncluded"]),
+        b(flags["modelExecution"]),
+        b(flags["runtimeExecution"]),
+        b(flags["kv260Access"]),
+        b(flags["networkCalls"]),
+        b(flags["providerCalls"]),
+        b(flags["executesPccxLab"]),
+    )
+)
+'
+    )"; then
+        ERROR "chat session index JSON could not be summarized"
+        return 1
+    fi
+
+    HEAD "chat session index"
+    printf '%s\n' "$CHAT_SESSION_INDEX_SUMMARY"
+}
 
 print_chat_audit_event_summary() {
     SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
@@ -989,6 +1100,10 @@ while [ $# -gt 0 ]; do
             INCLUDE_CHAT_SESSION="1"
             shift
             ;;
+        --include-chat-session-index)
+            INCLUDE_CHAT_SESSION_INDEX="1"
+            shift
+            ;;
         --include-chat-model-status)
             INCLUDE_CHAT_MODEL_STATUS="1"
             shift
@@ -1028,8 +1143,8 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-if [ -n "$BACKEND" ] && { [ "$INCLUDE_RUNTIME_READINESS" = "1" ] || [ "$INCLUDE_DEVICE_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SESSION" = "1" ] || [ "$INCLUDE_CHAT_MODEL_STATUS" = "1" ] || [ "$INCLUDE_CHAT_READINESS" = "1" ] || [ "$INCLUDE_CHAT_COMPOSER" = "1" ] || [ "$INCLUDE_CHAT_SEND_RESULT" = "1" ] || [ "$INCLUDE_CHAT_TRANSCRIPT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_AUDIT_EVENT" = "1" ]; }; then
-    ERROR "--include-runtime-readiness, --include-device-session, --include-chat-session, --include-chat-model-status, --include-chat-readiness, --include-chat-composer, --include-chat-send-result, --include-chat-transcript-policy, and --include-chat-audit-event are only supported in local scaffold mode"
+if [ -n "$BACKEND" ] && { [ "$INCLUDE_RUNTIME_READINESS" = "1" ] || [ "$INCLUDE_DEVICE_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SESSION_INDEX" = "1" ] || [ "$INCLUDE_CHAT_MODEL_STATUS" = "1" ] || [ "$INCLUDE_CHAT_READINESS" = "1" ] || [ "$INCLUDE_CHAT_COMPOSER" = "1" ] || [ "$INCLUDE_CHAT_SEND_RESULT" = "1" ] || [ "$INCLUDE_CHAT_TRANSCRIPT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_AUDIT_EVENT" = "1" ]; }; then
+    ERROR "--include-runtime-readiness, --include-device-session, --include-chat-session, --include-chat-session-index, --include-chat-model-status, --include-chat-readiness, --include-chat-composer, --include-chat-send-result, --include-chat-transcript-policy, and --include-chat-audit-event are only supported in local scaffold mode"
     exit 1
 fi
 
@@ -1045,6 +1160,7 @@ if [ -z "$BACKEND" ]; then
     NOTE "runtime ready  : opt-in via --include-runtime-readiness (read-only data)"
     NOTE "device/session: opt-in via --include-device-session (read-only panel data)"
     NOTE "chat/session  : opt-in via --include-chat-session (read-only blocked chat and lifecycle data)"
+    NOTE "chat index    : opt-in via --include-chat-session-index (read-only empty session index data)"
     NOTE "chat model    : opt-in via --include-chat-model-status (read-only model status display data)"
     NOTE "chat readiness: opt-in via --include-chat-readiness (read-only readiness and recovery data)"
     NOTE "chat composer : opt-in via --include-chat-composer (read-only input control data)"
@@ -1055,6 +1171,12 @@ if [ -z "$BACKEND" ]; then
 
     if [ "$INCLUDE_CHAT_AUDIT_EVENT" = "1" ]; then
         if ! print_chat_audit_event_summary; then
+            exit 1
+        fi
+    fi
+
+    if [ "$INCLUDE_CHAT_SESSION_INDEX" = "1" ]; then
+        if ! print_chat_session_index_summary; then
             exit 1
         fi
     fi

--- a/scripts/tests/chat_session_index_contract_test.py
+++ b/scripts/tests/chat_session_index_contract_test.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Fixture tests for the standalone chat session-index contract."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "contracts" / "chat_session_index_contract.py"
+FIXTURE_PATH = (
+    ROOT
+    / "contracts"
+    / "fixtures"
+    / "chat-session-index.gemma3n-e4b-kv260-placeholder.json"
+)
+SCRIPT_PATH = ROOT / "scripts" / "chat-session-index-stub.sh"
+STATUS_TEST_PATH = ROOT / "scripts" / "tests" / "status-chat-session-index.sh"
+DOC_PATH = ROOT / "docs" / "STANDALONE_CHAT_SESSION_CONTRACT.md"
+README_PATH = ROOT / "README.md"
+CI_PATH = ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location(
+        "chat_session_index_contract",
+        MODULE_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def iter_state_values(value):
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            if (
+                key == "state"
+                or key.endswith("State")
+                or key.endswith("Status")
+            ) and isinstance(nested, str):
+                yield nested
+            yield from iter_state_values(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            yield from iter_state_values(nested)
+
+
+def iter_keys(value):
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            yield key
+            yield from iter_keys(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            yield from iter_keys(nested)
+
+
+def assert_no_private_or_generated_data(text: str) -> None:
+    forbidden_patterns = [
+        r"/home/[^\s\"']+",
+        r"/Users/[^\s\"']+",
+        r"[A-Za-z]:\\Users\\",
+        r"\b(?:api[_-]?key|authorization|bearer|client[_-]?secret|password|private[_-]?key|secret|token)\b\s*[:=]",
+        r"\.(?:gguf|safetensors|ckpt|pt|pth|onnx)\b",
+        r"(?:weights|model_weights|model-cache)/(?:[^\"'\s]+)",
+        r"(?:raw[_-]?full[_-]?logs|hardware[_-]?dump|generated[_-]?blob)\s*[:=]",
+    ]
+    for pattern in forbidden_patterns:
+        assert not re.search(pattern, text, re.IGNORECASE), pattern
+
+
+def assert_no_runtime_implementation_terms(source: str) -> None:
+    forbidden = [
+        "subprocess",
+        "os.system",
+        "popen",
+        "socket",
+        "urllib",
+        "requests",
+        "http.client",
+        "openai",
+        "anthropic",
+        "gemini",
+        "modelcontextprotocol",
+        "websocket",
+        "xmutil",
+        "xrt-smi",
+        "lsusb",
+        "dmesg",
+    ]
+    lowered = source.lower()
+    for term in forbidden:
+        assert term not in lowered, term
+
+
+def assert_no_provider_configs(value) -> None:
+    forbidden_keys = {
+        "apiKey",
+        "accessToken",
+        "refreshToken",
+        "authorization",
+        "bearerToken",
+        "provider",
+        "providers",
+        "providerConfig",
+        "providerConfigs",
+    }
+    for key in iter_keys(value):
+        assert key not in forbidden_keys, key
+
+
+def assert_no_unsupported_claims(text: str) -> None:
+    literal_claims = [
+        "production-ready",
+        "marketplace-ready",
+        "stable API",
+        "stable ABI",
+        "KV260 inference works",
+        "Gemma 3N E4B runs on KV260",
+        "20 tok/s achieved",
+        "timing closed",
+        "bitstream ready",
+        "launcher executes pccx-lab",
+        "IDE controls launcher",
+        "AI provider integration is live",
+    ]
+    lowered = text.lower()
+    for claim in literal_claims:
+        assert claim.lower() not in lowered, claim
+
+
+def test_chat_session_index_matches_fixture_and_is_deterministic() -> None:
+    module = load_module()
+    generated = module.create_gemma3n_e4b_kv260_chat_session_index()
+    fixture = json.loads(read_text(FIXTURE_PATH))
+
+    assert generated == fixture
+    assert (
+        module.chat_session_index_json(generated)
+        == module.chat_session_index_json(generated)
+    )
+    assert module.chat_session_index_json(generated).endswith("\n")
+    assert json.loads(module.chat_session_index_json(generated)) == fixture
+
+
+def test_cli_stub_outputs_deterministic_json() -> None:
+    fixture = json.loads(read_text(FIXTURE_PATH))
+    command = [
+        "bash",
+        str(SCRIPT_PATH),
+        "--model",
+        "gemma3n-e4b",
+        "--target",
+        "kv260",
+    ]
+    first = subprocess.run(command, check=True, capture_output=True, text=True)
+    second = subprocess.run(command, check=True, capture_output=True, text=True)
+
+    assert first.stderr == ""
+    assert first.stdout == second.stdout
+    assert first.stdout.endswith("\n")
+    assert json.loads(first.stdout) == fixture
+
+
+def test_required_fields_and_allowed_states() -> None:
+    module = load_module()
+    index = module.create_gemma3n_e4b_kv260_chat_session_index()
+    allowed = set(module.CHAT_SESSION_INDEX_STATE_VALUES)
+
+    assert tuple(index.keys()) == module.CHAT_SESSION_INDEX_FIELDS
+    assert index["schemaVersion"] == "pccx.chatSessionIndex.v0"
+    assert tuple(index["indexPolicy"].keys()) == module.INDEX_POLICY_FIELDS
+    assert tuple(index["emptyState"].keys()) == module.EMPTY_STATE_FIELDS
+
+    states = list(iter_state_values(index))
+    assert states
+    for state in states:
+        assert state in allowed, state
+
+    for control in index["indexControls"]:
+        assert tuple(control.keys()) == module.INDEX_CONTROL_FIELDS
+    for reason in index["blockedReasons"]:
+        assert tuple(reason.keys()) == module.BLOCKED_REASON_FIELDS
+    for ref in index["handoffRefs"]:
+        assert tuple(ref.keys()) == module.HANDOFF_REF_FIELDS
+
+
+def test_chat_session_index_covers_issue_9_session_sidebar_boundary() -> None:
+    index = load_module().create_gemma3n_e4b_kv260_chat_session_index()
+    flags = index["safetyFlags"]
+    policy = index["indexPolicy"]
+    controls = {control["controlId"]: control for control in index["indexControls"]}
+    reasons = {reason["reasonId"]: reason for reason in index["blockedReasons"]}
+    refs = {ref["refId"]: ref for ref in index["handoffRefs"]}
+
+    assert index["indexState"] == "not_configured"
+    assert index["sessionStoreState"] == "not_configured"
+    assert index["manifestState"] == "unavailable"
+    assert index["selectionState"] == "disabled"
+    assert index["restoreState"] == "unavailable"
+    assert index["contentState"] == "empty_not_captured"
+    assert index["privacyState"] == "summary_only"
+    assert policy["localStoreConfigured"] is False
+    assert policy["manifestReadEnabled"] is False
+    assert policy["transcriptReadEnabled"] is False
+    assert index["emptyState"]["itemCount"] == 0
+    assert set(controls) == {
+        "open_session_index",
+        "refresh_session_index",
+        "select_session",
+        "restore_selected_session",
+        "rename_session",
+        "delete_session",
+    }
+    assert controls["open_session_index"]["enabled"] is True
+    assert controls["refresh_session_index"]["enabled"] is False
+    assert controls["restore_selected_session"]["state"] == "unavailable"
+    assert {
+        "session_store_not_configured",
+        "session_manifest_boundary_absent",
+        "session_titles_not_captured",
+        "active_session_absent",
+        "artifact_read_boundary_absent",
+    } <= set(reasons)
+    assert set(refs) == {
+        "chat_session",
+        "chat_session_lifecycle",
+        "chat_transcript_policy",
+        "chat_readiness",
+    }
+    assert flags["readOnly"] is True
+    assert flags["sessionIndexDisplayOnly"] is True
+    assert flags["readsArtifacts"] is False
+    assert flags["writesArtifacts"] is False
+    assert flags["readsSessionManifest"] is False
+    assert flags["readsTranscript"] is False
+    assert flags["sessionPersistence"] is False
+    assert flags["transcriptPersistence"] is False
+    assert flags["sessionTitleIncluded"] is False
+    assert flags["summaryIncluded"] is False
+    assert flags["promptContentIncluded"] is False
+    assert flags["responseContentIncluded"] is False
+    assert flags["modelExecution"] is False
+    assert flags["runtimeExecution"] is False
+    assert flags["kv260Access"] is False
+    assert flags["providerCalls"] is False
+    assert flags["executesPccxLab"] is False
+
+
+def test_contract_avoids_runtime_or_private_data() -> None:
+    module_source = read_text(MODULE_PATH)
+    fixture_text = read_text(FIXTURE_PATH)
+    fixture = json.loads(fixture_text)
+
+    assert_no_runtime_implementation_terms(module_source)
+    assert_no_private_or_generated_data(fixture_text)
+    assert_no_provider_configs(fixture)
+    assert_no_unsupported_claims(fixture_text)
+    assert "hello" not in fixture_text.lower()
+    assert "promptText" not in fixture_text
+    assert "responseText" not in fixture_text
+    assert "sessionTitleText" not in fixture_text
+
+
+def test_docs_readme_status_tests_and_ci_reference_session_index() -> None:
+    docs = read_text(DOC_PATH)
+    readme = read_text(README_PATH)
+    status_test = read_text(STATUS_TEST_PATH)
+    ci = read_text(CI_PATH)
+
+    assert "chat_session_index_contract.py" in docs
+    assert "chat-session-index-stub.sh" in docs
+    assert "chat-session-index.gemma3n-e4b-kv260-placeholder.json" in docs
+    assert "chat session index" in docs
+    assert "--include-chat-session-index" in docs
+    assert "chat-session-index-stub.sh" in readme
+    assert "--include-chat-session-index" in readme
+    assert "status-chat-session-index" in ci
+    assert "chat_session_index_contract_test.py" in ci
+    assert "no session-store/transcript/prompt" in status_test
+
+
+if __name__ == "__main__":
+    for name, func in sorted(globals().items()):
+        if name.startswith("test_") and callable(func):
+            func()
+    print("chat session index contract tests ok")

--- a/scripts/tests/status-chat-session-index.sh
+++ b/scripts/tests/status-chat-session-index.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+# scripts/tests/status-chat-session-index.sh - status session-index tests.
+#
+# Usage: bash scripts/tests/status-chat-session-index.sh [path/to/status-stub.sh]
+
+set -eu
+
+PASS() { printf '[PASS]  %s\n' "$*"; }
+FAIL() { printf '[FAIL]  %s\n' "$*" >&2; }
+HEAD() { printf '\n=== %s ===\n' "$*"; }
+
+STUB="${1:-scripts/status-stub.sh}"
+
+if [ ! -x "$STUB" ]; then
+    chmod +x "$STUB"
+fi
+
+contains() {
+    case "$1" in
+        *"$2"*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+require_contains() {
+    local output="$1"
+    local expected="$2"
+    if ! contains "$output" "$expected"; then
+        FAIL "expected output to contain: $expected"
+        printf '%s\n' "$output" >&2
+        exit 1
+    fi
+}
+
+require_not_contains() {
+    local output="$1"
+    local forbidden="$2"
+    if contains "$output" "$forbidden"; then
+        FAIL "output contained forbidden text: $forbidden"
+        printf '%s\n' "$output" >&2
+        exit 1
+    fi
+}
+
+HEAD "1: status can include chat session index"
+OUTPUT="$("$STUB" --include-chat-session-index)"
+require_contains "$OUTPUT" "=== chat session index ==="
+require_contains "$OUTPUT" "source     : scripts/chat-session-index-stub.sh --model gemma3n-e4b --target kv260"
+require_contains "$OUTPUT" "boundary   : read-only data; no session-store/transcript/prompt/model/hardware/lab/IDE execution"
+require_contains "$OUTPUT" "target     : kv260"
+require_contains "$OUTPUT" "model      : gemma3n-e4b"
+require_contains "$OUTPUT" "index      : not_configured"
+require_contains "$OUTPUT" "store      : not_configured"
+require_contains "$OUTPUT" "manifest   : unavailable"
+require_contains "$OUTPUT" "selection  : disabled"
+require_contains "$OUTPUT" "restore    : unavailable"
+require_contains "$OUTPUT" "content    : empty_not_captured"
+require_contains "$OUTPUT" "privacy    : summary_only"
+PASS "chat session index section is present and conservative"
+
+HEAD "2: policy and controls stay local-render only"
+require_contains "$OUTPUT" "index-policy : not_configured localStoreConfigured=false manifestReadEnabled=false transcriptReadEnabled=false"
+require_contains "$OUTPUT" "empty      : placeholder itemCount=0 displayKind=no_sessions_available"
+require_contains "$OUTPUT" "controls   : open_session_index=available_as_data"
+require_contains "$OUTPUT" "refresh_session_index=blocked"
+require_contains "$OUTPUT" "select_session=disabled"
+require_contains "$OUTPUT" "restore_selected_session=unavailable"
+require_contains "$OUTPUT" "rename_session=disabled"
+require_contains "$OUTPUT" "delete_session=inactive"
+require_contains "$OUTPUT" "blocked    : session_store_not_configured=not_configured"
+require_contains "$OUTPUT" "session_manifest_boundary_absent=planned"
+require_contains "$OUTPUT" "session_titles_not_captured=empty_not_captured"
+require_contains "$OUTPUT" "artifact_read_boundary_absent=requires_evidence"
+PASS "session index metadata is summarized without store or transcript reads"
+
+HEAD "3: safety flags stay read-only and non-executing"
+require_contains "$OUTPUT" "readOnly=true"
+require_contains "$OUTPUT" "dataOnly=true"
+require_contains "$OUTPUT" "deterministic=true"
+require_contains "$OUTPUT" "sessionIndexDisplayOnly=true"
+require_contains "$OUTPUT" "writesArtifacts=false"
+require_contains "$OUTPUT" "readsArtifacts=false"
+require_contains "$OUTPUT" "readsSessionManifest=false"
+require_contains "$OUTPUT" "readsTranscript=false"
+require_contains "$OUTPUT" "sessionPersistence=false"
+require_contains "$OUTPUT" "transcriptPersistence=false"
+require_contains "$OUTPUT" "promptContentIncluded=false"
+require_contains "$OUTPUT" "responseContentIncluded=false"
+require_contains "$OUTPUT" "messageBodiesIncluded=false"
+require_contains "$OUTPUT" "summaryIncluded=false"
+require_contains "$OUTPUT" "sessionTitleIncluded=false"
+require_contains "$OUTPUT" "modelExecution=false"
+require_contains "$OUTPUT" "runtimeExecution=false"
+require_contains "$OUTPUT" "kv260Access=false"
+require_contains "$OUTPUT" "networkCalls=false"
+require_contains "$OUTPUT" "providerCalls=false"
+require_contains "$OUTPUT" "executesPccxLab=false"
+PASS "session-index execution, persistence, and content flags remain false"
+
+HEAD "4: output is deterministic"
+OUTPUT_AGAIN="$("$STUB" --include-chat-session-index)"
+if [ "$OUTPUT" != "$OUTPUT_AGAIN" ]; then
+    FAIL "status chat session index output changed between runs"
+    exit 1
+fi
+PASS "status chat session index output is deterministic"
+
+HEAD "5: session-index option does not combine with pccx-lab backend"
+if "$STUB" --include-chat-session-index --backend pccx-lab >/dev/null 2>&1; then
+    FAIL "expected combined session-index/backend mode to fail"
+    exit 1
+fi
+PASS "chat session index remains separate from backend execution"
+
+HEAD "6: output avoids known overclaims and chat content"
+FORBIDDEN_PREFIX="KV260 inference"
+FORBIDDEN_CLAIM="${FORBIDDEN_PREFIX} works"
+require_not_contains "$OUTPUT" "$FORBIDDEN_CLAIM"
+THROUGHPUT_PREFIX="20 tok/s"
+THROUGHPUT_CLAIM="${THROUGHPUT_PREFIX} achieved"
+require_not_contains "$OUTPUT" "$THROUGHPUT_CLAIM"
+require_not_contains "$OUTPUT" "hello"
+require_not_contains "$OUTPUT" "assistant response:"
+require_not_contains "$OUTPUT" "session title:"
+PASS "no session-index overclaim or chat content in status output"
+
+printf '\n[DONE]  all status-chat-session-index tests passed\n'


### PR DESCRIPTION
## Summary

- Add a checked `pccx.chatSessionIndex.v0` data-only fixture and stub for the planned standalone chat session list/sidebar.
- Add `--include-chat-session-index` status output plus README, standalone chat contract docs, tests, and CI coverage.
- Keep store refresh, manifest reads, selection, restore, rename, and delete unavailable, disabled, inactive, or blocked until separate reviewed boundaries exist.

## Boundaries

- No runtime, model, hardware, provider, pccx-lab, or IDE execution.
- No session store, manifest, transcript, prompt, response, session-title, summary, model-path, private-path, or raw-log reads.
- No artifact writes, deletes, refreshes, imports, exports, persistence, telemetry, upload, or write-back.

Refs pccxai/pccx-llm-launcher#9

## Validation

- `python3 -m py_compile contracts/*.py scripts/tests/*.py`
- `for test in scripts/tests/*_test.py; do python3 "$test"; done`
- `for test in scripts/tests/status-*.sh; do bash "$test" scripts/status-stub.sh; done`
- `bash -n scripts/*.sh scripts/tests/*.sh`
- `bash scripts/check.sh`
- `bash scripts/check-device-stub.sh`
- `bash scripts/install-stub.sh`
- `bash scripts/launch-stub.sh --dry-run`
- `bash scripts/chat-stub.sh --dry-run --prompt hello`
- local claim scan
- `git diff --check`
- `git diff --cached --check`