### PR TITLE
Add chat surface layout boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,7 @@ jobs:
                    scripts/chat-model-status-stub.sh \
                    scripts/chat-session-stub.sh \
                    scripts/chat-session-lifecycle-stub.sh \
+                   scripts/chat-surface-layout-stub.sh \
                    scripts/chat-session-index-stub.sh \
                    scripts/chat-readiness-stub.sh \
                    scripts/chat-composer-stub.sh \
@@ -169,6 +170,10 @@ jobs:
         run: ./scripts/chat-session-stub.sh --model gemma3n-e4b --target kv260
       - name: run scripts/chat-session-lifecycle-stub.sh
         run: ./scripts/chat-session-lifecycle-stub.sh --model gemma3n-e4b --target kv260
+      - name: run scripts/status-stub.sh with chat surface layout
+        run: ./scripts/status-stub.sh --include-chat-surface-layout
+      - name: run scripts/chat-surface-layout-stub.sh
+        run: ./scripts/chat-surface-layout-stub.sh --model gemma3n-e4b --target kv260
       - name: run scripts/status-stub.sh with chat session index
         run: ./scripts/status-stub.sh --include-chat-session-index
       - name: run scripts/chat-session-index-stub.sh
@@ -221,6 +226,8 @@ jobs:
         run: python3 scripts/tests/chat_model_status_contract_test.py
       - name: run chat/session lifecycle contract tests
         run: python3 scripts/tests/chat_session_lifecycle_contract_test.py
+      - name: run chat surface-layout contract tests
+        run: python3 scripts/tests/chat_surface_layout_contract_test.py
       - name: run chat session-index contract tests
         run: python3 scripts/tests/chat_session_index_contract_test.py
       - name: run chat readiness contract tests
@@ -248,6 +255,7 @@ jobs:
           chmod +x scripts/chat-model-status-stub.sh
           chmod +x scripts/chat-session-stub.sh
           chmod +x scripts/chat-session-lifecycle-stub.sh
+          chmod +x scripts/chat-surface-layout-stub.sh
           chmod +x scripts/chat-session-index-stub.sh
           chmod +x scripts/chat-readiness-stub.sh
           chmod +x scripts/chat-composer-stub.sh
@@ -260,6 +268,7 @@ jobs:
           chmod +x scripts/tests/status-readiness.sh
           chmod +x scripts/tests/status-chat-model-status.sh
           chmod +x scripts/tests/status-chat-session.sh
+          chmod +x scripts/tests/status-chat-surface-layout.sh
           chmod +x scripts/tests/status-chat-session-index.sh
           chmod +x scripts/tests/status-chat-readiness.sh
           chmod +x scripts/tests/status-chat-composer.sh
@@ -275,6 +284,7 @@ jobs:
           shellcheck scripts/tests/status-readiness.sh
           shellcheck scripts/tests/status-chat-model-status.sh
           shellcheck scripts/tests/status-chat-session.sh
+          shellcheck scripts/tests/status-chat-surface-layout.sh
           shellcheck scripts/tests/status-chat-session-index.sh
           shellcheck scripts/tests/status-chat-readiness.sh
           shellcheck scripts/tests/status-chat-composer.sh
@@ -291,6 +301,8 @@ jobs:
         run: bash scripts/tests/status-chat-model-status.sh scripts/status-stub.sh
       - name: run status-chat-session tests
         run: bash scripts/tests/status-chat-session.sh scripts/status-stub.sh
+      - name: run status-chat-surface-layout tests
+        run: bash scripts/tests/status-chat-surface-layout.sh scripts/status-stub.sh
       - name: run status-chat-session-index tests
         run: bash scripts/tests/status-chat-session-index.sh scripts/status-stub.sh
       - name: run status-chat-readiness tests

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ publishes a verified end-to-end path.
 - Owns or uses a supported edge device such as Xilinx Kria KV260.
 - Wants a guided launcher workflow rather than a hand-built kernel stack.
 - Does not want to work directly on kernel / RTL internals.
-- Wants a path toward local model execution and, later, coding-assistant
+- Wants a path toward local model execution and, later, local assistant
   workflows.
 
 ## v002 target
@@ -51,7 +51,7 @@ publishes a verified end-to-end path.
 
 ## Roadmap
 
-- Coding-assistant mode (AI-assisted local workflow with a controlled
+- Local assistant mode (controlled local workflow with a reviewed
   tool boundary). The later-track plan is tracked in
   [docs/LOCAL_CODING_ASSISTANT_MODE_PLAN.md](./docs/LOCAL_CODING_ASSISTANT_MODE_PLAN.md).
 - VS Code and other editor bridge planning for guided launches and log
@@ -87,11 +87,12 @@ and verify host-side prerequisites before the real engine lands.
 | [`scripts/check.sh`](./scripts/check.sh) | Probe host info, tooling availability, edge-device hints. Always exits 0. |
 | [`scripts/check-device-stub.sh`](./scripts/check-device-stub.sh) | Narrowly scoped device-tree / FPGA-node probe (KV260 / Kria detection only). Always exits 0. |
 | [`scripts/install-stub.sh`](./scripts/install-stub.sh) | Preview of the planned install flow; reports which host runtime pieces are present, lists device-side pieces as future deliverables. Always exits 0. |
-| [`scripts/status-stub.sh`](./scripts/status-stub.sh) | Launcher state summary. Default mode: local scaffold output, always exits 0. With `--include-chat-audit-event`, adds read-only blocked chat audit-event metadata. With `--include-chat-session-index`, adds read-only empty chat session index data. With `--include-chat-transcript-policy`, adds read-only chat transcript retention/export policy data. With `--include-chat-send-result`, adds read-only blocked chat send-result data. With `--include-chat-composer`, adds read-only chat composer/input-control data. With `--include-chat-model-status`, adds read-only blocked chat model-status display data. With `--include-chat-session`, adds read-only blocked chat/session and lifecycle summaries. With `--include-chat-readiness`, adds read-only chat readiness checks and recovery actions. With `--include-device-session`, adds a read-only device/session status panel. With `--include-runtime-readiness`, adds a read-only runtime readiness summary. With `--backend pccx-lab`, calls `pccx-lab status --format json` and forwards the run-status envelope (exits non-zero if binary is missing or output is invalid). |
+| [`scripts/status-stub.sh`](./scripts/status-stub.sh) | Launcher state summary. Default mode: local scaffold output, always exits 0. With `--include-chat-audit-event`, adds read-only blocked chat audit-event metadata. With `--include-chat-surface-layout`, adds read-only chat surface layout data. With `--include-chat-session-index`, adds read-only empty chat session index data. With `--include-chat-transcript-policy`, adds read-only chat transcript retention/export policy data. With `--include-chat-send-result`, adds read-only blocked chat send-result data. With `--include-chat-composer`, adds read-only chat composer/input-control data. With `--include-chat-model-status`, adds read-only blocked chat model-status display data. With `--include-chat-session`, adds read-only blocked chat/session and lifecycle summaries. With `--include-chat-readiness`, adds read-only chat readiness checks and recovery actions. With `--include-device-session`, adds a read-only device/session status panel. With `--include-runtime-readiness`, adds a read-only runtime readiness summary. With `--backend pccx-lab`, calls `pccx-lab status --format json` and forwards the run-status envelope (exits non-zero if binary is missing or output is invalid). |
 | [`scripts/device-session-status-stub.sh`](./scripts/device-session-status-stub.sh) | Data-only device/session status JSON for the Gemma 3N E4B + KV260 target. Reports connection, model load, session, diagnostics, readiness, discovery paths, flow steps, and error taxonomy as placeholder / blocked. |
 | [`scripts/runtime-readiness-stub.sh`](./scripts/runtime-readiness-stub.sh) | Data-only runtime readiness JSON for the Gemma 3N E4B + KV260 target. Reports blocked / not yet evidence-backed. |
 | [`scripts/chat-session-stub.sh`](./scripts/chat-session-stub.sh) | Data-only standalone chat/session JSON for the Gemma 3N E4B + KV260 target. Reports disabled send controls, inactive session state, no prompt/response persistence, and readiness handoff references. |
 | [`scripts/chat-session-lifecycle-stub.sh`](./scripts/chat-session-lifecycle-stub.sh) | Data-only chat session lifecycle JSON for the Gemma 3N E4B + KV260 target. Reports create, restore, clear, close, and export-summary operations as disabled, blocked, inactive, or unavailable. |
+| [`scripts/chat-surface-layout-stub.sh`](./scripts/chat-surface-layout-stub.sh) | Data-only chat surface layout JSON for the Gemma 3N E4B + KV260 target. Reports planned shell regions and navigation items as local metadata without prompt/response/transcript/session-store reads or runtime actions. |
 | [`scripts/chat-session-index-stub.sh`](./scripts/chat-session-index-stub.sh) | Data-only chat session index JSON for the Gemma 3N E4B + KV260 target. Reports an empty, not-configured session list/sidebar boundary without reading a store, session titles, prompts, responses, transcripts, or summaries. |
 | [`scripts/chat-model-status-stub.sh`](./scripts/chat-model-status-stub.sh) | Data-only chat model-status JSON for the Gemma 3N E4B + KV260 target. Reports descriptor, asset, load, runtime, context, and response display rows as blocked, disabled, or unavailable. |
 | [`scripts/chat-readiness-stub.sh`](./scripts/chat-readiness-stub.sh) | Data-only chat readiness JSON for the Gemma 3N E4B + KV260 target. Reports readiness checks, error categories, and recovery actions as blocked, disabled, or local data only. |
@@ -110,6 +111,7 @@ bash scripts/install-stub.sh
 bash scripts/status-stub.sh
 bash scripts/status-stub.sh --include-chat-model-status
 bash scripts/status-stub.sh --include-chat-session
+bash scripts/status-stub.sh --include-chat-surface-layout
 bash scripts/status-stub.sh --include-chat-session-index
 bash scripts/status-stub.sh --include-chat-readiness
 bash scripts/status-stub.sh --include-chat-composer
@@ -123,6 +125,7 @@ bash scripts/runtime-readiness-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-model-status-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-session-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-session-lifecycle-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/chat-surface-layout-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-session-index-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-readiness-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-composer-stub.sh --model gemma3n-e4b --target kv260
@@ -187,7 +190,7 @@ promise. See
 [docs/LAUNCHER_IDE_BRIDGE_CONTRACT.md](./docs/LAUNCHER_IDE_BRIDGE_CONTRACT.md).
 The later-track JetBrains and generic editor direction is tracked in
 [docs/OTHER_EDITOR_BRIDGE_PLAN.md](./docs/OTHER_EDITOR_BRIDGE_PLAN.md).
-The later-track local coding-assistant mode direction is tracked in
+The later-track local assistant mode direction is tracked in
 [docs/LOCAL_CODING_ASSISTANT_MODE_PLAN.md](./docs/LOCAL_CODING_ASSISTANT_MODE_PLAN.md).
 
 ### Model / runtime descriptor boundary (planned)

--- a/contracts/chat_surface_layout_contract.py
+++ b/contracts/chat_surface_layout_contract.py
@@ -1,0 +1,485 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Data-only chat surface layout contract for the planned launcher UI.
+
+The contract describes the future standalone chat shell regions and navigation
+items while keeping every runtime, model, store, and content path disabled or
+blocked. It does not read prompts, responses, transcripts, session stores,
+session titles, model assets, private paths, or logs; it does not write
+artifacts, load models, touch KV260 hardware, call providers, invoke pccx-lab,
+or start runtime code.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import sys
+
+
+SCHEMA_VERSION = "pccx.chatSurfaceLayout.v0"
+
+CHAT_SURFACE_LAYOUT_FIELDS = (
+    "schemaVersion",
+    "layoutId",
+    "fixtureVersion",
+    "lastUpdatedSource",
+    "targetDevice",
+    "targetBoard",
+    "targetModel",
+    "layoutState",
+    "shellState",
+    "navigationState",
+    "primaryRegionState",
+    "sideRegionState",
+    "footerState",
+    "contentState",
+    "privacyState",
+    "chatSessionRef",
+    "chatSessionIndexRef",
+    "chatModelStatusRef",
+    "chatReadinessRef",
+    "chatComposerRef",
+    "chatSendResultRef",
+    "chatTranscriptPolicyRef",
+    "chatAuditEventRef",
+    "layoutPolicy",
+    "surfaceRegions",
+    "navigationItems",
+    "blockedReasons",
+    "handoffRefs",
+    "safetyFlags",
+    "limitations",
+    "issueRefs",
+)
+
+LAYOUT_POLICY_FIELDS = (
+    "state",
+    "renderMode",
+    "shellPolicy",
+    "contentPolicy",
+    "interactionPolicy",
+    "sideEffectPolicy",
+    "externalDependencyPolicy",
+)
+
+SURFACE_REGION_FIELDS = (
+    "regionId",
+    "label",
+    "state",
+    "visible",
+    "enabled",
+    "sourceRef",
+    "layoutRole",
+    "sideEffectPolicy",
+    "contentPolicy",
+)
+
+NAVIGATION_ITEM_FIELDS = (
+    "navId",
+    "label",
+    "state",
+    "enabled",
+    "targetRegion",
+    "userAction",
+    "launcherAction",
+    "sideEffectPolicy",
+    "contentPolicy",
+)
+
+BLOCKED_REASON_FIELDS = (
+    "reasonId",
+    "state",
+    "summary",
+    "requiredBefore",
+)
+
+HANDOFF_REF_FIELDS = (
+    "refId",
+    "schemaVersion",
+    "fixturePath",
+    "state",
+    "summary",
+)
+
+CHAT_SURFACE_LAYOUT_STATE_VALUES = (
+    "available_as_data",
+    "blocked",
+    "disabled",
+    "empty_not_captured",
+    "inactive",
+    "not_configured",
+    "not_loaded",
+    "not_started",
+    "placeholder",
+    "planned",
+    "summary_only",
+    "target_selected",
+    "unavailable",
+)
+
+_CHAT_SURFACE_LAYOUT = {
+    "schemaVersion": SCHEMA_VERSION,
+    "layoutId": "chat_surface_layout_gemma3n_e4b_kv260_placeholder",
+    "fixtureVersion": "chat-surface-layout.gemma3n-e4b-kv260.2026-05-04",
+    "lastUpdatedSource": "pccx_launcher_issue_9_chat_surface_layout_boundary_2026-05-04",
+    "targetDevice": "kv260",
+    "targetBoard": "xilinx_kria_kv260",
+    "targetModel": "gemma3n-e4b",
+    "layoutState": "blocked",
+    "shellState": "placeholder",
+    "navigationState": "available_as_data",
+    "primaryRegionState": "empty_not_captured",
+    "sideRegionState": "placeholder",
+    "footerState": "available_as_data",
+    "contentState": "empty_not_captured",
+    "privacyState": "summary_only",
+    "chatSessionRef": "chat_session_gemma3n_e4b_kv260_placeholder",
+    "chatSessionIndexRef": "chat_session_index_gemma3n_e4b_kv260_placeholder",
+    "chatModelStatusRef": "chat_model_status_gemma3n_e4b_kv260_placeholder",
+    "chatReadinessRef": "chat_readiness_gemma3n_e4b_kv260_placeholder",
+    "chatComposerRef": "chat_composer_gemma3n_e4b_kv260_placeholder",
+    "chatSendResultRef": "chat_send_result_gemma3n_e4b_kv260_placeholder",
+    "chatTranscriptPolicyRef": "chat_transcript_policy_gemma3n_e4b_kv260_placeholder",
+    "chatAuditEventRef": "chat_audit_event_gemma3n_e4b_kv260_placeholder",
+    "layoutPolicy": {
+        "state": "placeholder",
+        "renderMode": "future_local_shell_layout",
+        "shellPolicy": "deterministic layout metadata only; no app shell implementation is started",
+        "contentPolicy": "no_prompt_response_transcript_summary_session_title_or_model_path_content",
+        "interactionPolicy": "navigation metadata may be rendered while runtime and content actions remain disabled",
+        "sideEffectPolicy": "local_render_only",
+        "externalDependencyPolicy": "no provider, network, hardware, pccx-lab, or IDE dependency is used",
+    },
+    "surfaceRegions": [
+        {
+            "regionId": "session_index_sidebar",
+            "label": "session index sidebar",
+            "state": "placeholder",
+            "visible": True,
+            "enabled": True,
+            "sourceRef": "chat_session_index",
+            "layoutRole": "side_navigation",
+            "sideEffectPolicy": "local_render_only",
+            "contentPolicy": "no_session_titles_summaries_prompts_responses_or_transcripts",
+        },
+        {
+            "regionId": "model_status_header",
+            "label": "model status header",
+            "state": "blocked",
+            "visible": True,
+            "enabled": False,
+            "sourceRef": "chat_model_status",
+            "layoutRole": "status",
+            "sideEffectPolicy": "local_render_only",
+            "contentPolicy": "descriptor_metadata_only_no_model_paths",
+        },
+        {
+            "regionId": "readiness_banner",
+            "label": "readiness banner",
+            "state": "blocked",
+            "visible": True,
+            "enabled": False,
+            "sourceRef": "chat_readiness",
+            "layoutRole": "readiness",
+            "sideEffectPolicy": "local_render_only",
+            "contentPolicy": "readiness_metadata_only",
+        },
+        {
+            "regionId": "transcript_region",
+            "label": "transcript region",
+            "state": "empty_not_captured",
+            "visible": True,
+            "enabled": False,
+            "sourceRef": "chat_transcript_policy",
+            "layoutRole": "primary",
+            "sideEffectPolicy": "local_render_only",
+            "contentPolicy": "no_message_transcript_or_summary_content",
+        },
+        {
+            "regionId": "composer_bar",
+            "label": "composer bar",
+            "state": "disabled",
+            "visible": True,
+            "enabled": False,
+            "sourceRef": "chat_composer",
+            "layoutRole": "input",
+            "sideEffectPolicy": "local_render_only",
+            "contentPolicy": "no_prompt_capture_echo_or_persistence",
+        },
+        {
+            "regionId": "send_result_region",
+            "label": "send result region",
+            "state": "blocked",
+            "visible": False,
+            "enabled": False,
+            "sourceRef": "chat_send_result",
+            "layoutRole": "feedback",
+            "sideEffectPolicy": "local_render_only",
+            "contentPolicy": "no_prompt_or_response_content",
+        },
+        {
+            "regionId": "audit_footer",
+            "label": "audit footer",
+            "state": "summary_only",
+            "visible": True,
+            "enabled": False,
+            "sourceRef": "chat_audit_event",
+            "layoutRole": "footer",
+            "sideEffectPolicy": "local_render_only",
+            "contentPolicy": "summary_metadata_only_no_actor_identifier",
+        },
+    ],
+    "navigationItems": [
+        {
+            "navId": "open_chat_surface",
+            "label": "open chat surface",
+            "state": "available_as_data",
+            "enabled": True,
+            "targetRegion": "transcript_region",
+            "userAction": "Open the planned standalone chat surface.",
+            "launcherAction": "Render blocked local layout metadata only.",
+            "sideEffectPolicy": "local_render_only",
+            "contentPolicy": "no_prompt_response_or_transcript_content",
+        },
+        {
+            "navId": "open_session_index",
+            "label": "open session index",
+            "state": "available_as_data",
+            "enabled": True,
+            "targetRegion": "session_index_sidebar",
+            "userAction": "Open the empty local session index surface.",
+            "launcherAction": "Render the checked session-index fixture reference.",
+            "sideEffectPolicy": "local_render_only",
+            "contentPolicy": "no_session_store_read",
+        },
+        {
+            "navId": "open_model_status",
+            "label": "open model status",
+            "state": "blocked",
+            "enabled": False,
+            "targetRegion": "model_status_header",
+            "userAction": "Review model status after a separate readiness boundary changes.",
+            "launcherAction": "Keep the model-status region as blocked metadata.",
+            "sideEffectPolicy": "local_render_only",
+            "contentPolicy": "no_model_path_or_weight_content",
+        },
+        {
+            "navId": "open_readiness",
+            "label": "open readiness",
+            "state": "blocked",
+            "enabled": False,
+            "targetRegion": "readiness_banner",
+            "userAction": "Review readiness metadata without starting runtime code.",
+            "launcherAction": "Show blocked readiness state only.",
+            "sideEffectPolicy": "local_render_only",
+            "contentPolicy": "readiness_metadata_only",
+        },
+        {
+            "navId": "focus_composer",
+            "label": "focus composer",
+            "state": "disabled",
+            "enabled": False,
+            "targetRegion": "composer_bar",
+            "userAction": "Focus input only after prompt-capture boundaries are reviewed.",
+            "launcherAction": "Keep composer focus disabled.",
+            "sideEffectPolicy": "local_render_only",
+            "contentPolicy": "no_prompt_capture",
+        },
+    ],
+    "blockedReasons": [
+        {
+            "reasonId": "runtime_readiness_blocked",
+            "state": "blocked",
+            "summary": "Runtime readiness remains blocked for the Gemma 3N E4B plus KV260 target.",
+            "requiredBefore": "chat_surface_enabled",
+        },
+        {
+            "reasonId": "chat_runtime_not_started",
+            "state": "not_started",
+            "summary": "No local chat runtime has started.",
+            "requiredBefore": "transcript_region_active",
+        },
+        {
+            "reasonId": "composer_send_disabled",
+            "state": "disabled",
+            "summary": "Composer and send controls remain disabled.",
+            "requiredBefore": "composer_focus_or_send_enabled",
+        },
+        {
+            "reasonId": "transcript_content_absent",
+            "state": "empty_not_captured",
+            "summary": "No prompt, response, transcript, or summary content exists in checked data.",
+            "requiredBefore": "message_region_contains_content",
+        },
+        {
+            "reasonId": "session_store_not_configured",
+            "state": "not_configured",
+            "summary": "No local session store or session title source exists.",
+            "requiredBefore": "session_navigation_restores_content",
+        },
+    ],
+    "handoffRefs": [
+        {
+            "refId": "chat_session",
+            "schemaVersion": "pccx.chatSession.v0",
+            "fixturePath": "contracts/fixtures/chat-session.gemma3n-e4b-kv260-placeholder.json",
+            "state": "blocked",
+            "summary": "Base chat/session state is referenced for blocked surface state.",
+        },
+        {
+            "refId": "chat_session_index",
+            "schemaVersion": "pccx.chatSessionIndex.v0",
+            "fixturePath": "contracts/fixtures/chat-session-index.gemma3n-e4b-kv260-placeholder.json",
+            "state": "placeholder",
+            "summary": "Empty session index data can be rendered without store reads.",
+        },
+        {
+            "refId": "chat_model_status",
+            "schemaVersion": "pccx.chatModelStatus.v0",
+            "fixturePath": "contracts/fixtures/chat-model-status.gemma3n-e4b-kv260-placeholder.json",
+            "state": "blocked",
+            "summary": "Model status remains display-only and blocked.",
+        },
+        {
+            "refId": "chat_readiness",
+            "schemaVersion": "pccx.chatReadiness.v0",
+            "fixturePath": "contracts/fixtures/chat-readiness.gemma3n-e4b-kv260-placeholder.json",
+            "state": "blocked",
+            "summary": "Readiness gates stay separate from layout rendering.",
+        },
+        {
+            "refId": "chat_composer",
+            "schemaVersion": "pccx.chatComposer.v0",
+            "fixturePath": "contracts/fixtures/chat-composer.gemma3n-e4b-kv260-placeholder.json",
+            "state": "disabled",
+            "summary": "Composer input remains disabled with no prompt capture.",
+        },
+        {
+            "refId": "chat_transcript_policy",
+            "schemaVersion": "pccx.chatTranscriptPolicy.v0",
+            "fixturePath": "contracts/fixtures/chat-transcript-policy.gemma3n-e4b-kv260-placeholder.json",
+            "state": "disabled",
+            "summary": "Transcript persistence and export remain disabled.",
+        },
+    ],
+    "safetyFlags": {
+        "dataOnly": True,
+        "readOnly": True,
+        "deterministic": True,
+        "surfaceLayoutDisplayOnly": True,
+        "writesArtifacts": False,
+        "readsArtifacts": False,
+        "sessionStoreRead": False,
+        "readsSessionManifest": False,
+        "readsTranscript": False,
+        "sessionPersistence": False,
+        "transcriptPersistence": False,
+        "transcriptExport": False,
+        "sessionTitleIncluded": False,
+        "sessionTitleGenerated": False,
+        "messageBodiesIncluded": False,
+        "summaryIncluded": False,
+        "summaryGenerated": False,
+        "promptCapture": False,
+        "promptContentIncluded": False,
+        "promptEchoed": False,
+        "promptPersistence": False,
+        "inputAccepted": False,
+        "sendAttempted": False,
+        "responseContentIncluded": False,
+        "responseGenerated": False,
+        "transcriptContentIncluded": False,
+        "auditEventPersisted": False,
+        "localStoreConfigured": False,
+        "attachmentReads": False,
+        "fileUpload": False,
+        "clipboardRead": False,
+        "clipboardWrite": False,
+        "modelAssetPathsIncluded": False,
+        "modelWeightPathsIncluded": False,
+        "modelLoadAttempted": False,
+        "modelLoaded": False,
+        "modelExecution": False,
+        "runtimeExecution": False,
+        "touchesHardware": False,
+        "kv260Access": False,
+        "opensSerialPort": False,
+        "networkCalls": False,
+        "networkScan": False,
+        "sshExecution": False,
+        "providerCalls": False,
+        "cloudCalls": False,
+        "privatePathsIncluded": False,
+        "secretsIncluded": False,
+        "tokensIncluded": False,
+        "generatedBlobsIncluded": False,
+        "hardwareDumpsIncluded": False,
+        "telemetry": False,
+        "automaticUpload": False,
+        "writeBack": False,
+        "executesPccxLab": False,
+        "executesSystemverilogIde": False,
+        "mcpServerImplemented": False,
+        "lspImplemented": False,
+        "stableApiAbiClaim": False,
+    },
+    "limitations": [
+        "Data-only chat surface layout fixture; no app shell implementation is started.",
+        "No prompts, responses, transcripts, session titles, summaries, manifests, model paths, generated artifacts, private paths, secrets, or tokens are stored.",
+        "No artifacts are read, written, deleted, refreshed, imported, exported, or persisted.",
+        "No KV260 hardware access, serial access, network call, provider call, telemetry, upload, or write-back is performed.",
+        "Navigation and surface regions remain local metadata until explicit runtime, model-load, prompt-capture, session-store, and transcript boundaries exist.",
+        "This is not a release, tag, versioned compatibility commitment, MCP, LSP, IDE, marketplace, telemetry, or app-shell implementation.",
+    ],
+    "issueRefs": [
+        "pccxai/pccx-llm-launcher#9",
+    ],
+}
+
+
+def create_gemma3n_e4b_kv260_chat_surface_layout() -> dict:
+    """Return the checked Gemma 3N E4B plus KV260 surface-layout fixture."""
+    return copy.deepcopy(_CHAT_SURFACE_LAYOUT)
+
+
+def chat_surface_layout_json(status: dict | None = None) -> str:
+    """Render a deterministic JSON representation."""
+    return json.dumps(
+        status
+        if status is not None
+        else create_gemma3n_e4b_kv260_chat_surface_layout(),
+        indent=2,
+        sort_keys=True,
+    ) + "\n"
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Print data-only chat surface layout JSON.",
+    )
+    parser.add_argument(
+        "--model",
+        default="gemma3n-e4b",
+        choices=("gemma3n-e4b",),
+        help="model descriptor target",
+    )
+    parser.add_argument(
+        "--target",
+        default="kv260",
+        choices=("kv260",),
+        help="target board/device",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parse_args(sys.argv[1:] if argv is None else argv)
+    sys.stdout.write(chat_surface_layout_json())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contracts/fixtures/chat-surface-layout.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-surface-layout.gemma3n-e4b-kv260-placeholder.json
@@ -1,0 +1,318 @@
+{
+  "schemaVersion": "pccx.chatSurfaceLayout.v0",
+  "layoutId": "chat_surface_layout_gemma3n_e4b_kv260_placeholder",
+  "fixtureVersion": "chat-surface-layout.gemma3n-e4b-kv260.2026-05-04",
+  "lastUpdatedSource": "pccx_launcher_issue_9_chat_surface_layout_boundary_2026-05-04",
+  "targetDevice": "kv260",
+  "targetBoard": "xilinx_kria_kv260",
+  "targetModel": "gemma3n-e4b",
+  "layoutState": "blocked",
+  "shellState": "placeholder",
+  "navigationState": "available_as_data",
+  "primaryRegionState": "empty_not_captured",
+  "sideRegionState": "placeholder",
+  "footerState": "available_as_data",
+  "contentState": "empty_not_captured",
+  "privacyState": "summary_only",
+  "chatSessionRef": "chat_session_gemma3n_e4b_kv260_placeholder",
+  "chatSessionIndexRef": "chat_session_index_gemma3n_e4b_kv260_placeholder",
+  "chatModelStatusRef": "chat_model_status_gemma3n_e4b_kv260_placeholder",
+  "chatReadinessRef": "chat_readiness_gemma3n_e4b_kv260_placeholder",
+  "chatComposerRef": "chat_composer_gemma3n_e4b_kv260_placeholder",
+  "chatSendResultRef": "chat_send_result_gemma3n_e4b_kv260_placeholder",
+  "chatTranscriptPolicyRef": "chat_transcript_policy_gemma3n_e4b_kv260_placeholder",
+  "chatAuditEventRef": "chat_audit_event_gemma3n_e4b_kv260_placeholder",
+  "layoutPolicy": {
+    "state": "placeholder",
+    "renderMode": "future_local_shell_layout",
+    "shellPolicy": "deterministic layout metadata only; no app shell implementation is started",
+    "contentPolicy": "no_prompt_response_transcript_summary_session_title_or_model_path_content",
+    "interactionPolicy": "navigation metadata may be rendered while runtime and content actions remain disabled",
+    "sideEffectPolicy": "local_render_only",
+    "externalDependencyPolicy": "no provider, network, hardware, pccx-lab, or IDE dependency is used"
+  },
+  "surfaceRegions": [
+    {
+      "regionId": "session_index_sidebar",
+      "label": "session index sidebar",
+      "state": "placeholder",
+      "visible": true,
+      "enabled": true,
+      "sourceRef": "chat_session_index",
+      "layoutRole": "side_navigation",
+      "sideEffectPolicy": "local_render_only",
+      "contentPolicy": "no_session_titles_summaries_prompts_responses_or_transcripts"
+    },
+    {
+      "regionId": "model_status_header",
+      "label": "model status header",
+      "state": "blocked",
+      "visible": true,
+      "enabled": false,
+      "sourceRef": "chat_model_status",
+      "layoutRole": "status",
+      "sideEffectPolicy": "local_render_only",
+      "contentPolicy": "descriptor_metadata_only_no_model_paths"
+    },
+    {
+      "regionId": "readiness_banner",
+      "label": "readiness banner",
+      "state": "blocked",
+      "visible": true,
+      "enabled": false,
+      "sourceRef": "chat_readiness",
+      "layoutRole": "readiness",
+      "sideEffectPolicy": "local_render_only",
+      "contentPolicy": "readiness_metadata_only"
+    },
+    {
+      "regionId": "transcript_region",
+      "label": "transcript region",
+      "state": "empty_not_captured",
+      "visible": true,
+      "enabled": false,
+      "sourceRef": "chat_transcript_policy",
+      "layoutRole": "primary",
+      "sideEffectPolicy": "local_render_only",
+      "contentPolicy": "no_message_transcript_or_summary_content"
+    },
+    {
+      "regionId": "composer_bar",
+      "label": "composer bar",
+      "state": "disabled",
+      "visible": true,
+      "enabled": false,
+      "sourceRef": "chat_composer",
+      "layoutRole": "input",
+      "sideEffectPolicy": "local_render_only",
+      "contentPolicy": "no_prompt_capture_echo_or_persistence"
+    },
+    {
+      "regionId": "send_result_region",
+      "label": "send result region",
+      "state": "blocked",
+      "visible": false,
+      "enabled": false,
+      "sourceRef": "chat_send_result",
+      "layoutRole": "feedback",
+      "sideEffectPolicy": "local_render_only",
+      "contentPolicy": "no_prompt_or_response_content"
+    },
+    {
+      "regionId": "audit_footer",
+      "label": "audit footer",
+      "state": "summary_only",
+      "visible": true,
+      "enabled": false,
+      "sourceRef": "chat_audit_event",
+      "layoutRole": "footer",
+      "sideEffectPolicy": "local_render_only",
+      "contentPolicy": "summary_metadata_only_no_actor_identifier"
+    }
+  ],
+  "navigationItems": [
+    {
+      "navId": "open_chat_surface",
+      "label": "open chat surface",
+      "state": "available_as_data",
+      "enabled": true,
+      "targetRegion": "transcript_region",
+      "userAction": "Open the planned standalone chat surface.",
+      "launcherAction": "Render blocked local layout metadata only.",
+      "sideEffectPolicy": "local_render_only",
+      "contentPolicy": "no_prompt_response_or_transcript_content"
+    },
+    {
+      "navId": "open_session_index",
+      "label": "open session index",
+      "state": "available_as_data",
+      "enabled": true,
+      "targetRegion": "session_index_sidebar",
+      "userAction": "Open the empty local session index surface.",
+      "launcherAction": "Render the checked session-index fixture reference.",
+      "sideEffectPolicy": "local_render_only",
+      "contentPolicy": "no_session_store_read"
+    },
+    {
+      "navId": "open_model_status",
+      "label": "open model status",
+      "state": "blocked",
+      "enabled": false,
+      "targetRegion": "model_status_header",
+      "userAction": "Review model status after a separate readiness boundary changes.",
+      "launcherAction": "Keep the model-status region as blocked metadata.",
+      "sideEffectPolicy": "local_render_only",
+      "contentPolicy": "no_model_path_or_weight_content"
+    },
+    {
+      "navId": "open_readiness",
+      "label": "open readiness",
+      "state": "blocked",
+      "enabled": false,
+      "targetRegion": "readiness_banner",
+      "userAction": "Review readiness metadata without starting runtime code.",
+      "launcherAction": "Show blocked readiness state only.",
+      "sideEffectPolicy": "local_render_only",
+      "contentPolicy": "readiness_metadata_only"
+    },
+    {
+      "navId": "focus_composer",
+      "label": "focus composer",
+      "state": "disabled",
+      "enabled": false,
+      "targetRegion": "composer_bar",
+      "userAction": "Focus input only after prompt-capture boundaries are reviewed.",
+      "launcherAction": "Keep composer focus disabled.",
+      "sideEffectPolicy": "local_render_only",
+      "contentPolicy": "no_prompt_capture"
+    }
+  ],
+  "blockedReasons": [
+    {
+      "reasonId": "runtime_readiness_blocked",
+      "state": "blocked",
+      "summary": "Runtime readiness remains blocked for the Gemma 3N E4B plus KV260 target.",
+      "requiredBefore": "chat_surface_enabled"
+    },
+    {
+      "reasonId": "chat_runtime_not_started",
+      "state": "not_started",
+      "summary": "No local chat runtime has started.",
+      "requiredBefore": "transcript_region_active"
+    },
+    {
+      "reasonId": "composer_send_disabled",
+      "state": "disabled",
+      "summary": "Composer and send controls remain disabled.",
+      "requiredBefore": "composer_focus_or_send_enabled"
+    },
+    {
+      "reasonId": "transcript_content_absent",
+      "state": "empty_not_captured",
+      "summary": "No prompt, response, transcript, or summary content exists in checked data.",
+      "requiredBefore": "message_region_contains_content"
+    },
+    {
+      "reasonId": "session_store_not_configured",
+      "state": "not_configured",
+      "summary": "No local session store or session title source exists.",
+      "requiredBefore": "session_navigation_restores_content"
+    }
+  ],
+  "handoffRefs": [
+    {
+      "refId": "chat_session",
+      "schemaVersion": "pccx.chatSession.v0",
+      "fixturePath": "contracts/fixtures/chat-session.gemma3n-e4b-kv260-placeholder.json",
+      "state": "blocked",
+      "summary": "Base chat/session state is referenced for blocked surface state."
+    },
+    {
+      "refId": "chat_session_index",
+      "schemaVersion": "pccx.chatSessionIndex.v0",
+      "fixturePath": "contracts/fixtures/chat-session-index.gemma3n-e4b-kv260-placeholder.json",
+      "state": "placeholder",
+      "summary": "Empty session index data can be rendered without store reads."
+    },
+    {
+      "refId": "chat_model_status",
+      "schemaVersion": "pccx.chatModelStatus.v0",
+      "fixturePath": "contracts/fixtures/chat-model-status.gemma3n-e4b-kv260-placeholder.json",
+      "state": "blocked",
+      "summary": "Model status remains display-only and blocked."
+    },
+    {
+      "refId": "chat_readiness",
+      "schemaVersion": "pccx.chatReadiness.v0",
+      "fixturePath": "contracts/fixtures/chat-readiness.gemma3n-e4b-kv260-placeholder.json",
+      "state": "blocked",
+      "summary": "Readiness gates stay separate from layout rendering."
+    },
+    {
+      "refId": "chat_composer",
+      "schemaVersion": "pccx.chatComposer.v0",
+      "fixturePath": "contracts/fixtures/chat-composer.gemma3n-e4b-kv260-placeholder.json",
+      "state": "disabled",
+      "summary": "Composer input remains disabled with no prompt capture."
+    },
+    {
+      "refId": "chat_transcript_policy",
+      "schemaVersion": "pccx.chatTranscriptPolicy.v0",
+      "fixturePath": "contracts/fixtures/chat-transcript-policy.gemma3n-e4b-kv260-placeholder.json",
+      "state": "disabled",
+      "summary": "Transcript persistence and export remain disabled."
+    }
+  ],
+  "safetyFlags": {
+    "dataOnly": true,
+    "readOnly": true,
+    "deterministic": true,
+    "surfaceLayoutDisplayOnly": true,
+    "writesArtifacts": false,
+    "readsArtifacts": false,
+    "sessionStoreRead": false,
+    "readsSessionManifest": false,
+    "readsTranscript": false,
+    "sessionPersistence": false,
+    "transcriptPersistence": false,
+    "transcriptExport": false,
+    "sessionTitleIncluded": false,
+    "sessionTitleGenerated": false,
+    "messageBodiesIncluded": false,
+    "summaryIncluded": false,
+    "summaryGenerated": false,
+    "promptCapture": false,
+    "promptContentIncluded": false,
+    "promptEchoed": false,
+    "promptPersistence": false,
+    "inputAccepted": false,
+    "sendAttempted": false,
+    "responseContentIncluded": false,
+    "responseGenerated": false,
+    "transcriptContentIncluded": false,
+    "auditEventPersisted": false,
+    "localStoreConfigured": false,
+    "attachmentReads": false,
+    "fileUpload": false,
+    "clipboardRead": false,
+    "clipboardWrite": false,
+    "modelAssetPathsIncluded": false,
+    "modelWeightPathsIncluded": false,
+    "modelLoadAttempted": false,
+    "modelLoaded": false,
+    "modelExecution": false,
+    "runtimeExecution": false,
+    "touchesHardware": false,
+    "kv260Access": false,
+    "opensSerialPort": false,
+    "networkCalls": false,
+    "networkScan": false,
+    "sshExecution": false,
+    "providerCalls": false,
+    "cloudCalls": false,
+    "privatePathsIncluded": false,
+    "secretsIncluded": false,
+    "tokensIncluded": false,
+    "generatedBlobsIncluded": false,
+    "hardwareDumpsIncluded": false,
+    "telemetry": false,
+    "automaticUpload": false,
+    "writeBack": false,
+    "executesPccxLab": false,
+    "executesSystemverilogIde": false,
+    "mcpServerImplemented": false,
+    "lspImplemented": false,
+    "stableApiAbiClaim": false
+  },
+  "limitations": [
+    "Data-only chat surface layout fixture; no app shell implementation is started.",
+    "No prompts, responses, transcripts, session titles, summaries, manifests, model paths, generated artifacts, private paths, secrets, or tokens are stored.",
+    "No artifacts are read, written, deleted, refreshed, imported, exported, or persisted.",
+    "No KV260 hardware access, serial access, network call, provider call, telemetry, upload, or write-back is performed.",
+    "Navigation and surface regions remain local metadata until explicit runtime, model-load, prompt-capture, session-store, and transcript boundaries exist.",
+    "This is not a release, tag, versioned compatibility commitment, MCP, LSP, IDE, marketplace, telemetry, or app-shell implementation."
+  ],
+  "issueRefs": [
+    "pccxai/pccx-llm-launcher#9"
+  ]
+}

--- a/docs/STANDALONE_CHAT_SESSION_CONTRACT.md
+++ b/docs/STANDALONE_CHAT_SESSION_CONTRACT.md
@@ -11,6 +11,7 @@ The implementation lives in:
 - `contracts/chat_session_contract.py`
 - `contracts/chat_model_status_contract.py`
 - `contracts/chat_session_lifecycle_contract.py`
+- `contracts/chat_surface_layout_contract.py`
 - `contracts/chat_session_index_contract.py`
 - `contracts/chat_readiness_contract.py`
 - `contracts/chat_composer_contract.py`
@@ -20,6 +21,7 @@ The implementation lives in:
 - `contracts/fixtures/chat-session.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-model-status.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-session-lifecycle.gemma3n-e4b-kv260-placeholder.json`
+- `contracts/fixtures/chat-surface-layout.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-session-index.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-readiness.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-composer.gemma3n-e4b-kv260-placeholder.json`
@@ -29,6 +31,7 @@ The implementation lives in:
 - `scripts/chat-session-stub.sh`
 - `scripts/chat-model-status-stub.sh`
 - `scripts/chat-session-lifecycle-stub.sh`
+- `scripts/chat-surface-layout-stub.sh`
 - `scripts/chat-session-index-stub.sh`
 - `scripts/chat-readiness-stub.sh`
 - `scripts/chat-composer-stub.sh`
@@ -39,6 +42,7 @@ The implementation lives in:
 - `scripts/tests/chat_session_contract_test.py`
 - `scripts/tests/chat_model_status_contract_test.py`
 - `scripts/tests/chat_session_lifecycle_contract_test.py`
+- `scripts/tests/chat_surface_layout_contract_test.py`
 - `scripts/tests/chat_session_index_contract_test.py`
 - `scripts/tests/chat_readiness_contract_test.py`
 - `scripts/tests/chat_composer_contract_test.py`
@@ -47,6 +51,7 @@ The implementation lives in:
 - `scripts/tests/chat_audit_event_contract_test.py`
 - `scripts/tests/chat_surface_preview_test.py`
 - `scripts/tests/status-chat-model-status.sh`
+- `scripts/tests/status-chat-surface-layout.sh`
 - `scripts/tests/status-chat-session-index.sh`
 - `scripts/tests/status-chat-readiness.sh`
 - `scripts/tests/status-chat-composer.sh`
@@ -62,6 +67,8 @@ The chat/session contract records:
 - chat surface, model-load, input, send, and session states
 - disabled session controls for new session, model status, send,
   clear, and export actions
+- planned shell regions and navigation items for the blocked chat
+  surface layout
 - an empty session index/list surface with disabled refresh, selection,
   restore, rename, and delete controls
 - a message envelope vocabulary without prompt or response content
@@ -101,6 +108,21 @@ until runtime readiness, model-load evidence, a reviewed local session
 store, and explicit export/redaction rules exist. The fixture does not
 read or write manifests, transcripts, summaries, prompts, responses, or
 model paths.
+
+The chat surface layout fixture records the shell-region and navigation
+boundary for the planned standalone chat UI:
+
+```bash
+bash scripts/chat-surface-layout-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/status-stub.sh --include-chat-surface-layout
+```
+
+It reports local metadata for the session sidebar, model-status header,
+readiness banner, transcript region, composer bar, send-result region,
+and audit footer. The fixture does not implement an app shell, read
+prompt/response/transcript/session-store content, focus the composer,
+start runtime code, load a model, touch hardware, call providers,
+invoke pccx-lab, or write artifacts.
 
 The chat session index fixture records the list/sidebar boundary for
 future local chat sessions:
@@ -256,6 +278,21 @@ session storage and transcript content:
 - `summary_only`: privacy state contains metadata only
 - `unavailable`: restore output or indexed sessions are unavailable
 
+The surface-layout states keep shell chrome separate from runtime,
+message content, and local stores:
+
+- `available_as_data`: layout or navigation metadata can be rendered
+  from checked fixture data
+- `blocked`: runtime readiness or content boundaries are missing
+- `disabled`: composer, model, or readiness actions are intentionally
+  unavailable
+- `empty_not_captured`: transcript/message content is absent
+- `not_configured`: no local session store exists
+- `not_started`: no local chat runtime has started
+- `placeholder`: deterministic local shell-region metadata only
+- `summary_only`: footer/privacy metadata excludes actor and content
+  identifiers
+
 The readiness states keep send-control gating separate from model-status
 display and lifecycle operations:
 
@@ -337,6 +374,9 @@ calls, persistence, target access, artifact reads, or artifact writes.
 The readiness contract ties those display and lifecycle states into a
 single checklist and recovery-action view without enabling any send,
 load, restore, or export action.
+The surface-layout contract adds a reviewable shell-region and
+navigation map without starting an app shell, reading content, focusing
+the composer, or enabling runtime/model/store actions.
 The session-index contract adds a reviewable empty list/sidebar boundary
 without enabling manifest reads, transcript reads, title capture,
 restore, rename, delete, refresh, persistence, or artifact writes.

--- a/scripts/chat-surface-layout-stub.sh
+++ b/scripts/chat-surface-layout-stub.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+# Print the data-only chat surface layout contract.
+
+set -eu
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+
+python3 "$ROOT_DIR/contracts/chat_surface_layout_contract.py" "$@"

--- a/scripts/status-stub.sh
+++ b/scripts/status-stub.sh
@@ -13,6 +13,9 @@
 # Chat/session status and lifecycle plan (explicit opt-in, read-only local data):
 #   --include-chat-session
 #
+# Chat surface layout/chrome plan (explicit opt-in, read-only local data):
+#   --include-chat-surface-layout
+#
 # Chat session index/sidebar plan (explicit opt-in, read-only local data):
 #   --include-chat-session-index
 #
@@ -52,6 +55,7 @@ BACKEND=""
 INCLUDE_RUNTIME_READINESS="0"
 INCLUDE_DEVICE_SESSION="0"
 INCLUDE_CHAT_SESSION="0"
+INCLUDE_CHAT_SURFACE_LAYOUT="0"
 INCLUDE_CHAT_SESSION_INDEX="0"
 INCLUDE_CHAT_MODEL_STATUS="0"
 INCLUDE_CHAT_READINESS="0"
@@ -59,6 +63,109 @@ INCLUDE_CHAT_COMPOSER="0"
 INCLUDE_CHAT_SEND_RESULT="0"
 INCLUDE_CHAT_TRANSCRIPT_POLICY="0"
 INCLUDE_CHAT_AUDIT_EVENT="0"
+
+print_chat_surface_layout_summary() {
+    SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+    ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+    CHAT_SURFACE_LAYOUT_STUB="$ROOT_DIR/scripts/chat-surface-layout-stub.sh"
+
+    if [ ! -f "$CHAT_SURFACE_LAYOUT_STUB" ]; then
+        ERROR "chat surface layout stub not found: $CHAT_SURFACE_LAYOUT_STUB"
+        return 1
+    fi
+
+    if ! CHAT_SURFACE_LAYOUT_JSON="$(bash "$CHAT_SURFACE_LAYOUT_STUB" --model gemma3n-e4b --target kv260 2>&1)"; then
+        ERROR "chat surface layout stub failed"
+        printf '%s\n' "$CHAT_SURFACE_LAYOUT_JSON" >&2
+        return 1
+    fi
+
+    if ! CHAT_SURFACE_LAYOUT_SUMMARY="$(
+        printf '%s\n' "$CHAT_SURFACE_LAYOUT_JSON" | python3 -c '
+import json
+import sys
+
+data = json.load(sys.stdin)
+flags = data["safetyFlags"]
+policy = data["layoutPolicy"]
+regions = " ".join(
+    "{}={}".format(region["regionId"], region["state"])
+    for region in data["surfaceRegions"]
+)
+nav = " ".join(
+    "{}={}".format(item["navId"], item["state"])
+    for item in data["navigationItems"]
+)
+blocked = " ".join(
+    "{}={}".format(reason["reasonId"], reason["state"])
+    for reason in data["blockedReasons"]
+)
+
+def b(value):
+    return "true" if value else "false"
+
+print("[INFO]  source     : scripts/chat-surface-layout-stub.sh --model gemma3n-e4b --target kv260")
+print("[INFO]  boundary   : read-only data; no prompt/response/transcript/session-store/model/hardware/lab/IDE execution")
+print("[INFO]  target     : {}".format(data["targetDevice"]))
+print("[INFO]  model      : {}".format(data["targetModel"]))
+print("[INFO]  layout     : {}".format(data["layoutState"]))
+print("[INFO]  shell      : {}".format(data["shellState"]))
+print("[INFO]  navigation : {}".format(data["navigationState"]))
+print("[INFO]  primary    : {}".format(data["primaryRegionState"]))
+print("[INFO]  side       : {}".format(data["sideRegionState"]))
+print("[INFO]  footer     : {}".format(data["footerState"]))
+print("[INFO]  content    : {}".format(data["contentState"]))
+print("[INFO]  privacy    : {}".format(data["privacyState"]))
+print(
+    "[INFO]  layout-policy : {} renderMode={} sideEffectPolicy={}".format(
+        policy["state"],
+        policy["renderMode"],
+        policy["sideEffectPolicy"],
+    )
+)
+print("[INFO]  regions    : {}".format(regions))
+print("[INFO]  nav        : {}".format(nav))
+print("[INFO]  blocked    : {}".format(blocked))
+print(
+    "[INFO]  flags      : readOnly={} dataOnly={} deterministic={} "
+    "surfaceLayoutDisplayOnly={} writesArtifacts={} readsArtifacts={} "
+    "sessionStoreRead={} promptCapture={} promptContentIncluded={} "
+    "responseContentIncluded={} transcriptContentIncluded={} "
+    "sessionTitleIncluded={} summaryIncluded={} inputAccepted={} "
+    "sendAttempted={} modelExecution={} runtimeExecution={} kv260Access={} "
+    "networkCalls={} providerCalls={} executesPccxLab={}".format(
+        b(flags["readOnly"]),
+        b(flags["dataOnly"]),
+        b(flags["deterministic"]),
+        b(flags["surfaceLayoutDisplayOnly"]),
+        b(flags["writesArtifacts"]),
+        b(flags["readsArtifacts"]),
+        b(flags["sessionStoreRead"]),
+        b(flags["promptCapture"]),
+        b(flags["promptContentIncluded"]),
+        b(flags["responseContentIncluded"]),
+        b(flags["transcriptContentIncluded"]),
+        b(flags["sessionTitleIncluded"]),
+        b(flags["summaryIncluded"]),
+        b(flags["inputAccepted"]),
+        b(flags["sendAttempted"]),
+        b(flags["modelExecution"]),
+        b(flags["runtimeExecution"]),
+        b(flags["kv260Access"]),
+        b(flags["networkCalls"]),
+        b(flags["providerCalls"]),
+        b(flags["executesPccxLab"]),
+    )
+)
+'
+    )"; then
+        ERROR "chat surface layout JSON could not be summarized"
+        return 1
+    fi
+
+    HEAD "chat surface layout"
+    printf '%s\n' "$CHAT_SURFACE_LAYOUT_SUMMARY"
+}
 
 print_chat_session_index_summary() {
     SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
@@ -1100,6 +1207,10 @@ while [ $# -gt 0 ]; do
             INCLUDE_CHAT_SESSION="1"
             shift
             ;;
+        --include-chat-surface-layout)
+            INCLUDE_CHAT_SURFACE_LAYOUT="1"
+            shift
+            ;;
         --include-chat-session-index)
             INCLUDE_CHAT_SESSION_INDEX="1"
             shift
@@ -1143,8 +1254,8 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-if [ -n "$BACKEND" ] && { [ "$INCLUDE_RUNTIME_READINESS" = "1" ] || [ "$INCLUDE_DEVICE_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SESSION_INDEX" = "1" ] || [ "$INCLUDE_CHAT_MODEL_STATUS" = "1" ] || [ "$INCLUDE_CHAT_READINESS" = "1" ] || [ "$INCLUDE_CHAT_COMPOSER" = "1" ] || [ "$INCLUDE_CHAT_SEND_RESULT" = "1" ] || [ "$INCLUDE_CHAT_TRANSCRIPT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_AUDIT_EVENT" = "1" ]; }; then
-    ERROR "--include-runtime-readiness, --include-device-session, --include-chat-session, --include-chat-session-index, --include-chat-model-status, --include-chat-readiness, --include-chat-composer, --include-chat-send-result, --include-chat-transcript-policy, and --include-chat-audit-event are only supported in local scaffold mode"
+if [ -n "$BACKEND" ] && { [ "$INCLUDE_RUNTIME_READINESS" = "1" ] || [ "$INCLUDE_DEVICE_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SURFACE_LAYOUT" = "1" ] || [ "$INCLUDE_CHAT_SESSION_INDEX" = "1" ] || [ "$INCLUDE_CHAT_MODEL_STATUS" = "1" ] || [ "$INCLUDE_CHAT_READINESS" = "1" ] || [ "$INCLUDE_CHAT_COMPOSER" = "1" ] || [ "$INCLUDE_CHAT_SEND_RESULT" = "1" ] || [ "$INCLUDE_CHAT_TRANSCRIPT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_AUDIT_EVENT" = "1" ]; }; then
+    ERROR "--include-runtime-readiness, --include-device-session, --include-chat-session, --include-chat-surface-layout, --include-chat-session-index, --include-chat-model-status, --include-chat-readiness, --include-chat-composer, --include-chat-send-result, --include-chat-transcript-policy, and --include-chat-audit-event are only supported in local scaffold mode"
     exit 1
 fi
 
@@ -1160,6 +1271,7 @@ if [ -z "$BACKEND" ]; then
     NOTE "runtime ready  : opt-in via --include-runtime-readiness (read-only data)"
     NOTE "device/session: opt-in via --include-device-session (read-only panel data)"
     NOTE "chat/session  : opt-in via --include-chat-session (read-only blocked chat and lifecycle data)"
+    NOTE "chat layout   : opt-in via --include-chat-surface-layout (read-only surface layout data)"
     NOTE "chat index    : opt-in via --include-chat-session-index (read-only empty session index data)"
     NOTE "chat model    : opt-in via --include-chat-model-status (read-only model status display data)"
     NOTE "chat readiness: opt-in via --include-chat-readiness (read-only readiness and recovery data)"
@@ -1171,6 +1283,12 @@ if [ -z "$BACKEND" ]; then
 
     if [ "$INCLUDE_CHAT_AUDIT_EVENT" = "1" ]; then
         if ! print_chat_audit_event_summary; then
+            exit 1
+        fi
+    fi
+
+    if [ "$INCLUDE_CHAT_SURFACE_LAYOUT" = "1" ]; then
+        if ! print_chat_surface_layout_summary; then
             exit 1
         fi
     fi

--- a/scripts/tests/chat_surface_layout_contract_test.py
+++ b/scripts/tests/chat_surface_layout_contract_test.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Fixture tests for the standalone chat surface-layout contract."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "contracts" / "chat_surface_layout_contract.py"
+FIXTURE_PATH = (
+    ROOT
+    / "contracts"
+    / "fixtures"
+    / "chat-surface-layout.gemma3n-e4b-kv260-placeholder.json"
+)
+SCRIPT_PATH = ROOT / "scripts" / "chat-surface-layout-stub.sh"
+STATUS_TEST_PATH = ROOT / "scripts" / "tests" / "status-chat-surface-layout.sh"
+DOC_PATH = ROOT / "docs" / "STANDALONE_CHAT_SESSION_CONTRACT.md"
+README_PATH = ROOT / "README.md"
+CI_PATH = ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location(
+        "chat_surface_layout_contract",
+        MODULE_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def iter_state_values(value):
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            if (
+                key == "state"
+                or key.endswith("State")
+                or key.endswith("Status")
+            ) and isinstance(nested, str):
+                yield nested
+            yield from iter_state_values(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            yield from iter_state_values(nested)
+
+
+def iter_keys(value):
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            yield key
+            yield from iter_keys(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            yield from iter_keys(nested)
+
+
+def assert_no_private_or_generated_data(text: str) -> None:
+    forbidden_patterns = [
+        r"/home/[^\s\"']+",
+        r"/Users/[^\s\"']+",
+        r"[A-Za-z]:\\Users\\",
+        r"\b(?:api[_-]?key|authorization|bearer|client[_-]?secret|password|private[_-]?key|secret|token)\b\s*[:=]",
+        r"\.(?:gguf|safetensors|ckpt|pt|pth|onnx)\b",
+        r"(?:weights|model_weights|model-cache)/(?:[^\"'\s]+)",
+        r"(?:raw[_-]?full[_-]?logs|hardware[_-]?dump|generated[_-]?blob)\s*[:=]",
+    ]
+    for pattern in forbidden_patterns:
+        assert not re.search(pattern, text, re.IGNORECASE), pattern
+
+
+def assert_no_runtime_implementation_terms(source: str) -> None:
+    forbidden = [
+        "subprocess",
+        "os.system",
+        "popen",
+        "socket",
+        "urllib",
+        "requests",
+        "http.client",
+        "openai",
+        "anthropic",
+        "gem" + "ini",
+        "modelcontextprotocol",
+        "websocket",
+        "xmutil",
+        "xrt-smi",
+        "lsusb",
+        "dmesg",
+    ]
+    lowered = source.lower()
+    for term in forbidden:
+        assert term not in lowered, term
+
+
+def assert_no_provider_configs(value) -> None:
+    forbidden_keys = {
+        "apiKey",
+        "accessToken",
+        "refreshToken",
+        "authorization",
+        "bearerToken",
+        "provider",
+        "providers",
+        "providerConfig",
+        "providerConfigs",
+    }
+    for key in iter_keys(value):
+        assert key not in forbidden_keys, key
+
+
+def assert_no_unsupported_claims(text: str) -> None:
+    literal_claims = [
+        "production" + "-ready",
+        "marketplace" + "-ready",
+        "stable " + "API",
+        "stable " + "ABI",
+        "KV260 inference " + "works",
+        "Gemma 3N E4B " + "runs on KV260",
+        "20 tok/s " + "achieved",
+        "timing " + "closed",
+        "bitstream " + "ready",
+        "launcher executes " + "pccx-lab",
+        "IDE controls " + "launcher",
+        "AI provider integration " + "is live",
+    ]
+    lowered = text.lower()
+    for claim in literal_claims:
+        assert claim.lower() not in lowered, claim
+
+
+def test_chat_surface_layout_matches_fixture_and_is_deterministic() -> None:
+    module = load_module()
+    generated = module.create_gemma3n_e4b_kv260_chat_surface_layout()
+    fixture = json.loads(read_text(FIXTURE_PATH))
+
+    assert generated == fixture
+    assert (
+        module.chat_surface_layout_json(generated)
+        == module.chat_surface_layout_json(generated)
+    )
+    assert module.chat_surface_layout_json(generated).endswith("\n")
+    assert json.loads(module.chat_surface_layout_json(generated)) == fixture
+
+
+def test_cli_stub_outputs_deterministic_json() -> None:
+    fixture = json.loads(read_text(FIXTURE_PATH))
+    command = [
+        "bash",
+        str(SCRIPT_PATH),
+        "--model",
+        "gemma3n-e4b",
+        "--target",
+        "kv260",
+    ]
+    first = subprocess.run(command, check=True, capture_output=True, text=True)
+    second = subprocess.run(command, check=True, capture_output=True, text=True)
+
+    assert first.stderr == ""
+    assert first.stdout == second.stdout
+    assert first.stdout.endswith("\n")
+    assert json.loads(first.stdout) == fixture
+
+
+def test_required_fields_and_allowed_states() -> None:
+    module = load_module()
+    layout = module.create_gemma3n_e4b_kv260_chat_surface_layout()
+    allowed = set(module.CHAT_SURFACE_LAYOUT_STATE_VALUES)
+
+    assert tuple(layout.keys()) == module.CHAT_SURFACE_LAYOUT_FIELDS
+    assert layout["schemaVersion"] == "pccx.chatSurfaceLayout.v0"
+    assert tuple(layout["layoutPolicy"].keys()) == module.LAYOUT_POLICY_FIELDS
+
+    states = list(iter_state_values(layout))
+    assert states
+    for state in states:
+        assert state in allowed, state
+
+    for region in layout["surfaceRegions"]:
+        assert tuple(region.keys()) == module.SURFACE_REGION_FIELDS
+    for item in layout["navigationItems"]:
+        assert tuple(item.keys()) == module.NAVIGATION_ITEM_FIELDS
+    for reason in layout["blockedReasons"]:
+        assert tuple(reason.keys()) == module.BLOCKED_REASON_FIELDS
+    for ref in layout["handoffRefs"]:
+        assert tuple(ref.keys()) == module.HANDOFF_REF_FIELDS
+
+
+def test_chat_surface_layout_covers_issue_9_shell_boundary() -> None:
+    layout = load_module().create_gemma3n_e4b_kv260_chat_surface_layout()
+    flags = layout["safetyFlags"]
+    regions = {region["regionId"]: region for region in layout["surfaceRegions"]}
+    items = {item["navId"]: item for item in layout["navigationItems"]}
+    reasons = {reason["reasonId"]: reason for reason in layout["blockedReasons"]}
+    refs = {ref["refId"]: ref for ref in layout["handoffRefs"]}
+
+    assert layout["layoutState"] == "blocked"
+    assert layout["shellState"] == "placeholder"
+    assert layout["navigationState"] == "available_as_data"
+    assert layout["primaryRegionState"] == "empty_not_captured"
+    assert layout["contentState"] == "empty_not_captured"
+    assert layout["privacyState"] == "summary_only"
+    assert set(regions) == {
+        "session_index_sidebar",
+        "model_status_header",
+        "readiness_banner",
+        "transcript_region",
+        "composer_bar",
+        "send_result_region",
+        "audit_footer",
+    }
+    assert regions["session_index_sidebar"]["enabled"] is True
+    assert regions["transcript_region"]["state"] == "empty_not_captured"
+    assert regions["composer_bar"]["enabled"] is False
+    assert set(items) == {
+        "open_chat_surface",
+        "open_session_index",
+        "open_model_status",
+        "open_readiness",
+        "focus_composer",
+    }
+    assert items["open_chat_surface"]["enabled"] is True
+    assert items["focus_composer"]["state"] == "disabled"
+    assert {
+        "runtime_readiness_blocked",
+        "chat_runtime_not_started",
+        "composer_send_disabled",
+        "transcript_content_absent",
+        "session_store_not_configured",
+    } <= set(reasons)
+    assert set(refs) == {
+        "chat_session",
+        "chat_session_index",
+        "chat_model_status",
+        "chat_readiness",
+        "chat_composer",
+        "chat_transcript_policy",
+    }
+    assert flags["readOnly"] is True
+    assert flags["surfaceLayoutDisplayOnly"] is True
+    assert flags["readsArtifacts"] is False
+    assert flags["writesArtifacts"] is False
+    assert flags["sessionStoreRead"] is False
+    assert flags["promptCapture"] is False
+    assert flags["promptContentIncluded"] is False
+    assert flags["responseContentIncluded"] is False
+    assert flags["transcriptContentIncluded"] is False
+    assert flags["sessionTitleIncluded"] is False
+    assert flags["summaryIncluded"] is False
+    assert flags["inputAccepted"] is False
+    assert flags["sendAttempted"] is False
+    assert flags["modelExecution"] is False
+    assert flags["runtimeExecution"] is False
+    assert flags["kv260Access"] is False
+    assert flags["providerCalls"] is False
+    assert flags["executesPccxLab"] is False
+
+
+def test_contract_avoids_runtime_or_private_data() -> None:
+    module_source = read_text(MODULE_PATH)
+    fixture_text = read_text(FIXTURE_PATH)
+    fixture = json.loads(fixture_text)
+
+    assert_no_runtime_implementation_terms(module_source)
+    assert_no_private_or_generated_data(fixture_text)
+    assert_no_provider_configs(fixture)
+    assert_no_unsupported_claims(fixture_text)
+    assert "hello" not in fixture_text.lower()
+    assert "promptText" not in fixture_text
+    assert "responseText" not in fixture_text
+    assert "sessionTitleText" not in fixture_text
+
+
+def test_docs_readme_status_tests_and_ci_reference_surface_layout() -> None:
+    docs = read_text(DOC_PATH)
+    readme = read_text(README_PATH)
+    status_test = read_text(STATUS_TEST_PATH)
+    ci = read_text(CI_PATH)
+
+    assert "chat_surface_layout_contract.py" in docs
+    assert "chat-surface-layout-stub.sh" in docs
+    assert "chat-surface-layout.gemma3n-e4b-kv260-placeholder.json" in docs
+    assert "chat surface layout" in docs
+    assert "--include-chat-surface-layout" in docs
+    assert "chat-surface-layout-stub.sh" in readme
+    assert "--include-chat-surface-layout" in readme
+    assert "status-chat-surface-layout" in ci
+    assert "chat_surface_layout_contract_test.py" in ci
+    assert "no prompt/response/transcript/session-store" in status_test
+
+
+if __name__ == "__main__":
+    for name, func in sorted(globals().items()):
+        if name.startswith("test_") and callable(func):
+            func()
+    print("chat surface layout contract tests ok")

--- a/scripts/tests/status-chat-surface-layout.sh
+++ b/scripts/tests/status-chat-surface-layout.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+# scripts/tests/status-chat-surface-layout.sh - status surface-layout tests.
+#
+# Usage: bash scripts/tests/status-chat-surface-layout.sh [path/to/status-stub.sh]
+
+set -eu
+
+PASS() { printf '[PASS]  %s\n' "$*"; }
+FAIL() { printf '[FAIL]  %s\n' "$*" >&2; }
+HEAD() { printf '\n=== %s ===\n' "$*"; }
+
+STUB="${1:-scripts/status-stub.sh}"
+
+if [ ! -x "$STUB" ]; then
+    chmod +x "$STUB"
+fi
+
+contains() {
+    case "$1" in
+        *"$2"*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+require_contains() {
+    local output="$1"
+    local expected="$2"
+    if ! contains "$output" "$expected"; then
+        FAIL "expected output to contain: $expected"
+        printf '%s\n' "$output" >&2
+        exit 1
+    fi
+}
+
+require_not_contains() {
+    local output="$1"
+    local forbidden="$2"
+    if contains "$output" "$forbidden"; then
+        FAIL "output contained forbidden text: $forbidden"
+        printf '%s\n' "$output" >&2
+        exit 1
+    fi
+}
+
+HEAD "1: status can include chat surface layout"
+OUTPUT="$("$STUB" --include-chat-surface-layout)"
+require_contains "$OUTPUT" "=== chat surface layout ==="
+require_contains "$OUTPUT" "source     : scripts/chat-surface-layout-stub.sh --model gemma3n-e4b --target kv260"
+require_contains "$OUTPUT" "boundary   : read-only data; no prompt/response/transcript/session-store/model/hardware/lab/IDE execution"
+require_contains "$OUTPUT" "target     : kv260"
+require_contains "$OUTPUT" "model      : gemma3n-e4b"
+require_contains "$OUTPUT" "layout     : blocked"
+require_contains "$OUTPUT" "shell      : placeholder"
+require_contains "$OUTPUT" "navigation : available_as_data"
+require_contains "$OUTPUT" "primary    : empty_not_captured"
+require_contains "$OUTPUT" "side       : placeholder"
+require_contains "$OUTPUT" "footer     : available_as_data"
+require_contains "$OUTPUT" "content    : empty_not_captured"
+require_contains "$OUTPUT" "privacy    : summary_only"
+PASS "chat surface layout section is present and conservative"
+
+HEAD "2: regions and navigation stay local metadata"
+require_contains "$OUTPUT" "layout-policy : placeholder renderMode=future_local_shell_layout sideEffectPolicy=local_render_only"
+require_contains "$OUTPUT" "regions    : session_index_sidebar=placeholder"
+require_contains "$OUTPUT" "model_status_header=blocked"
+require_contains "$OUTPUT" "transcript_region=empty_not_captured"
+require_contains "$OUTPUT" "composer_bar=disabled"
+require_contains "$OUTPUT" "audit_footer=summary_only"
+require_contains "$OUTPUT" "nav        : open_chat_surface=available_as_data"
+require_contains "$OUTPUT" "open_session_index=available_as_data"
+require_contains "$OUTPUT" "open_model_status=blocked"
+require_contains "$OUTPUT" "focus_composer=disabled"
+require_contains "$OUTPUT" "blocked    : runtime_readiness_blocked=blocked"
+require_contains "$OUTPUT" "chat_runtime_not_started=not_started"
+require_contains "$OUTPUT" "composer_send_disabled=disabled"
+require_contains "$OUTPUT" "transcript_content_absent=empty_not_captured"
+PASS "surface layout metadata is summarized without content or runtime actions"
+
+HEAD "3: safety flags stay read-only and non-executing"
+require_contains "$OUTPUT" "readOnly=true"
+require_contains "$OUTPUT" "dataOnly=true"
+require_contains "$OUTPUT" "deterministic=true"
+require_contains "$OUTPUT" "surfaceLayoutDisplayOnly=true"
+require_contains "$OUTPUT" "writesArtifacts=false"
+require_contains "$OUTPUT" "readsArtifacts=false"
+require_contains "$OUTPUT" "sessionStoreRead=false"
+require_contains "$OUTPUT" "promptCapture=false"
+require_contains "$OUTPUT" "promptContentIncluded=false"
+require_contains "$OUTPUT" "responseContentIncluded=false"
+require_contains "$OUTPUT" "transcriptContentIncluded=false"
+require_contains "$OUTPUT" "sessionTitleIncluded=false"
+require_contains "$OUTPUT" "summaryIncluded=false"
+require_contains "$OUTPUT" "inputAccepted=false"
+require_contains "$OUTPUT" "sendAttempted=false"
+require_contains "$OUTPUT" "modelExecution=false"
+require_contains "$OUTPUT" "runtimeExecution=false"
+require_contains "$OUTPUT" "kv260Access=false"
+require_contains "$OUTPUT" "networkCalls=false"
+require_contains "$OUTPUT" "providerCalls=false"
+require_contains "$OUTPUT" "executesPccxLab=false"
+PASS "surface-layout execution, persistence, and content flags remain false"
+
+HEAD "4: output is deterministic"
+OUTPUT_AGAIN="$("$STUB" --include-chat-surface-layout)"
+if [ "$OUTPUT" != "$OUTPUT_AGAIN" ]; then
+    FAIL "status chat surface layout output changed between runs"
+    exit 1
+fi
+PASS "status chat surface layout output is deterministic"
+
+HEAD "5: surface-layout option does not combine with pccx-lab backend"
+if "$STUB" --include-chat-surface-layout --backend pccx-lab >/dev/null 2>&1; then
+    FAIL "expected combined surface-layout/backend mode to fail"
+    exit 1
+fi
+PASS "chat surface layout remains separate from backend execution"
+
+HEAD "6: output avoids known overclaims and chat content"
+FORBIDDEN_PREFIX="KV260 inference"
+FORBIDDEN_CLAIM="${FORBIDDEN_PREFIX} works"
+require_not_contains "$OUTPUT" "$FORBIDDEN_CLAIM"
+THROUGHPUT_PREFIX="20 tok/s"
+THROUGHPUT_CLAIM="${THROUGHPUT_PREFIX} achieved"
+require_not_contains "$OUTPUT" "$THROUGHPUT_CLAIM"
+require_not_contains "$OUTPUT" "hello"
+require_not_contains "$OUTPUT" "assistant response:"
+require_not_contains "$OUTPUT" "session title:"
+PASS "no surface-layout overclaim or chat content in status output"
+
+printf '\n[DONE]  all status-chat-surface-layout tests passed\n'


### PR DESCRIPTION
## Summary

- Add a checked `pccx.chatSurfaceLayout.v0` data-only fixture and stub for planned standalone chat shell regions and navigation items.
- Add `--include-chat-surface-layout` status output plus README, standalone chat contract docs, tests, and CI coverage.
- Tighten existing README wording for the later local assistant direction so the public wording guard stays clean.

## Boundaries

- No app shell implementation, runtime, model, hardware, provider, pccx-lab, or IDE execution.
- No prompt, response, transcript, session-store, session-title, summary, model-path, private-path, raw-log, or artifact reads.
- No artifact writes, deletes, refreshes, imports, exports, persistence, telemetry, upload, or write-back.

Refs pccxai/pccx-llm-launcher#9

## Validation

- `python3 -m py_compile contracts/*.py scripts/tests/*.py`
- `for test in scripts/tests/*_test.py; do python3 "$test"; done`
- `for test in scripts/tests/status-*.sh; do bash "$test" scripts/status-stub.sh; done`
- `bash -n scripts/*.sh scripts/tests/*.sh`
- `bash scripts/check.sh`
- `bash scripts/check-device-stub.sh`
- `bash scripts/install-stub.sh`
- `bash scripts/launch-stub.sh --dry-run`
- `bash scripts/chat-stub.sh --dry-run --prompt hello`
- launch/chat dry-run refusal guards
- combined local status summary with all opt-in local-data sections
- local claim scan
- `git diff --check`
- `git diff --cached --check`