### PR TITLE
Add chat error taxonomy boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,7 @@ jobs:
                    scripts/chat-send-result-stub.sh \
                    scripts/chat-transcript-policy-stub.sh \
                    scripts/chat-audit-event-stub.sh \
+                   scripts/chat-error-taxonomy-stub.sh \
                    scripts/chat-surface-preview.sh \
                    scripts/chat-stub.sh; do
             [ -f "$f" ] && chmod +x "$f" || true
@@ -208,6 +209,10 @@ jobs:
         run: ./scripts/status-stub.sh --include-chat-audit-event
       - name: run scripts/chat-audit-event-stub.sh
         run: ./scripts/chat-audit-event-stub.sh --model gemma3n-e4b --target kv260
+      - name: run scripts/status-stub.sh with chat error taxonomy
+        run: ./scripts/status-stub.sh --include-chat-error-taxonomy
+      - name: run scripts/chat-error-taxonomy-stub.sh
+        run: ./scripts/chat-error-taxonomy-stub.sh --model gemma3n-e4b --target kv260
       - name: run scripts/chat-surface-preview.sh
         run: ./scripts/chat-surface-preview.sh --model gemma3n-e4b --target kv260
       - name: run scripts/chat-stub.sh --dry-run
@@ -254,6 +259,8 @@ jobs:
         run: python3 scripts/tests/chat_transcript_policy_contract_test.py
       - name: run chat audit-event contract tests
         run: python3 scripts/tests/chat_audit_event_contract_test.py
+      - name: run chat error-taxonomy contract tests
+        run: python3 scripts/tests/chat_error_taxonomy_contract_test.py
       - name: run chat surface preview tests
         run: python3 scripts/tests/chat_surface_preview_test.py
 
@@ -278,6 +285,7 @@ jobs:
           chmod +x scripts/chat-send-result-stub.sh
           chmod +x scripts/chat-transcript-policy-stub.sh
           chmod +x scripts/chat-audit-event-stub.sh
+          chmod +x scripts/chat-error-taxonomy-stub.sh
           chmod +x scripts/launch-stub.sh
           chmod +x scripts/tests/status-backend.sh
           chmod +x scripts/tests/status-device-session.sh
@@ -293,6 +301,7 @@ jobs:
           chmod +x scripts/tests/status-chat-send-result.sh
           chmod +x scripts/tests/status-chat-transcript-policy.sh
           chmod +x scripts/tests/status-chat-audit-event.sh
+          chmod +x scripts/tests/status-chat-error-taxonomy.sh
       - name: shellcheck status-stub and test script
         run: |
           sudo apt-get update -q && sudo apt-get install -y -q shellcheck
@@ -311,6 +320,7 @@ jobs:
           shellcheck scripts/tests/status-chat-send-result.sh
           shellcheck scripts/tests/status-chat-transcript-policy.sh
           shellcheck scripts/tests/status-chat-audit-event.sh
+          shellcheck scripts/tests/status-chat-error-taxonomy.sh
       - name: run status-backend tests
         run: bash scripts/tests/status-backend.sh scripts/status-stub.sh
       - name: run status-device-session tests
@@ -339,3 +349,5 @@ jobs:
         run: bash scripts/tests/status-chat-transcript-policy.sh scripts/status-stub.sh
       - name: run status-chat-audit-event tests
         run: bash scripts/tests/status-chat-audit-event.sh scripts/status-stub.sh
+      - name: run status-chat-error-taxonomy tests
+        run: bash scripts/tests/status-chat-error-taxonomy.sh scripts/status-stub.sh

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ and verify host-side prerequisites before the real engine lands.
 | [`scripts/check.sh`](./scripts/check.sh) | Probe host info, tooling availability, edge-device hints. Always exits 0. |
 | [`scripts/check-device-stub.sh`](./scripts/check-device-stub.sh) | Narrowly scoped device-tree / FPGA-node probe (KV260 / Kria detection only). Always exits 0. |
 | [`scripts/install-stub.sh`](./scripts/install-stub.sh) | Preview of the planned install flow; reports which host runtime pieces are present, lists device-side pieces as future deliverables. Always exits 0. |
-| [`scripts/status-stub.sh`](./scripts/status-stub.sh) | Launcher state summary. Default mode: local scaffold output, always exits 0. With `--include-chat-audit-event`, adds read-only blocked chat audit-event metadata. With `--include-chat-surface-layout`, adds read-only chat surface layout data. With `--include-chat-local-only-policy`, adds read-only local-only/cloud-block policy data. With `--include-chat-preferences`, adds read-only chat preferences/settings data. With `--include-chat-session-index`, adds read-only empty chat session index data. With `--include-chat-transcript-policy`, adds read-only chat transcript retention/export policy data. With `--include-chat-send-result`, adds read-only blocked chat send-result data. With `--include-chat-composer`, adds read-only chat composer/input-control data. With `--include-chat-model-status`, adds read-only blocked chat model-status display data. With `--include-chat-session`, adds read-only blocked chat/session and lifecycle summaries. With `--include-chat-readiness`, adds read-only chat readiness checks and recovery actions. With `--include-device-session`, adds a read-only device/session status panel. With `--include-runtime-readiness`, adds a read-only runtime readiness summary. With `--backend pccx-lab`, calls `pccx-lab status --format json` and forwards the run-status envelope (exits non-zero if binary is missing or output is invalid). |
+| [`scripts/status-stub.sh`](./scripts/status-stub.sh) | Launcher state summary. Default mode: local scaffold output, always exits 0. With `--include-chat-error-taxonomy`, adds read-only chat error taxonomy data. With `--include-chat-audit-event`, adds read-only blocked chat audit-event metadata. With `--include-chat-surface-layout`, adds read-only chat surface layout data. With `--include-chat-local-only-policy`, adds read-only local-only/cloud-block policy data. With `--include-chat-preferences`, adds read-only chat preferences/settings data. With `--include-chat-session-index`, adds read-only empty chat session index data. With `--include-chat-transcript-policy`, adds read-only chat transcript retention/export policy data. With `--include-chat-send-result`, adds read-only blocked chat send-result data. With `--include-chat-composer`, adds read-only chat composer/input-control data. With `--include-chat-model-status`, adds read-only blocked chat model-status display data. With `--include-chat-session`, adds read-only blocked chat/session and lifecycle summaries. With `--include-chat-readiness`, adds read-only chat readiness checks and recovery actions. With `--include-device-session`, adds a read-only device/session status panel. With `--include-runtime-readiness`, adds a read-only runtime readiness summary. With `--backend pccx-lab`, calls `pccx-lab status --format json` and forwards the run-status envelope (exits non-zero if binary is missing or output is invalid). |
 | [`scripts/device-session-status-stub.sh`](./scripts/device-session-status-stub.sh) | Data-only device/session status JSON for the Gemma 3N E4B + KV260 target. Reports connection, model load, session, diagnostics, readiness, discovery paths, flow steps, and error taxonomy as placeholder / blocked. |
 | [`scripts/runtime-readiness-stub.sh`](./scripts/runtime-readiness-stub.sh) | Data-only runtime readiness JSON for the Gemma 3N E4B + KV260 target. Reports blocked / not yet evidence-backed. |
 | [`scripts/chat-session-stub.sh`](./scripts/chat-session-stub.sh) | Data-only standalone chat/session JSON for the Gemma 3N E4B + KV260 target. Reports disabled send controls, inactive session state, no prompt/response persistence, and readiness handoff references. |
@@ -102,6 +102,7 @@ and verify host-side prerequisites before the real engine lands.
 | [`scripts/chat-send-result-stub.sh`](./scripts/chat-send-result-stub.sh) | Data-only blocked chat send-result JSON for the Gemma 3N E4B + KV260 target. Reports disabled send state, no accepted input, no prompt echo, no generated response, and no runtime/model handoff. |
 | [`scripts/chat-transcript-policy-stub.sh`](./scripts/chat-transcript-policy-stub.sh) | Data-only chat transcript policy JSON for the Gemma 3N E4B + KV260 target. Reports retention, export, storage, and privacy policy state without reading, generating, storing, persisting, summarizing, or exporting prompt/response/transcript content. |
 | [`scripts/chat-audit-event-stub.sh`](./scripts/chat-audit-event-stub.sh) | Data-only chat audit-event JSON for the Gemma 3N E4B + KV260 target. Reports blocked send metadata, redaction policy, absent prompt/response/transcript content, and disabled audit persistence. |
+| [`scripts/chat-error-taxonomy-stub.sh`](./scripts/chat-error-taxonomy-stub.sh) | Data-only chat error taxonomy JSON for the Gemma 3N E4B + KV260 target. Groups blocked readiness, model/runtime, session, and policy errors without reading prompts, providers, configs, model paths, logs, stores, or artifacts. |
 | [`scripts/chat-surface-preview.sh`](./scripts/chat-surface-preview.sh) | Read-only terminal preview of the standalone chat surface. Renders the checked chat/session contract as blocked UI state without accepting prompts, executing a model, or writing artifacts. |
 | [`scripts/launch-stub.sh`](./scripts/launch-stub.sh) | Dry-run preview of the intended launch sequence. Requires `--dry-run`; exits 1 without it. |
 | [`scripts/chat-stub.sh`](./scripts/chat-stub.sh) | Dry-run chat stub. Requires `--dry-run`; exits 1 without it. Accepts `--prompt "..."` or stdin. No model is executed. |
@@ -122,6 +123,7 @@ bash scripts/status-stub.sh --include-chat-composer
 bash scripts/status-stub.sh --include-chat-send-result
 bash scripts/status-stub.sh --include-chat-transcript-policy
 bash scripts/status-stub.sh --include-chat-audit-event
+bash scripts/status-stub.sh --include-chat-error-taxonomy
 bash scripts/status-stub.sh --include-device-session
 bash scripts/status-stub.sh --include-runtime-readiness
 bash scripts/device-session-status-stub.sh --model gemma3n-e4b --target kv260
@@ -138,6 +140,7 @@ bash scripts/chat-composer-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-send-result-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-transcript-policy-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-audit-event-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/chat-error-taxonomy-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-surface-preview.sh --model gemma3n-e4b --target kv260
 bash scripts/launch-stub.sh --dry-run
 bash scripts/chat-stub.sh --dry-run --prompt "hello"
@@ -306,26 +309,31 @@ python3 contracts/chat_session_contract.py --model gemma3n-e4b --target kv260
 python3 contracts/chat_model_status_contract.py --model gemma3n-e4b --target kv260
 python3 contracts/chat_readiness_contract.py --model gemma3n-e4b --target kv260
 python3 contracts/chat_audit_event_contract.py --model gemma3n-e4b --target kv260
+python3 contracts/chat_error_taxonomy_contract.py --model gemma3n-e4b --target kv260
 bash scripts/chat-model-status-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-session-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-session-lifecycle-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-readiness-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-audit-event-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/chat-error-taxonomy-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-surface-preview.sh --model gemma3n-e4b --target kv260
 bash scripts/status-stub.sh --include-chat-model-status
 bash scripts/status-stub.sh --include-chat-session
 bash scripts/status-stub.sh --include-chat-readiness
 bash scripts/status-stub.sh --include-chat-audit-event
+bash scripts/status-stub.sh --include-chat-error-taxonomy
 python3 scripts/tests/chat_session_contract_test.py
 python3 scripts/tests/chat_model_status_contract_test.py
 python3 scripts/tests/chat_session_lifecycle_contract_test.py
 python3 scripts/tests/chat_readiness_contract_test.py
 python3 scripts/tests/chat_audit_event_contract_test.py
+python3 scripts/tests/chat_error_taxonomy_contract_test.py
 python3 scripts/tests/chat_surface_preview_test.py
 bash scripts/tests/status-chat-model-status.sh
 bash scripts/tests/status-chat-session.sh
 bash scripts/tests/status-chat-readiness.sh
 bash scripts/tests/status-chat-audit-event.sh
+bash scripts/tests/status-chat-error-taxonomy.sh
 ```
 
 The checked chat/session fixture reports the chat surface as blocked,
@@ -358,6 +366,13 @@ future chat UI audit summaries. It records event ids, states, blocked
 reason ids, redaction policy, and fixture references without prompt,
 response, transcript, actor, path, model, runtime, raw log, or artifact
 content. Audit logging and persistence remain disabled and not configured.
+
+The chat error taxonomy fixture groups blocked chat error categories for
+future banners, status rows, and recovery affordances. It summarizes
+readiness blockers, model/runtime blockers, session/policy blockers, and
+local-only/provider policy metadata without reading prompts, responses,
+transcripts, configs, provider settings, model paths, logs, session stores,
+or artifacts.
 
 The preview command renders that same contract as a deterministic
 terminal chat surface sketch with disabled controls, blocked reasons, and

--- a/contracts/chat_error_taxonomy_contract.py
+++ b/contracts/chat_error_taxonomy_contract.py
@@ -1,0 +1,419 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Data-only chat error taxonomy contract for the planned launcher UI.
+
+The contract describes grouped, user-visible blocked error categories for the
+local chat surface. It does not read prompts, responses, transcripts, config,
+provider settings, environment variables, secrets, tokens, model assets,
+session stores, logs, or artifacts; it does not start runtime code, load
+models, touch KV260 hardware, call providers, invoke pccx-lab, or persist
+anything.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import sys
+
+
+SCHEMA_VERSION = "pccx.chatErrorTaxonomy.v0"
+
+CHAT_ERROR_TAXONOMY_FIELDS = (
+    "schemaVersion",
+    "taxonomyId",
+    "fixtureVersion",
+    "lastUpdatedSource",
+    "targetDevice",
+    "targetBoard",
+    "targetModel",
+    "taxonomyState",
+    "displayState",
+    "inputContentState",
+    "runtimeState",
+    "chatReadinessRef",
+    "chatSendResultRef",
+    "chatComposerRef",
+    "chatAuditEventRef",
+    "chatLocalOnlyPolicyRef",
+    "errorGroups",
+    "errorItems",
+    "actionRefs",
+    "handoffRefs",
+    "safetyFlags",
+    "limitations",
+    "issueRefs",
+)
+
+ERROR_GROUP_FIELDS = (
+    "groupId",
+    "label",
+    "state",
+    "severity",
+    "sourceRefs",
+    "displayPolicy",
+    "contentPolicy",
+)
+
+ERROR_ITEM_FIELDS = (
+    "itemId",
+    "groupId",
+    "state",
+    "severity",
+    "userMessage",
+    "diagnosticHint",
+    "primaryActionRef",
+    "sourceErrorRefs",
+    "contentPolicy",
+)
+
+ACTION_REF_FIELDS = (
+    "actionId",
+    "label",
+    "state",
+    "enabled",
+    "sourceRef",
+    "sideEffectPolicy",
+)
+
+HANDOFF_REF_FIELDS = (
+    "refId",
+    "schemaVersion",
+    "fixturePath",
+    "state",
+    "summary",
+)
+
+CHAT_ERROR_TAXONOMY_STATE_VALUES = (
+    "available_as_data",
+    "blocked",
+    "disabled",
+    "external_not_configured",
+    "inactive",
+    "not_configured",
+    "not_loaded",
+    "not_started",
+    "not_used",
+    "planned",
+    "requires_evidence",
+    "summary_only",
+    "unavailable",
+)
+
+_CHAT_ERROR_TAXONOMY = {
+    "schemaVersion": SCHEMA_VERSION,
+    "taxonomyId": "chat_error_taxonomy_gemma3n_e4b_kv260_placeholder",
+    "fixtureVersion": "chat-error-taxonomy.gemma3n-e4b-kv260.2026-05-04",
+    "lastUpdatedSource": "pccx_launcher_issue_9_chat_error_taxonomy_boundary_2026-05-04",
+    "targetDevice": "kv260",
+    "targetBoard": "xilinx_kria_kv260",
+    "targetModel": "gemma3n-e4b",
+    "taxonomyState": "available_as_data",
+    "displayState": "summary_only",
+    "inputContentState": "unavailable",
+    "runtimeState": "not_started",
+    "chatReadinessRef": "chat_readiness_gemma3n_e4b_kv260_placeholder",
+    "chatSendResultRef": "chat_send_result_gemma3n_e4b_kv260_placeholder",
+    "chatComposerRef": "chat_composer_gemma3n_e4b_kv260_placeholder",
+    "chatAuditEventRef": "chat_audit_event_gemma3n_e4b_kv260_placeholder",
+    "chatLocalOnlyPolicyRef": "chat_local_only_policy_gemma3n_e4b_kv260_placeholder",
+    "errorGroups": [
+        {
+            "groupId": "readiness_blockers",
+            "label": "readiness blockers",
+            "state": "blocked",
+            "severity": "blocked",
+            "sourceRefs": [
+                "chat_readiness",
+                "runtime_readiness",
+                "device_session_status",
+            ],
+            "displayPolicy": "show concise blocked status rows only",
+            "contentPolicy": "no_prompt_response_transcript_or_log_content",
+        },
+        {
+            "groupId": "model_and_runtime_blockers",
+            "label": "model and runtime blockers",
+            "state": "requires_evidence",
+            "severity": "blocked",
+            "sourceRefs": [
+                "chat_model_status",
+                "runtime_readiness",
+            ],
+            "displayPolicy": "show evidence requirements without model paths",
+            "contentPolicy": "no_model_path_weight_or_runtime_log_content",
+        },
+        {
+            "groupId": "session_and_policy_blockers",
+            "label": "session and policy blockers",
+            "state": "not_configured",
+            "severity": "blocked",
+            "sourceRefs": [
+                "chat_session_index",
+                "chat_transcript_policy",
+                "chat_local_only_policy",
+            ],
+            "displayPolicy": "show policy summaries without reading stores",
+            "contentPolicy": "no_session_store_title_summary_or_path_content",
+        },
+    ],
+    "errorItems": [
+        {
+            "itemId": "send_disabled_by_readiness",
+            "groupId": "readiness_blockers",
+            "state": "blocked",
+            "severity": "blocked",
+            "userMessage": "Send stays disabled until local chat readiness evidence exists.",
+            "diagnosticHint": "Review the chat readiness and blocked send-result fixtures.",
+            "primaryActionRef": "review_chat_readiness",
+            "sourceErrorRefs": [
+                "runtime_not_ready",
+                "readiness_blocked",
+            ],
+            "contentPolicy": "no_prompt_response_or_transcript_content",
+        },
+        {
+            "itemId": "model_assets_not_configured",
+            "groupId": "model_and_runtime_blockers",
+            "state": "external_not_configured",
+            "severity": "blocked",
+            "userMessage": "Model assets are not configured by this fixture.",
+            "diagnosticHint": "A future reviewed asset input boundary must redact local paths.",
+            "primaryActionRef": "wait_for_asset_boundary",
+            "sourceErrorRefs": [
+                "model_assets_missing",
+                "model_not_loaded",
+            ],
+            "contentPolicy": "no_model_paths_or_weight_names",
+        },
+        {
+            "itemId": "runtime_not_started",
+            "groupId": "model_and_runtime_blockers",
+            "state": "not_started",
+            "severity": "blocked",
+            "userMessage": "No local chat runtime is available for responses.",
+            "diagnosticHint": "Runtime execution requires a separate reviewed implementation boundary.",
+            "primaryActionRef": "wait_for_runtime_boundary",
+            "sourceErrorRefs": [
+                "chat_runtime_absent",
+                "runtime_not_started",
+            ],
+            "contentPolicy": "no_generated_response_content",
+        },
+        {
+            "itemId": "session_store_not_configured",
+            "groupId": "session_and_policy_blockers",
+            "state": "not_configured",
+            "severity": "blocked",
+            "userMessage": "Session restore, transcript retention, and export are unavailable.",
+            "diagnosticHint": "A future local session store must define retention and redaction rules.",
+            "primaryActionRef": "review_session_policy",
+            "sourceErrorRefs": [
+                "session_store_absent",
+                "session_store_not_configured",
+            ],
+            "contentPolicy": "no_manifest_transcript_summary_or_path_content",
+        },
+        {
+            "itemId": "provider_paths_not_used",
+            "groupId": "session_and_policy_blockers",
+            "state": "not_used",
+            "severity": "info",
+            "userMessage": "External provider paths are not used for core local chat.",
+            "diagnosticHint": "Local-only policy remains display data and does not read provider configuration.",
+            "primaryActionRef": "review_local_only_policy",
+            "sourceErrorRefs": [
+                "provider_mode",
+                "provider_and_network_paths_blocked",
+            ],
+            "contentPolicy": "no_provider_configuration_or_prompt_content",
+        },
+    ],
+    "actionRefs": [
+        {
+            "actionId": "review_chat_readiness",
+            "label": "review chat readiness",
+            "state": "available_as_data",
+            "enabled": False,
+            "sourceRef": "chat_readiness",
+            "sideEffectPolicy": "read_only_data",
+        },
+        {
+            "actionId": "wait_for_asset_boundary",
+            "label": "wait for asset boundary",
+            "state": "requires_evidence",
+            "enabled": False,
+            "sourceRef": "chat_model_status",
+            "sideEffectPolicy": "no_model_asset_read",
+        },
+        {
+            "actionId": "wait_for_runtime_boundary",
+            "label": "wait for runtime boundary",
+            "state": "requires_evidence",
+            "enabled": False,
+            "sourceRef": "runtime_readiness",
+            "sideEffectPolicy": "no_runtime_execution",
+        },
+        {
+            "actionId": "review_session_policy",
+            "label": "review session policy",
+            "state": "planned",
+            "enabled": False,
+            "sourceRef": "chat_transcript_policy",
+            "sideEffectPolicy": "no_artifact_read_no_write",
+        },
+        {
+            "actionId": "review_local_only_policy",
+            "label": "review local-only policy",
+            "state": "available_as_data",
+            "enabled": False,
+            "sourceRef": "chat_local_only_policy",
+            "sideEffectPolicy": "no_provider_or_network_call",
+        },
+    ],
+    "handoffRefs": [
+        {
+            "refId": "chat_readiness",
+            "schemaVersion": "pccx.chatReadiness.v0",
+            "fixturePath": "contracts/fixtures/chat-readiness.gemma3n-e4b-kv260-placeholder.json",
+            "state": "blocked",
+            "summary": "Readiness checks and recovery actions remain local data only.",
+        },
+        {
+            "refId": "chat_send_result",
+            "schemaVersion": "pccx.chatSendResult.v0",
+            "fixturePath": "contracts/fixtures/chat-send-result.gemma3n-e4b-kv260-placeholder.json",
+            "state": "blocked",
+            "summary": "Send result stays blocked with no accepted input.",
+        },
+        {
+            "refId": "chat_model_status",
+            "schemaVersion": "pccx.chatModelStatus.v0",
+            "fixturePath": "contracts/fixtures/chat-model-status.gemma3n-e4b-kv260-placeholder.json",
+            "state": "available_as_data",
+            "summary": "Model status display is consumed without model paths.",
+        },
+        {
+            "refId": "chat_transcript_policy",
+            "schemaVersion": "pccx.chatTranscriptPolicy.v0",
+            "fixturePath": "contracts/fixtures/chat-transcript-policy.gemma3n-e4b-kv260-placeholder.json",
+            "state": "blocked",
+            "summary": "Transcript retention and export remain disabled.",
+        },
+        {
+            "refId": "chat_local_only_policy",
+            "schemaVersion": "pccx.chatLocalOnlyPolicy.v0",
+            "fixturePath": "contracts/fixtures/chat-local-only-policy.gemma3n-e4b-kv260-placeholder.json",
+            "state": "available_as_data",
+            "summary": "Local-only policy is consumed as summary data only.",
+        },
+    ],
+    "safetyFlags": {
+        "readOnly": True,
+        "dataOnly": True,
+        "deterministic": True,
+        "taxonomyDisplayOnly": True,
+        "writesArtifacts": False,
+        "readsArtifacts": False,
+        "promptCapture": False,
+        "promptContentIncluded": False,
+        "promptEchoed": False,
+        "promptPersistence": False,
+        "inputAccepted": False,
+        "responseContentIncluded": False,
+        "responseGenerated": False,
+        "transcriptContentIncluded": False,
+        "transcriptPersistence": False,
+        "sessionStoreRead": False,
+        "sessionStoreWrite": False,
+        "sessionTitleIncluded": False,
+        "summaryIncluded": False,
+        "configRead": False,
+        "environmentRead": False,
+        "secretsRead": False,
+        "tokensRead": False,
+        "providerConfigRead": False,
+        "providerCalls": False,
+        "cloudCalls": False,
+        "networkCalls": False,
+        "modelAssetRead": False,
+        "modelPathIncluded": False,
+        "modelWeightPathsIncluded": False,
+        "modelLoadAttempted": False,
+        "modelLoaded": False,
+        "modelExecution": False,
+        "runtimeExecution": False,
+        "kv260Access": False,
+        "hardwareAccess": False,
+        "opensSerialPort": False,
+        "networkScan": False,
+        "sshExecution": False,
+        "privatePathIncluded": False,
+        "rawLogIncluded": False,
+        "hardwareDumpsIncluded": False,
+        "generatedBlobsIncluded": False,
+        "telemetry": False,
+        "upload": False,
+        "writeBack": False,
+        "executesPccxLab": False,
+        "executesSystemverilogIde": False,
+        "compatibilityClaim": False,
+    },
+    "limitations": [
+        "error taxonomy is deterministic fixture data only",
+        "error groups summarize blocked local chat states without reading prompts, responses, transcripts, logs, paths, or artifacts",
+        "model assets, provider configuration, environment secrets, tokens, and network paths are not read",
+        "no recovery action, runtime launch, model load, provider call, hardware probe, preference write, or artifact read/write is performed",
+        "no compatibility promise is made",
+    ],
+    "issueRefs": [
+        "pccxai/pccx-llm-launcher#9",
+    ],
+}
+
+
+def create_gemma3n_e4b_kv260_chat_error_taxonomy() -> dict:
+    """Return the checked Gemma 3N E4B plus KV260 chat error taxonomy fixture."""
+    return copy.deepcopy(_CHAT_ERROR_TAXONOMY)
+
+
+def chat_error_taxonomy_json(taxonomy: dict | None = None) -> str:
+    """Render a deterministic JSON representation."""
+    return json.dumps(
+        taxonomy
+        if taxonomy is not None
+        else create_gemma3n_e4b_kv260_chat_error_taxonomy(),
+        indent=2,
+        sort_keys=True,
+    ) + "\n"
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Print data-only chat error taxonomy JSON.",
+    )
+    parser.add_argument(
+        "--model",
+        default="gemma3n-e4b",
+        choices=("gemma3n-e4b",),
+        help="model descriptor target",
+    )
+    parser.add_argument(
+        "--target",
+        default="kv260",
+        choices=("kv260",),
+        help="target board/device",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parse_args(sys.argv[1:] if argv is None else argv)
+    sys.stdout.write(chat_error_taxonomy_json())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contracts/fixtures/chat-error-taxonomy.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-error-taxonomy.gemma3n-e4b-kv260-placeholder.json
@@ -1,0 +1,270 @@
+{
+  "actionRefs": [
+    {
+      "actionId": "review_chat_readiness",
+      "enabled": false,
+      "label": "review chat readiness",
+      "sideEffectPolicy": "read_only_data",
+      "sourceRef": "chat_readiness",
+      "state": "available_as_data"
+    },
+    {
+      "actionId": "wait_for_asset_boundary",
+      "enabled": false,
+      "label": "wait for asset boundary",
+      "sideEffectPolicy": "no_model_asset_read",
+      "sourceRef": "chat_model_status",
+      "state": "requires_evidence"
+    },
+    {
+      "actionId": "wait_for_runtime_boundary",
+      "enabled": false,
+      "label": "wait for runtime boundary",
+      "sideEffectPolicy": "no_runtime_execution",
+      "sourceRef": "runtime_readiness",
+      "state": "requires_evidence"
+    },
+    {
+      "actionId": "review_session_policy",
+      "enabled": false,
+      "label": "review session policy",
+      "sideEffectPolicy": "no_artifact_read_no_write",
+      "sourceRef": "chat_transcript_policy",
+      "state": "planned"
+    },
+    {
+      "actionId": "review_local_only_policy",
+      "enabled": false,
+      "label": "review local-only policy",
+      "sideEffectPolicy": "no_provider_or_network_call",
+      "sourceRef": "chat_local_only_policy",
+      "state": "available_as_data"
+    }
+  ],
+  "chatAuditEventRef": "chat_audit_event_gemma3n_e4b_kv260_placeholder",
+  "chatComposerRef": "chat_composer_gemma3n_e4b_kv260_placeholder",
+  "chatLocalOnlyPolicyRef": "chat_local_only_policy_gemma3n_e4b_kv260_placeholder",
+  "chatReadinessRef": "chat_readiness_gemma3n_e4b_kv260_placeholder",
+  "chatSendResultRef": "chat_send_result_gemma3n_e4b_kv260_placeholder",
+  "displayState": "summary_only",
+  "errorGroups": [
+    {
+      "contentPolicy": "no_prompt_response_transcript_or_log_content",
+      "displayPolicy": "show concise blocked status rows only",
+      "groupId": "readiness_blockers",
+      "label": "readiness blockers",
+      "severity": "blocked",
+      "sourceRefs": [
+        "chat_readiness",
+        "runtime_readiness",
+        "device_session_status"
+      ],
+      "state": "blocked"
+    },
+    {
+      "contentPolicy": "no_model_path_weight_or_runtime_log_content",
+      "displayPolicy": "show evidence requirements without model paths",
+      "groupId": "model_and_runtime_blockers",
+      "label": "model and runtime blockers",
+      "severity": "blocked",
+      "sourceRefs": [
+        "chat_model_status",
+        "runtime_readiness"
+      ],
+      "state": "requires_evidence"
+    },
+    {
+      "contentPolicy": "no_session_store_title_summary_or_path_content",
+      "displayPolicy": "show policy summaries without reading stores",
+      "groupId": "session_and_policy_blockers",
+      "label": "session and policy blockers",
+      "severity": "blocked",
+      "sourceRefs": [
+        "chat_session_index",
+        "chat_transcript_policy",
+        "chat_local_only_policy"
+      ],
+      "state": "not_configured"
+    }
+  ],
+  "errorItems": [
+    {
+      "contentPolicy": "no_prompt_response_or_transcript_content",
+      "diagnosticHint": "Review the chat readiness and blocked send-result fixtures.",
+      "groupId": "readiness_blockers",
+      "itemId": "send_disabled_by_readiness",
+      "primaryActionRef": "review_chat_readiness",
+      "severity": "blocked",
+      "sourceErrorRefs": [
+        "runtime_not_ready",
+        "readiness_blocked"
+      ],
+      "state": "blocked",
+      "userMessage": "Send stays disabled until local chat readiness evidence exists."
+    },
+    {
+      "contentPolicy": "no_model_paths_or_weight_names",
+      "diagnosticHint": "A future reviewed asset input boundary must redact local paths.",
+      "groupId": "model_and_runtime_blockers",
+      "itemId": "model_assets_not_configured",
+      "primaryActionRef": "wait_for_asset_boundary",
+      "severity": "blocked",
+      "sourceErrorRefs": [
+        "model_assets_missing",
+        "model_not_loaded"
+      ],
+      "state": "external_not_configured",
+      "userMessage": "Model assets are not configured by this fixture."
+    },
+    {
+      "contentPolicy": "no_generated_response_content",
+      "diagnosticHint": "Runtime execution requires a separate reviewed implementation boundary.",
+      "groupId": "model_and_runtime_blockers",
+      "itemId": "runtime_not_started",
+      "primaryActionRef": "wait_for_runtime_boundary",
+      "severity": "blocked",
+      "sourceErrorRefs": [
+        "chat_runtime_absent",
+        "runtime_not_started"
+      ],
+      "state": "not_started",
+      "userMessage": "No local chat runtime is available for responses."
+    },
+    {
+      "contentPolicy": "no_manifest_transcript_summary_or_path_content",
+      "diagnosticHint": "A future local session store must define retention and redaction rules.",
+      "groupId": "session_and_policy_blockers",
+      "itemId": "session_store_not_configured",
+      "primaryActionRef": "review_session_policy",
+      "severity": "blocked",
+      "sourceErrorRefs": [
+        "session_store_absent",
+        "session_store_not_configured"
+      ],
+      "state": "not_configured",
+      "userMessage": "Session restore, transcript retention, and export are unavailable."
+    },
+    {
+      "contentPolicy": "no_provider_configuration_or_prompt_content",
+      "diagnosticHint": "Local-only policy remains display data and does not read provider configuration.",
+      "groupId": "session_and_policy_blockers",
+      "itemId": "provider_paths_not_used",
+      "primaryActionRef": "review_local_only_policy",
+      "severity": "info",
+      "sourceErrorRefs": [
+        "provider_mode",
+        "provider_and_network_paths_blocked"
+      ],
+      "state": "not_used",
+      "userMessage": "External provider paths are not used for core local chat."
+    }
+  ],
+  "fixtureVersion": "chat-error-taxonomy.gemma3n-e4b-kv260.2026-05-04",
+  "handoffRefs": [
+    {
+      "fixturePath": "contracts/fixtures/chat-readiness.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_readiness",
+      "schemaVersion": "pccx.chatReadiness.v0",
+      "state": "blocked",
+      "summary": "Readiness checks and recovery actions remain local data only."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-send-result.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_send_result",
+      "schemaVersion": "pccx.chatSendResult.v0",
+      "state": "blocked",
+      "summary": "Send result stays blocked with no accepted input."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-model-status.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_model_status",
+      "schemaVersion": "pccx.chatModelStatus.v0",
+      "state": "available_as_data",
+      "summary": "Model status display is consumed without model paths."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-transcript-policy.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_transcript_policy",
+      "schemaVersion": "pccx.chatTranscriptPolicy.v0",
+      "state": "blocked",
+      "summary": "Transcript retention and export remain disabled."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-local-only-policy.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_local_only_policy",
+      "schemaVersion": "pccx.chatLocalOnlyPolicy.v0",
+      "state": "available_as_data",
+      "summary": "Local-only policy is consumed as summary data only."
+    }
+  ],
+  "inputContentState": "unavailable",
+  "issueRefs": [
+    "pccxai/pccx-llm-launcher#9"
+  ],
+  "lastUpdatedSource": "pccx_launcher_issue_9_chat_error_taxonomy_boundary_2026-05-04",
+  "limitations": [
+    "error taxonomy is deterministic fixture data only",
+    "error groups summarize blocked local chat states without reading prompts, responses, transcripts, logs, paths, or artifacts",
+    "model assets, provider configuration, environment secrets, tokens, and network paths are not read",
+    "no recovery action, runtime launch, model load, provider call, hardware probe, preference write, or artifact read/write is performed",
+    "no compatibility promise is made"
+  ],
+  "runtimeState": "not_started",
+  "safetyFlags": {
+    "cloudCalls": false,
+    "compatibilityClaim": false,
+    "configRead": false,
+    "dataOnly": true,
+    "deterministic": true,
+    "environmentRead": false,
+    "executesPccxLab": false,
+    "executesSystemverilogIde": false,
+    "generatedBlobsIncluded": false,
+    "hardwareAccess": false,
+    "hardwareDumpsIncluded": false,
+    "inputAccepted": false,
+    "kv260Access": false,
+    "modelAssetRead": false,
+    "modelExecution": false,
+    "modelLoadAttempted": false,
+    "modelLoaded": false,
+    "modelPathIncluded": false,
+    "modelWeightPathsIncluded": false,
+    "networkCalls": false,
+    "networkScan": false,
+    "opensSerialPort": false,
+    "privatePathIncluded": false,
+    "promptCapture": false,
+    "promptContentIncluded": false,
+    "promptEchoed": false,
+    "promptPersistence": false,
+    "providerCalls": false,
+    "providerConfigRead": false,
+    "rawLogIncluded": false,
+    "readOnly": true,
+    "readsArtifacts": false,
+    "responseContentIncluded": false,
+    "responseGenerated": false,
+    "runtimeExecution": false,
+    "secretsRead": false,
+    "sessionStoreRead": false,
+    "sessionStoreWrite": false,
+    "sessionTitleIncluded": false,
+    "sshExecution": false,
+    "summaryIncluded": false,
+    "taxonomyDisplayOnly": true,
+    "telemetry": false,
+    "tokensRead": false,
+    "transcriptContentIncluded": false,
+    "transcriptPersistence": false,
+    "upload": false,
+    "writeBack": false,
+    "writesArtifacts": false
+  },
+  "schemaVersion": "pccx.chatErrorTaxonomy.v0",
+  "targetBoard": "xilinx_kria_kv260",
+  "targetDevice": "kv260",
+  "targetModel": "gemma3n-e4b",
+  "taxonomyId": "chat_error_taxonomy_gemma3n_e4b_kv260_placeholder",
+  "taxonomyState": "available_as_data"
+}

--- a/docs/STANDALONE_CHAT_SESSION_CONTRACT.md
+++ b/docs/STANDALONE_CHAT_SESSION_CONTRACT.md
@@ -20,6 +20,7 @@ The implementation lives in:
 - `contracts/chat_send_result_contract.py`
 - `contracts/chat_transcript_policy_contract.py`
 - `contracts/chat_audit_event_contract.py`
+- `contracts/chat_error_taxonomy_contract.py`
 - `contracts/fixtures/chat-session.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-model-status.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-session-lifecycle.gemma3n-e4b-kv260-placeholder.json`
@@ -32,6 +33,7 @@ The implementation lives in:
 - `contracts/fixtures/chat-send-result.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-transcript-policy.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-audit-event.gemma3n-e4b-kv260-placeholder.json`
+- `contracts/fixtures/chat-error-taxonomy.gemma3n-e4b-kv260-placeholder.json`
 - `scripts/chat-session-stub.sh`
 - `scripts/chat-model-status-stub.sh`
 - `scripts/chat-session-lifecycle-stub.sh`
@@ -44,6 +46,7 @@ The implementation lives in:
 - `scripts/chat-send-result-stub.sh`
 - `scripts/chat-transcript-policy-stub.sh`
 - `scripts/chat-audit-event-stub.sh`
+- `scripts/chat-error-taxonomy-stub.sh`
 - `scripts/chat-surface-preview.sh`
 - `scripts/tests/chat_session_contract_test.py`
 - `scripts/tests/chat_model_status_contract_test.py`
@@ -57,6 +60,7 @@ The implementation lives in:
 - `scripts/tests/chat_send_result_contract_test.py`
 - `scripts/tests/chat_transcript_policy_contract_test.py`
 - `scripts/tests/chat_audit_event_contract_test.py`
+- `scripts/tests/chat_error_taxonomy_contract_test.py`
 - `scripts/tests/chat_surface_preview_test.py`
 - `scripts/tests/status-chat-model-status.sh`
 - `scripts/tests/status-chat-surface-layout.sh`
@@ -68,6 +72,7 @@ The implementation lives in:
 - `scripts/tests/status-chat-send-result.sh`
 - `scripts/tests/status-chat-transcript-policy.sh`
 - `scripts/tests/status-chat-audit-event.sh`
+- `scripts/tests/status-chat-error-taxonomy.sh`
 
 ## What Is Implemented
 
@@ -91,6 +96,7 @@ The chat/session contract records:
 - blocked reasons that explain what must exist before send controls can
   be enabled
 - safety flags for the read-only boundary
+- grouped chat error taxonomy metadata for future banners and status rows
 
 The checked fixture is deterministic JSON. The stub command prints that
 JSON for the supported model and target pair:
@@ -257,6 +263,21 @@ runtime trace, raw log, model path, private path, or artifact content is
 read, logged, exported, stored, or persisted. Audit logging and local
 audit history remain disabled and not configured.
 
+The chat error taxonomy fixture records grouped blocked error metadata
+for future chat banners, status rows, and recovery affordances:
+
+```bash
+bash scripts/chat-error-taxonomy-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/status-stub.sh --include-chat-error-taxonomy
+```
+
+It summarizes readiness blockers, model/runtime blockers, session and
+policy blockers, and local-only/provider policy metadata as deterministic
+data. It does not read prompts, responses, transcripts, configuration
+files, provider settings, environment values, secrets, tokens, model
+asset paths, session-store paths, logs, or artifacts. Recovery actions
+remain disabled and side-effect-free.
+
 The terminal preview command renders the same checked contract as a
 read-only chat surface sketch:
 
@@ -413,6 +434,25 @@ message content, identity data, runtime traces, and persistence:
 - `target_selected`: planned target identity can be displayed as local
   data only
 
+The error-taxonomy states keep user-visible error grouping separate from
+runtime execution, provider state, local stores, and message content:
+
+- `available_as_data`: checked taxonomy data is available without
+  executing anything
+- `blocked`: a required readiness or execution boundary is missing
+- `disabled`: a referenced action remains intentionally unavailable
+- `external_not_configured`: user-provided model assets are not
+  configured
+- `inactive`: no runtime or target session exists
+- `not_configured`: no local session store or policy boundary exists
+- `not_loaded`: model assets are not loaded
+- `not_started`: no local chat runtime has started
+- `not_used`: provider paths are not part of core local chat
+- `planned`: described for a future reviewed boundary
+- `requires_evidence`: future enablement requires evidence first
+- `summary_only`: display data excludes raw content and private paths
+- `unavailable`: input content is not read or captured
+
 ## Coordination Boundary
 
 The standalone chat surface depends on the existing launcher model
@@ -445,6 +485,11 @@ without prompt capture, prompt echo, response content, transcript
 content, actor identifiers, runtime traces, audit persistence, artifact
 reads, artifact writes, runtime execution, model loading, provider
 calls, or target access.
+The error taxonomy contract adds a reviewable grouped error-display shape
+without prompt capture, response content, transcript content, provider
+configuration reads, model asset reads, session-store reads, artifact
+reads, artifact writes, runtime execution, model loading, provider calls,
+or target access.
 
 pccx-lab remains a separate CLI/core diagnostics and verification
 backend. systemverilog-ide may consume launcher data later as read-only
@@ -464,6 +509,8 @@ This chat/session surface does not add:
   transcript summaries, or transcript message content
 - audit logging, audit persistence, actor identifiers, event timestamps,
   runtime traces, raw logs, or audit export behavior
+- error recovery execution, provider/config reads, model asset reads, or
+  taxonomy persistence
 - session creation, restore, clear, close, or export behavior
 - readiness recovery execution
 - manifest, transcript, summary, or lifecycle artifact reads or writes

--- a/scripts/chat-error-taxonomy-stub.sh
+++ b/scripts/chat-error-taxonomy-stub.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+# Print the data-only chat error taxonomy contract.
+
+set -eu
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+
+python3 "$ROOT_DIR/contracts/chat_error_taxonomy_contract.py" "$@"

--- a/scripts/status-stub.sh
+++ b/scripts/status-stub.sh
@@ -43,6 +43,9 @@
 # Chat audit-event metadata boundary (explicit opt-in, read-only local data):
 #   --include-chat-audit-event
 #
+# Chat error taxonomy display boundary (explicit opt-in, read-only local data):
+#   --include-chat-error-taxonomy
+#
 # pccx-lab backend (explicit opt-in):
 #   --backend pccx-lab        call pccx-lab status --format json
 #   PCCX_LAB_BIN              override path to pccx-lab binary (takes priority over PATH)
@@ -71,6 +74,101 @@ INCLUDE_CHAT_COMPOSER="0"
 INCLUDE_CHAT_SEND_RESULT="0"
 INCLUDE_CHAT_TRANSCRIPT_POLICY="0"
 INCLUDE_CHAT_AUDIT_EVENT="0"
+INCLUDE_CHAT_ERROR_TAXONOMY="0"
+
+print_chat_error_taxonomy_summary() {
+    SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+    ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+    CHAT_ERROR_TAXONOMY_STUB="$ROOT_DIR/scripts/chat-error-taxonomy-stub.sh"
+
+    if [ ! -f "$CHAT_ERROR_TAXONOMY_STUB" ]; then
+        ERROR "chat error taxonomy stub not found: $CHAT_ERROR_TAXONOMY_STUB"
+        return 1
+    fi
+
+    if ! CHAT_ERROR_TAXONOMY_JSON="$(bash "$CHAT_ERROR_TAXONOMY_STUB" --model gemma3n-e4b --target kv260 2>&1)"; then
+        ERROR "chat error taxonomy stub failed"
+        printf '%s\n' "$CHAT_ERROR_TAXONOMY_JSON" >&2
+        return 1
+    fi
+
+    if ! CHAT_ERROR_TAXONOMY_SUMMARY="$(
+        printf '%s\n' "$CHAT_ERROR_TAXONOMY_JSON" | python3 -c '
+import json
+import sys
+
+data = json.load(sys.stdin)
+flags = data["safetyFlags"]
+groups = " ".join(
+    "{}={}".format(group["groupId"], group["state"])
+    for group in data["errorGroups"]
+)
+items = " ".join(
+    "{}={}".format(item["itemId"], item["state"])
+    for item in data["errorItems"]
+)
+actions = " ".join(
+    "{}={}".format(action["actionId"], action["state"])
+    for action in data["actionRefs"]
+)
+
+def b(value):
+    return "true" if value else "false"
+
+print("[INFO]  source     : scripts/chat-error-taxonomy-stub.sh --model gemma3n-e4b --target kv260")
+print("[INFO]  boundary   : read-only data; no prompt/provider/model/runtime/hardware/lab/IDE execution")
+print("[INFO]  target     : {}".format(data["targetDevice"]))
+print("[INFO]  model      : {}".format(data["targetModel"]))
+print("[INFO]  taxonomy   : {}".format(data["taxonomyState"]))
+print("[INFO]  display    : {}".format(data["displayState"]))
+print("[INFO]  input      : {}".format(data["inputContentState"]))
+print("[INFO]  runtime    : {}".format(data["runtimeState"]))
+print("[INFO]  groups     : {}".format(groups))
+print("[INFO]  items      : {}".format(items))
+print("[INFO]  actions    : {}".format(actions))
+print(
+    "[INFO]  flags      : readOnly={} dataOnly={} deterministic={} "
+    "taxonomyDisplayOnly={} promptContentIncluded={} "
+    "responseContentIncluded={} transcriptContentIncluded={} "
+    "sessionStoreRead={} configRead={} providerConfigRead={} "
+    "providerCalls={} cloudCalls={} networkCalls={} modelAssetRead={} "
+    "modelLoadAttempted={} modelExecution={} runtimeExecution={} "
+    "kv260Access={} hardwareAccess={} readsArtifacts={} "
+    "writesArtifacts={} executesPccxLab={} executesSystemverilogIde={}".format(
+        b(flags["readOnly"]),
+        b(flags["dataOnly"]),
+        b(flags["deterministic"]),
+        b(flags["taxonomyDisplayOnly"]),
+        b(flags["promptContentIncluded"]),
+        b(flags["responseContentIncluded"]),
+        b(flags["transcriptContentIncluded"]),
+        b(flags["sessionStoreRead"]),
+        b(flags["configRead"]),
+        b(flags["providerConfigRead"]),
+        b(flags["providerCalls"]),
+        b(flags["cloudCalls"]),
+        b(flags["networkCalls"]),
+        b(flags["modelAssetRead"]),
+        b(flags["modelLoadAttempted"]),
+        b(flags["modelExecution"]),
+        b(flags["runtimeExecution"]),
+        b(flags["kv260Access"]),
+        b(flags["hardwareAccess"]),
+        b(flags["readsArtifacts"]),
+        b(flags["writesArtifacts"]),
+        b(flags["executesPccxLab"]),
+        b(flags["executesSystemverilogIde"]),
+    )
+)
+'
+    )"; then
+        ERROR "chat error taxonomy JSON could not be summarized"
+        return 1
+    fi
+
+    HEAD "chat error taxonomy"
+    printf '%s\n' "$CHAT_ERROR_TAXONOMY_SUMMARY"
+}
 
 print_chat_local_only_policy_summary() {
     SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
@@ -1459,6 +1557,10 @@ while [ $# -gt 0 ]; do
             INCLUDE_CHAT_AUDIT_EVENT="1"
             shift
             ;;
+        --include-chat-error-taxonomy)
+            INCLUDE_CHAT_ERROR_TAXONOMY="1"
+            shift
+            ;;
         --backend)
             BACKEND="${2:-}"
             if [ -z "$BACKEND" ]; then
@@ -1474,8 +1576,8 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-if [ -n "$BACKEND" ] && { [ "$INCLUDE_RUNTIME_READINESS" = "1" ] || [ "$INCLUDE_DEVICE_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SURFACE_LAYOUT" = "1" ] || [ "$INCLUDE_CHAT_LOCAL_ONLY_POLICY" = "1" ] || [ "$INCLUDE_CHAT_PREFERENCES" = "1" ] || [ "$INCLUDE_CHAT_SESSION_INDEX" = "1" ] || [ "$INCLUDE_CHAT_MODEL_STATUS" = "1" ] || [ "$INCLUDE_CHAT_READINESS" = "1" ] || [ "$INCLUDE_CHAT_COMPOSER" = "1" ] || [ "$INCLUDE_CHAT_SEND_RESULT" = "1" ] || [ "$INCLUDE_CHAT_TRANSCRIPT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_AUDIT_EVENT" = "1" ]; }; then
-    ERROR "--include-runtime-readiness, --include-device-session, --include-chat-session, --include-chat-surface-layout, --include-chat-local-only-policy, --include-chat-preferences, --include-chat-session-index, --include-chat-model-status, --include-chat-readiness, --include-chat-composer, --include-chat-send-result, --include-chat-transcript-policy, and --include-chat-audit-event are only supported in local scaffold mode"
+if [ -n "$BACKEND" ] && { [ "$INCLUDE_RUNTIME_READINESS" = "1" ] || [ "$INCLUDE_DEVICE_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SURFACE_LAYOUT" = "1" ] || [ "$INCLUDE_CHAT_LOCAL_ONLY_POLICY" = "1" ] || [ "$INCLUDE_CHAT_PREFERENCES" = "1" ] || [ "$INCLUDE_CHAT_SESSION_INDEX" = "1" ] || [ "$INCLUDE_CHAT_MODEL_STATUS" = "1" ] || [ "$INCLUDE_CHAT_READINESS" = "1" ] || [ "$INCLUDE_CHAT_COMPOSER" = "1" ] || [ "$INCLUDE_CHAT_SEND_RESULT" = "1" ] || [ "$INCLUDE_CHAT_TRANSCRIPT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_AUDIT_EVENT" = "1" ] || [ "$INCLUDE_CHAT_ERROR_TAXONOMY" = "1" ]; }; then
+    ERROR "--include-runtime-readiness, --include-device-session, --include-chat-session, --include-chat-surface-layout, --include-chat-local-only-policy, --include-chat-preferences, --include-chat-session-index, --include-chat-model-status, --include-chat-readiness, --include-chat-composer, --include-chat-send-result, --include-chat-transcript-policy, --include-chat-audit-event, and --include-chat-error-taxonomy are only supported in local scaffold mode"
     exit 1
 fi
 
@@ -1501,7 +1603,14 @@ if [ -z "$BACKEND" ]; then
     NOTE "chat send     : opt-in via --include-chat-send-result (read-only blocked send-result data)"
     NOTE "chat transcript: opt-in via --include-chat-transcript-policy (read-only retention/export policy data)"
     NOTE "chat audit    : opt-in via --include-chat-audit-event (read-only blocked audit metadata)"
+    NOTE "chat errors   : opt-in via --include-chat-error-taxonomy (read-only error taxonomy data)"
     NOTE "editor bridge  : planned (VS Code / other IDEs)"
+
+    if [ "$INCLUDE_CHAT_ERROR_TAXONOMY" = "1" ]; then
+        if ! print_chat_error_taxonomy_summary; then
+            exit 1
+        fi
+    fi
 
     if [ "$INCLUDE_CHAT_AUDIT_EVENT" = "1" ]; then
         if ! print_chat_audit_event_summary; then

--- a/scripts/tests/chat_error_taxonomy_contract_test.py
+++ b/scripts/tests/chat_error_taxonomy_contract_test.py
@@ -1,0 +1,391 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Fixture tests for the standalone chat error taxonomy contract."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "contracts" / "chat_error_taxonomy_contract.py"
+FIXTURE_PATH = (
+    ROOT
+    / "contracts"
+    / "fixtures"
+    / "chat-error-taxonomy.gemma3n-e4b-kv260-placeholder.json"
+)
+SCRIPT_PATH = ROOT / "scripts" / "chat-error-taxonomy-stub.sh"
+STATUS_TEST_PATH = ROOT / "scripts" / "tests" / "status-chat-error-taxonomy.sh"
+DOC_PATH = ROOT / "docs" / "STANDALONE_CHAT_SESSION_CONTRACT.md"
+README_PATH = ROOT / "README.md"
+TEST_PATH = Path(__file__).resolve()
+CI_PATH = ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location(
+        "chat_error_taxonomy_contract",
+        MODULE_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def flatten(value) -> str:
+    return json.dumps(value, sort_keys=True)
+
+
+def iter_state_values(value):
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            if key == "state" or key.endswith("State") or key.endswith("Status"):
+                yield nested
+            yield from iter_state_values(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            yield from iter_state_values(nested)
+
+
+def iter_keys(value):
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            yield key
+            yield from iter_keys(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            yield from iter_keys(nested)
+
+
+def assert_no_private_or_generated_data(text: str) -> None:
+    forbidden_patterns = [
+        r"/home/[^\s\"']+",
+        r"/Users/[^\s\"']+",
+        r"[A-Za-z]:\\Users\\",
+        r"\b(?:api[_-]?key|authorization|bearer|client[_-]?secret|password|private[_-]?key|secret|token)\b\s*[:=]",
+        r"\.(?:gguf|safetensors|ckpt|pt|pth|onnx)\b",
+        r"(?:weights|model_weights|model-cache)/(?:[^\"'\s]+)",
+        r"(?:raw[_-]?full[_-]?logs|hardware[_-]?dump|generated[_-]?blob)\s*[:=]",
+    ]
+    for pattern in forbidden_patterns:
+        assert not re.search(pattern, text, re.IGNORECASE), pattern
+
+
+def assert_no_runtime_implementation_terms(source: str) -> None:
+    forbidden = [
+        "subprocess",
+        "os.system",
+        "popen",
+        "socket",
+        "urllib",
+        "requests",
+        "http.client",
+        "openai",
+        "anthropic",
+        "gemini",
+        "modelcontextprotocol",
+        "websocket",
+        "xmutil",
+        "xrt-smi",
+        "lsusb",
+        "dmesg",
+    ]
+    lowered = source.lower()
+    for term in forbidden:
+        assert term not in lowered, term
+
+
+def assert_no_provider_configs(value) -> None:
+    forbidden_keys = {
+        "apiKey",
+        "accessToken",
+        "refreshToken",
+        "authorization",
+        "bearerToken",
+        "provider",
+        "providers",
+        "providerConfig",
+        "providerConfigs",
+    }
+    for key in iter_keys(value):
+        assert key not in forbidden_keys, key
+
+
+def assert_no_unsupported_claims(text: str) -> None:
+    literal_claims = [
+        "production-ready",
+        "marketplace-ready",
+        "stable API",
+        "stable ABI",
+        "KV260 inference works",
+        "Gemma 3N E4B runs on KV260",
+        "20 tok/s achieved",
+        "timing closed",
+        "bitstream ready",
+        "launcher executes pccx-lab",
+        "IDE controls launcher",
+        "AI provider integration is live",
+    ]
+    lowered = text.lower()
+    for claim in literal_claims:
+        assert claim.lower() not in lowered, claim
+
+    asserted_claim_patterns = [
+        r"\bMCP\s+(?:server|client)\s+(?:is\s+)?implemented\b",
+        r"\bLSP\s+(?:server|client)\s+(?:is\s+)?implemented\b",
+        r"\bAI\s+provider\s+(?:is\s+)?implemented\b",
+        r"\bKV260\s+run\s+(?:is\s+)?claimed\b",
+    ]
+    for pattern in asserted_claim_patterns:
+        assert not re.search(pattern, text, re.IGNORECASE), pattern
+
+
+def assert_no_chat_invocation_flags(source: str) -> None:
+    forbidden_patterns = [
+        r"--backend\s+pccx-lab",
+        r"\bPCCX_LAB_BIN\b",
+        r"\bpccx-lab\s+(?:status|diagnostics|validate)\b",
+        r"\bsystemverilog-ide\s+--",
+        r"\bsystemverilog-ide\s+(?:open|run|status|validate|launch)\b",
+        r"\b(?:curl|wget)\b",
+        r"\b(?:upload|telemetry|write-back)\s+(?:enabled|true)\b",
+    ]
+    for pattern in forbidden_patterns:
+        assert not re.search(pattern, source, re.IGNORECASE), pattern
+
+
+def test_chat_error_taxonomy_matches_fixture_and_is_deterministic() -> None:
+    module = load_module()
+    generated = module.create_gemma3n_e4b_kv260_chat_error_taxonomy()
+    fixture = json.loads(read_text(FIXTURE_PATH))
+
+    assert generated == fixture
+    assert module.chat_error_taxonomy_json(generated) == (
+        module.chat_error_taxonomy_json(generated)
+    )
+    assert module.chat_error_taxonomy_json(generated).endswith("\n")
+    assert json.loads(module.chat_error_taxonomy_json(generated)) == fixture
+
+
+def test_cli_stub_outputs_deterministic_json() -> None:
+    fixture = json.loads(read_text(FIXTURE_PATH))
+    command = [
+        "bash",
+        str(SCRIPT_PATH),
+        "--model",
+        "gemma3n-e4b",
+        "--target",
+        "kv260",
+    ]
+    first = subprocess.run(
+        command,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    second = subprocess.run(
+        command,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert first.stderr == ""
+    assert first.stdout == second.stdout
+    assert first.stdout.endswith("\n")
+    assert json.loads(first.stdout) == fixture
+
+
+def test_required_fields_and_allowed_states() -> None:
+    module = load_module()
+    taxonomy = module.create_gemma3n_e4b_kv260_chat_error_taxonomy()
+    allowed = set(module.CHAT_ERROR_TAXONOMY_STATE_VALUES)
+
+    assert tuple(taxonomy.keys()) == module.CHAT_ERROR_TAXONOMY_FIELDS
+    assert taxonomy["schemaVersion"] == "pccx.chatErrorTaxonomy.v0"
+
+    states = list(iter_state_values(taxonomy))
+    assert states
+    for state in states:
+        assert state in allowed, state
+
+    for group in taxonomy["errorGroups"]:
+        assert tuple(group.keys()) == module.ERROR_GROUP_FIELDS
+    for item in taxonomy["errorItems"]:
+        assert tuple(item.keys()) == module.ERROR_ITEM_FIELDS
+    for action in taxonomy["actionRefs"]:
+        assert tuple(action.keys()) == module.ACTION_REF_FIELDS
+    for ref in taxonomy["handoffRefs"]:
+        assert tuple(ref.keys()) == module.HANDOFF_REF_FIELDS
+
+
+def test_chat_error_taxonomy_covers_blocked_chat_error_display() -> None:
+    taxonomy = load_module().create_gemma3n_e4b_kv260_chat_error_taxonomy()
+    groups = {group["groupId"]: group for group in taxonomy["errorGroups"]}
+    items = {item["itemId"]: item for item in taxonomy["errorItems"]}
+    actions = {action["actionId"]: action for action in taxonomy["actionRefs"]}
+    refs = {ref["refId"]: ref for ref in taxonomy["handoffRefs"]}
+
+    assert taxonomy["taxonomyState"] == "available_as_data"
+    assert taxonomy["displayState"] == "summary_only"
+    assert taxonomy["inputContentState"] == "unavailable"
+    assert taxonomy["runtimeState"] == "not_started"
+    assert set(groups) == {
+        "readiness_blockers",
+        "model_and_runtime_blockers",
+        "session_and_policy_blockers",
+    }
+    assert groups["readiness_blockers"]["state"] == "blocked"
+    assert groups["model_and_runtime_blockers"]["state"] == "requires_evidence"
+    assert groups["session_and_policy_blockers"]["state"] == "not_configured"
+    assert set(items) == {
+        "send_disabled_by_readiness",
+        "model_assets_not_configured",
+        "runtime_not_started",
+        "session_store_not_configured",
+        "provider_paths_not_used",
+    }
+    assert items["send_disabled_by_readiness"]["primaryActionRef"] == (
+        "review_chat_readiness"
+    )
+    assert items["send_disabled_by_readiness"]["contentPolicy"] == (
+        "no_prompt_response_or_transcript_content"
+    )
+    assert items["model_assets_not_configured"]["contentPolicy"] == (
+        "no_model_paths_or_weight_names"
+    )
+    assert items["runtime_not_started"]["contentPolicy"] == (
+        "no_generated_response_content"
+    )
+    assert items["session_store_not_configured"]["contentPolicy"] == (
+        "no_manifest_transcript_summary_or_path_content"
+    )
+    assert items["provider_paths_not_used"]["state"] == "not_used"
+    assert actions["review_chat_readiness"]["enabled"] is False
+    assert actions["wait_for_asset_boundary"]["sideEffectPolicy"] == (
+        "no_model_asset_read"
+    )
+    assert actions["wait_for_runtime_boundary"]["sideEffectPolicy"] == (
+        "no_runtime_execution"
+    )
+    assert actions["review_session_policy"]["sideEffectPolicy"] == (
+        "no_artifact_read_no_write"
+    )
+    assert refs["chat_readiness"]["schemaVersion"] == "pccx.chatReadiness.v0"
+    assert refs["chat_send_result"]["state"] == "blocked"
+
+
+def test_safety_flags_prevent_runtime_provider_and_content_paths() -> None:
+    taxonomy = load_module().create_gemma3n_e4b_kv260_chat_error_taxonomy()
+    flags = taxonomy["safetyFlags"]
+
+    assert flags["readOnly"] is True
+    assert flags["dataOnly"] is True
+    assert flags["deterministic"] is True
+    assert flags["taxonomyDisplayOnly"] is True
+    assert flags["promptCapture"] is False
+    assert flags["promptContentIncluded"] is False
+    assert flags["promptEchoed"] is False
+    assert flags["promptPersistence"] is False
+    assert flags["inputAccepted"] is False
+    assert flags["responseContentIncluded"] is False
+    assert flags["responseGenerated"] is False
+    assert flags["transcriptContentIncluded"] is False
+    assert flags["transcriptPersistence"] is False
+    assert flags["sessionStoreRead"] is False
+    assert flags["sessionStoreWrite"] is False
+    assert flags["configRead"] is False
+    assert flags["environmentRead"] is False
+    assert flags["providerConfigRead"] is False
+    assert flags["providerCalls"] is False
+    assert flags["cloudCalls"] is False
+    assert flags["networkCalls"] is False
+    assert flags["modelAssetRead"] is False
+    assert flags["modelPathIncluded"] is False
+    assert flags["modelLoadAttempted"] is False
+    assert flags["modelLoaded"] is False
+    assert flags["modelExecution"] is False
+    assert flags["runtimeExecution"] is False
+    assert flags["kv260Access"] is False
+    assert flags["hardwareAccess"] is False
+    assert flags["opensSerialPort"] is False
+    assert flags["sshExecution"] is False
+    assert flags["readsArtifacts"] is False
+    assert flags["writesArtifacts"] is False
+    assert flags["executesPccxLab"] is False
+    assert flags["executesSystemverilogIde"] is False
+
+
+def test_contract_avoids_private_data_runtime_terms_and_provider_config() -> None:
+    module_text = read_text(MODULE_PATH)
+    fixture_text = read_text(FIXTURE_PATH)
+    fixture = json.loads(fixture_text)
+
+    assert_no_private_or_generated_data(module_text)
+    assert_no_private_or_generated_data(fixture_text)
+    assert_no_runtime_implementation_terms(module_text)
+    assert_no_provider_configs(fixture)
+    assert_no_unsupported_claims(module_text)
+    assert_no_unsupported_claims(fixture_text)
+
+
+def test_docs_scripts_and_ci_reference_chat_error_taxonomy() -> None:
+    assert "chat_error_taxonomy_contract.py" in read_text(TEST_PATH)
+    assert "chat-error-taxonomy-stub.sh" in read_text(TEST_PATH)
+    assert "status-chat-error-taxonomy.sh" in read_text(TEST_PATH)
+    assert "chat-error-taxonomy-stub.sh" in read_text(README_PATH)
+    assert "chat_error_taxonomy_contract.py" in read_text(README_PATH)
+    assert "chat error taxonomy" in read_text(DOC_PATH)
+    assert "chat_error_taxonomy_contract_test.py" in read_text(CI_PATH)
+    assert "status-chat-error-taxonomy.sh" in read_text(CI_PATH)
+    assert_no_chat_invocation_flags(read_text(SCRIPT_PATH))
+
+
+def test_source_headers_for_touched_code_files() -> None:
+    expected_headers = {
+        MODULE_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        SCRIPT_PATH: [
+            "#!/usr/bin/env bash",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        STATUS_TEST_PATH: [
+            "#!/usr/bin/env bash",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        TEST_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        CI_PATH: [
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+    }
+
+    for path, header in expected_headers.items():
+        assert read_text(path).splitlines()[: len(header)] == header, path
+
+
+if __name__ == "__main__":
+    for name, func in sorted(globals().items()):
+        if name.startswith("test_") and callable(func):
+            func()
+    print("chat error taxonomy contract tests ok")

--- a/scripts/tests/status-chat-error-taxonomy.sh
+++ b/scripts/tests/status-chat-error-taxonomy.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+# scripts/tests/status-chat-error-taxonomy.sh - status error taxonomy tests.
+#
+# Usage: bash scripts/tests/status-chat-error-taxonomy.sh [path/to/status-stub.sh]
+
+set -eu
+
+PASS() { printf '[PASS]  %s\n' "$*"; }
+FAIL() { printf '[FAIL] %s\n' "$*" >&2; }
+HEAD() { printf '\n=== %s ===\n' "$*"; }
+
+STUB="${1:-scripts/status-stub.sh}"
+
+if [ ! -x "$STUB" ]; then
+    chmod +x "$STUB"
+fi
+
+contains() {
+    case "$1" in
+        *"$2"*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+require_contains() {
+    local output="$1"
+    local expected="$2"
+    if ! contains "$output" "$expected"; then
+        FAIL "expected output to contain: $expected"
+        printf '%s\n' "$output" >&2
+        exit 1
+    fi
+}
+
+require_not_contains() {
+    local output="$1"
+    local forbidden="$2"
+    if contains "$output" "$forbidden"; then
+        FAIL "output contained forbidden text: $forbidden"
+        printf '%s\n' "$output" >&2
+        exit 1
+    fi
+}
+
+HEAD "1: status can include chat error taxonomy"
+OUTPUT="$("$STUB" --include-chat-error-taxonomy)"
+require_contains "$OUTPUT" "=== chat error taxonomy ==="
+require_contains "$OUTPUT" "source     : scripts/chat-error-taxonomy-stub.sh --model gemma3n-e4b --target kv260"
+require_contains "$OUTPUT" "boundary   : read-only data; no prompt/provider/model/runtime/hardware/lab/IDE execution"
+require_contains "$OUTPUT" "target     : kv260"
+require_contains "$OUTPUT" "model      : gemma3n-e4b"
+require_contains "$OUTPUT" "taxonomy   : available_as_data"
+require_contains "$OUTPUT" "display    : summary_only"
+require_contains "$OUTPUT" "input      : unavailable"
+require_contains "$OUTPUT" "runtime    : not_started"
+PASS "chat error taxonomy section is present and conservative"
+
+HEAD "2: groups, items, and actions stay display-only"
+require_contains "$OUTPUT" "groups     : readiness_blockers=blocked"
+require_contains "$OUTPUT" "model_and_runtime_blockers=requires_evidence"
+require_contains "$OUTPUT" "session_and_policy_blockers=not_configured"
+require_contains "$OUTPUT" "items      : send_disabled_by_readiness=blocked"
+require_contains "$OUTPUT" "model_assets_not_configured=external_not_configured"
+require_contains "$OUTPUT" "runtime_not_started=not_started"
+require_contains "$OUTPUT" "session_store_not_configured=not_configured"
+require_contains "$OUTPUT" "provider_paths_not_used=not_used"
+require_contains "$OUTPUT" "actions    : review_chat_readiness=available_as_data"
+require_contains "$OUTPUT" "wait_for_asset_boundary=requires_evidence"
+require_contains "$OUTPUT" "wait_for_runtime_boundary=requires_evidence"
+require_contains "$OUTPUT" "review_session_policy=planned"
+require_contains "$OUTPUT" "review_local_only_policy=available_as_data"
+PASS "error groups, items, and actions are summarized"
+
+HEAD "3: safety flags stay read-only and non-executing"
+require_contains "$OUTPUT" "readOnly=true"
+require_contains "$OUTPUT" "dataOnly=true"
+require_contains "$OUTPUT" "deterministic=true"
+require_contains "$OUTPUT" "taxonomyDisplayOnly=true"
+require_contains "$OUTPUT" "promptContentIncluded=false"
+require_contains "$OUTPUT" "responseContentIncluded=false"
+require_contains "$OUTPUT" "transcriptContentIncluded=false"
+require_contains "$OUTPUT" "sessionStoreRead=false"
+require_contains "$OUTPUT" "configRead=false"
+require_contains "$OUTPUT" "providerConfigRead=false"
+require_contains "$OUTPUT" "providerCalls=false"
+require_contains "$OUTPUT" "cloudCalls=false"
+require_contains "$OUTPUT" "networkCalls=false"
+require_contains "$OUTPUT" "modelAssetRead=false"
+require_contains "$OUTPUT" "modelLoadAttempted=false"
+require_contains "$OUTPUT" "modelExecution=false"
+require_contains "$OUTPUT" "runtimeExecution=false"
+require_contains "$OUTPUT" "kv260Access=false"
+require_contains "$OUTPUT" "hardwareAccess=false"
+require_contains "$OUTPUT" "readsArtifacts=false"
+require_contains "$OUTPUT" "writesArtifacts=false"
+require_contains "$OUTPUT" "executesPccxLab=false"
+PASS "execution-related flags remain false"
+
+HEAD "4: output is deterministic"
+OUTPUT_AGAIN="$("$STUB" --include-chat-error-taxonomy)"
+if [ "$OUTPUT" != "$OUTPUT_AGAIN" ]; then
+    FAIL "status chat error taxonomy output changed between runs"
+    exit 1
+fi
+PASS "status chat error taxonomy output is deterministic"
+
+HEAD "5: chat error taxonomy option does not combine with pccx-lab backend"
+if "$STUB" --include-chat-error-taxonomy --backend pccx-lab >/dev/null 2>&1; then
+    FAIL "expected combined chat-error-taxonomy/backend mode to fail"
+    exit 1
+fi
+PASS "chat error taxonomy remains separate from backend execution"
+
+HEAD "6: output avoids known overclaims"
+FORBIDDEN_PREFIX="KV260 inference"
+FORBIDDEN_CLAIM="${FORBIDDEN_PREFIX} works"
+require_not_contains "$OUTPUT" "$FORBIDDEN_CLAIM"
+THROUGHPUT_PREFIX="20 tok/s"
+THROUGHPUT_CLAIM="${THROUGHPUT_PREFIX} achieved"
+require_not_contains "$OUTPUT" "$THROUGHPUT_CLAIM"
+PASS "no chat error taxonomy or throughput overclaim in status output"
+
+printf '\n[DONE]  all status-chat-error-taxonomy tests passed\n'


### PR DESCRIPTION
## Summary

- add a deterministic `pccx.chatErrorTaxonomy.v0` fixture and CLI stub for grouped blocked chat error display data
- expose the taxonomy through `status-stub.sh --include-chat-error-taxonomy`
- document the boundary and add direct/status CI coverage

Refs #9

## Scope and safety

This is a data-only display boundary for future chat banners/status rows. It does not accept prompts, emit responses, read transcripts, read provider configuration, read environment values, read model assets, start a runtime, access KV260 hardware, call pccx-lab, call systemverilog-ide, or read/write artifacts.

## Validation

- `python3 scripts/tests/chat_error_taxonomy_contract_test.py`
- `bash scripts/tests/status-chat-error-taxonomy.sh scripts/status-stub.sh`
- `python3 -m json.tool contracts/fixtures/chat-error-taxonomy.gemma3n-e4b-kv260-placeholder.json`
- `./scripts/chat-error-taxonomy-stub.sh --model gemma3n-e4b --target kv260`
- `./scripts/status-stub.sh --include-chat-error-taxonomy`
- `python3 -m py_compile contracts/*.py scripts/tests/*.py`
- `bash -n scripts/*.sh scripts/tests/*.sh`
- `for test in scripts/tests/*_test.py; do python3 "$test"; done`
- `for test in scripts/tests/status-*.sh; do bash "$test" scripts/status-stub.sh; done`
- `bash scripts/check.sh`
- local claim-scan matching CI
- `git diff --check`
- `git diff --cached --check`

Local note: `shellcheck` is not installed on this host; the GitHub workflow installs it before running shell lint.
