### PR TITLE
Add chat response stream boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,7 @@ jobs:
                    scripts/chat-transcript-policy-stub.sh \
                    scripts/chat-audit-event-stub.sh \
                    scripts/chat-error-taxonomy-stub.sh \
+                   scripts/chat-response-stream-stub.sh \
                    scripts/chat-surface-preview.sh \
                    scripts/chat-stub.sh; do
             [ -f "$f" ] && chmod +x "$f" || true
@@ -213,6 +214,10 @@ jobs:
         run: ./scripts/status-stub.sh --include-chat-error-taxonomy
       - name: run scripts/chat-error-taxonomy-stub.sh
         run: ./scripts/chat-error-taxonomy-stub.sh --model gemma3n-e4b --target kv260
+      - name: run scripts/status-stub.sh with chat response stream
+        run: ./scripts/status-stub.sh --include-chat-response-stream
+      - name: run scripts/chat-response-stream-stub.sh
+        run: ./scripts/chat-response-stream-stub.sh --model gemma3n-e4b --target kv260
       - name: run scripts/chat-surface-preview.sh
         run: ./scripts/chat-surface-preview.sh --model gemma3n-e4b --target kv260
       - name: run scripts/chat-stub.sh --dry-run
@@ -261,6 +266,8 @@ jobs:
         run: python3 scripts/tests/chat_audit_event_contract_test.py
       - name: run chat error-taxonomy contract tests
         run: python3 scripts/tests/chat_error_taxonomy_contract_test.py
+      - name: run chat response-stream contract tests
+        run: python3 scripts/tests/chat_response_stream_contract_test.py
       - name: run chat surface preview tests
         run: python3 scripts/tests/chat_surface_preview_test.py
 
@@ -286,6 +293,7 @@ jobs:
           chmod +x scripts/chat-transcript-policy-stub.sh
           chmod +x scripts/chat-audit-event-stub.sh
           chmod +x scripts/chat-error-taxonomy-stub.sh
+          chmod +x scripts/chat-response-stream-stub.sh
           chmod +x scripts/launch-stub.sh
           chmod +x scripts/tests/status-backend.sh
           chmod +x scripts/tests/status-device-session.sh
@@ -302,6 +310,7 @@ jobs:
           chmod +x scripts/tests/status-chat-transcript-policy.sh
           chmod +x scripts/tests/status-chat-audit-event.sh
           chmod +x scripts/tests/status-chat-error-taxonomy.sh
+          chmod +x scripts/tests/status-chat-response-stream.sh
       - name: shellcheck status-stub and test script
         run: |
           sudo apt-get update -q && sudo apt-get install -y -q shellcheck
@@ -321,6 +330,7 @@ jobs:
           shellcheck scripts/tests/status-chat-transcript-policy.sh
           shellcheck scripts/tests/status-chat-audit-event.sh
           shellcheck scripts/tests/status-chat-error-taxonomy.sh
+          shellcheck scripts/tests/status-chat-response-stream.sh
       - name: run status-backend tests
         run: bash scripts/tests/status-backend.sh scripts/status-stub.sh
       - name: run status-device-session tests
@@ -351,3 +361,5 @@ jobs:
         run: bash scripts/tests/status-chat-audit-event.sh scripts/status-stub.sh
       - name: run status-chat-error-taxonomy tests
         run: bash scripts/tests/status-chat-error-taxonomy.sh scripts/status-stub.sh
+      - name: run status-chat-response-stream tests
+        run: bash scripts/tests/status-chat-response-stream.sh scripts/status-stub.sh

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ and verify host-side prerequisites before the real engine lands.
 | [`scripts/check.sh`](./scripts/check.sh) | Probe host info, tooling availability, edge-device hints. Always exits 0. |
 | [`scripts/check-device-stub.sh`](./scripts/check-device-stub.sh) | Narrowly scoped device-tree / FPGA-node probe (KV260 / Kria detection only). Always exits 0. |
 | [`scripts/install-stub.sh`](./scripts/install-stub.sh) | Preview of the planned install flow; reports which host runtime pieces are present, lists device-side pieces as future deliverables. Always exits 0. |
-| [`scripts/status-stub.sh`](./scripts/status-stub.sh) | Launcher state summary. Default mode: local scaffold output, always exits 0. With `--include-chat-error-taxonomy`, adds read-only chat error taxonomy data. With `--include-chat-audit-event`, adds read-only blocked chat audit-event metadata. With `--include-chat-surface-layout`, adds read-only chat surface layout data. With `--include-chat-local-only-policy`, adds read-only local-only/cloud-block policy data. With `--include-chat-preferences`, adds read-only chat preferences/settings data. With `--include-chat-session-index`, adds read-only empty chat session index data. With `--include-chat-transcript-policy`, adds read-only chat transcript retention/export policy data. With `--include-chat-send-result`, adds read-only blocked chat send-result data. With `--include-chat-composer`, adds read-only chat composer/input-control data. With `--include-chat-model-status`, adds read-only blocked chat model-status display data. With `--include-chat-session`, adds read-only blocked chat/session and lifecycle summaries. With `--include-chat-readiness`, adds read-only chat readiness checks and recovery actions. With `--include-device-session`, adds a read-only device/session status panel. With `--include-runtime-readiness`, adds a read-only runtime readiness summary. With `--backend pccx-lab`, calls `pccx-lab status --format json` and forwards the run-status envelope (exits non-zero if binary is missing or output is invalid). |
+| [`scripts/status-stub.sh`](./scripts/status-stub.sh) | Launcher state summary. Default mode: local scaffold output, always exits 0. With `--include-chat-response-stream`, adds read-only blocked chat response stream data. With `--include-chat-error-taxonomy`, adds read-only chat error taxonomy data. With `--include-chat-audit-event`, adds read-only blocked chat audit-event metadata. With `--include-chat-surface-layout`, adds read-only chat surface layout data. With `--include-chat-local-only-policy`, adds read-only local-only/cloud-block policy data. With `--include-chat-preferences`, adds read-only chat preferences/settings data. With `--include-chat-session-index`, adds read-only empty chat session index data. With `--include-chat-transcript-policy`, adds read-only chat transcript retention/export policy data. With `--include-chat-send-result`, adds read-only blocked chat send-result data. With `--include-chat-composer`, adds read-only chat composer/input-control data. With `--include-chat-model-status`, adds read-only blocked chat model-status display data. With `--include-chat-session`, adds read-only blocked chat/session and lifecycle summaries. With `--include-chat-readiness`, adds read-only chat readiness checks and recovery actions. With `--include-device-session`, adds a read-only device/session status panel. With `--include-runtime-readiness`, adds a read-only runtime readiness summary. With `--backend pccx-lab`, calls `pccx-lab status --format json` and forwards the run-status envelope (exits non-zero if binary is missing or output is invalid). |
 | [`scripts/device-session-status-stub.sh`](./scripts/device-session-status-stub.sh) | Data-only device/session status JSON for the Gemma 3N E4B + KV260 target. Reports connection, model load, session, diagnostics, readiness, discovery paths, flow steps, and error taxonomy as placeholder / blocked. |
 | [`scripts/runtime-readiness-stub.sh`](./scripts/runtime-readiness-stub.sh) | Data-only runtime readiness JSON for the Gemma 3N E4B + KV260 target. Reports blocked / not yet evidence-backed. |
 | [`scripts/chat-session-stub.sh`](./scripts/chat-session-stub.sh) | Data-only standalone chat/session JSON for the Gemma 3N E4B + KV260 target. Reports disabled send controls, inactive session state, no prompt/response persistence, and readiness handoff references. |
@@ -100,6 +100,7 @@ and verify host-side prerequisites before the real engine lands.
 | [`scripts/chat-readiness-stub.sh`](./scripts/chat-readiness-stub.sh) | Data-only chat readiness JSON for the Gemma 3N E4B + KV260 target. Reports readiness checks, error categories, and recovery actions as blocked, disabled, or local data only. |
 | [`scripts/chat-composer-stub.sh`](./scripts/chat-composer-stub.sh) | Data-only chat composer JSON for the Gemma 3N E4B + KV260 target. Reports input buffer, send, attachment, validation, and privacy states without reading, echoing, storing, or persisting prompt text. |
 | [`scripts/chat-send-result-stub.sh`](./scripts/chat-send-result-stub.sh) | Data-only blocked chat send-result JSON for the Gemma 3N E4B + KV260 target. Reports disabled send state, no accepted input, no prompt echo, no generated response, and no runtime/model handoff. |
+| [`scripts/chat-response-stream-stub.sh`](./scripts/chat-response-stream-stub.sh) | Data-only blocked chat response stream JSON for the Gemma 3N E4B + KV260 target. Reports disabled response streaming, progress, token counter, and stop-control state without opening transport, generating chunks, counting tokens, or writing transcripts. |
 | [`scripts/chat-transcript-policy-stub.sh`](./scripts/chat-transcript-policy-stub.sh) | Data-only chat transcript policy JSON for the Gemma 3N E4B + KV260 target. Reports retention, export, storage, and privacy policy state without reading, generating, storing, persisting, summarizing, or exporting prompt/response/transcript content. |
 | [`scripts/chat-audit-event-stub.sh`](./scripts/chat-audit-event-stub.sh) | Data-only chat audit-event JSON for the Gemma 3N E4B + KV260 target. Reports blocked send metadata, redaction policy, absent prompt/response/transcript content, and disabled audit persistence. |
 | [`scripts/chat-error-taxonomy-stub.sh`](./scripts/chat-error-taxonomy-stub.sh) | Data-only chat error taxonomy JSON for the Gemma 3N E4B + KV260 target. Groups blocked readiness, model/runtime, session, and policy errors without reading prompts, providers, configs, model paths, logs, stores, or artifacts. |
@@ -124,6 +125,7 @@ bash scripts/status-stub.sh --include-chat-send-result
 bash scripts/status-stub.sh --include-chat-transcript-policy
 bash scripts/status-stub.sh --include-chat-audit-event
 bash scripts/status-stub.sh --include-chat-error-taxonomy
+bash scripts/status-stub.sh --include-chat-response-stream
 bash scripts/status-stub.sh --include-device-session
 bash scripts/status-stub.sh --include-runtime-readiness
 bash scripts/device-session-status-stub.sh --model gemma3n-e4b --target kv260
@@ -141,6 +143,7 @@ bash scripts/chat-send-result-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-transcript-policy-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-audit-event-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-error-taxonomy-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/chat-response-stream-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-surface-preview.sh --model gemma3n-e4b --target kv260
 bash scripts/launch-stub.sh --dry-run
 bash scripts/chat-stub.sh --dry-run --prompt "hello"
@@ -310,30 +313,35 @@ python3 contracts/chat_model_status_contract.py --model gemma3n-e4b --target kv2
 python3 contracts/chat_readiness_contract.py --model gemma3n-e4b --target kv260
 python3 contracts/chat_audit_event_contract.py --model gemma3n-e4b --target kv260
 python3 contracts/chat_error_taxonomy_contract.py --model gemma3n-e4b --target kv260
+python3 contracts/chat_response_stream_contract.py --model gemma3n-e4b --target kv260
 bash scripts/chat-model-status-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-session-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-session-lifecycle-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-readiness-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-audit-event-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-error-taxonomy-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/chat-response-stream-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-surface-preview.sh --model gemma3n-e4b --target kv260
 bash scripts/status-stub.sh --include-chat-model-status
 bash scripts/status-stub.sh --include-chat-session
 bash scripts/status-stub.sh --include-chat-readiness
 bash scripts/status-stub.sh --include-chat-audit-event
 bash scripts/status-stub.sh --include-chat-error-taxonomy
+bash scripts/status-stub.sh --include-chat-response-stream
 python3 scripts/tests/chat_session_contract_test.py
 python3 scripts/tests/chat_model_status_contract_test.py
 python3 scripts/tests/chat_session_lifecycle_contract_test.py
 python3 scripts/tests/chat_readiness_contract_test.py
 python3 scripts/tests/chat_audit_event_contract_test.py
 python3 scripts/tests/chat_error_taxonomy_contract_test.py
+python3 scripts/tests/chat_response_stream_contract_test.py
 python3 scripts/tests/chat_surface_preview_test.py
 bash scripts/tests/status-chat-model-status.sh
 bash scripts/tests/status-chat-session.sh
 bash scripts/tests/status-chat-readiness.sh
 bash scripts/tests/status-chat-audit-event.sh
 bash scripts/tests/status-chat-error-taxonomy.sh
+bash scripts/tests/status-chat-response-stream.sh
 ```
 
 The checked chat/session fixture reports the chat surface as blocked,
@@ -373,6 +381,13 @@ readiness blockers, model/runtime blockers, session/policy blockers, and
 local-only/provider policy metadata without reading prompts, responses,
 transcripts, configs, provider settings, model paths, logs, session stores,
 or artifacts.
+
+The chat response stream fixture defines the disabled assistant response
+stream/progress display for the planned chat surface. It records stream
+phases, response placeholders, token-counter state, and stop-control state
+without accepting prompts, opening stream transport, generating response
+chunks, counting tokens, appending transcripts, reading stores, or writing
+artifacts.
 
 The preview command renders that same contract as a deterministic
 terminal chat surface sketch with disabled controls, blocked reasons, and

--- a/contracts/chat_response_stream_contract.py
+++ b/contracts/chat_response_stream_contract.py
@@ -1,0 +1,426 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Data-only chat response stream contract for the planned launcher UI.
+
+The contract describes the disabled assistant response streaming/progress
+display for the local chat surface. It does not read prompts, accept input,
+generate response chunks, count produced tokens, start runtime code, load
+models, touch KV260 hardware, call providers, invoke pccx-lab, read stores,
+or persist anything.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import sys
+
+
+SCHEMA_VERSION = "pccx.chatResponseStream.v0"
+STREAM_ENVELOPE_SCHEMA_VERSION = "pccx.chatResponseStreamEnvelope.v0"
+
+CHAT_RESPONSE_STREAM_FIELDS = (
+    "schemaVersion",
+    "streamId",
+    "fixtureVersion",
+    "lastUpdatedSource",
+    "targetDevice",
+    "targetBoard",
+    "targetModel",
+    "streamState",
+    "responseState",
+    "streamTransportState",
+    "tokenState",
+    "progressState",
+    "cancelState",
+    "runtimeState",
+    "modelState",
+    "sessionState",
+    "chatSendResultRef",
+    "chatReadinessRef",
+    "chatModelStatusRef",
+    "chatTranscriptPolicyRef",
+    "streamEnvelope",
+    "streamPhases",
+    "displaySlots",
+    "blockedReasons",
+    "handoffRefs",
+    "safetyFlags",
+    "limitations",
+    "issueRefs",
+)
+
+STREAM_ENVELOPE_FIELDS = (
+    "schemaVersion",
+    "envelopeId",
+    "state",
+    "streamStarted",
+    "transportOpened",
+    "chunksEmitted",
+    "tokenContentIncluded",
+    "responseContentIncluded",
+    "tokenCount",
+    "stopSignalSent",
+    "contentPolicy",
+    "sideEffectPolicy",
+    "summary",
+)
+
+STREAM_PHASE_FIELDS = (
+    "phaseId",
+    "label",
+    "state",
+    "visible",
+    "enabled",
+    "summary",
+    "requiredBefore",
+    "contentPolicy",
+)
+
+DISPLAY_SLOT_FIELDS = (
+    "slotId",
+    "label",
+    "state",
+    "visible",
+    "enabled",
+    "sourceRef",
+    "displayPolicy",
+    "contentPolicy",
+)
+
+BLOCKED_REASON_FIELDS = (
+    "reasonId",
+    "state",
+    "summary",
+    "requiredBefore",
+)
+
+HANDOFF_REF_FIELDS = (
+    "refId",
+    "schemaVersion",
+    "fixturePath",
+    "state",
+    "summary",
+)
+
+CHAT_RESPONSE_STREAM_STATE_VALUES = (
+    "available_as_data",
+    "blocked",
+    "disabled",
+    "empty_not_captured",
+    "external_not_configured",
+    "inactive",
+    "not_configured",
+    "not_generated",
+    "not_loaded",
+    "not_started",
+    "not_used",
+    "placeholder",
+    "planned",
+    "requires_evidence",
+    "target_selected",
+    "unavailable",
+)
+
+_CHAT_RESPONSE_STREAM = {
+    "schemaVersion": SCHEMA_VERSION,
+    "streamId": "chat_response_stream_gemma3n_e4b_kv260_placeholder",
+    "fixtureVersion": "chat-response-stream.gemma3n-e4b-kv260.2026-05-04",
+    "lastUpdatedSource": "pccx_launcher_issue_9_chat_response_stream_boundary_2026-05-04",
+    "targetDevice": "kv260",
+    "targetBoard": "xilinx_kria_kv260",
+    "targetModel": "gemma3n-e4b",
+    "streamState": "blocked",
+    "responseState": "not_generated",
+    "streamTransportState": "not_started",
+    "tokenState": "unavailable",
+    "progressState": "disabled",
+    "cancelState": "disabled",
+    "runtimeState": "not_started",
+    "modelState": "not_loaded",
+    "sessionState": "inactive",
+    "chatSendResultRef": "chat_send_result_gemma3n_e4b_kv260_placeholder",
+    "chatReadinessRef": "chat_readiness_gemma3n_e4b_kv260_placeholder",
+    "chatModelStatusRef": "chat_model_status_gemma3n_e4b_kv260_placeholder",
+    "chatTranscriptPolicyRef": "chat_transcript_policy_gemma3n_e4b_kv260_placeholder",
+    "streamEnvelope": {
+        "schemaVersion": STREAM_ENVELOPE_SCHEMA_VERSION,
+        "envelopeId": "blocked_response_stream_gemma3n_e4b_kv260_placeholder",
+        "state": "blocked",
+        "streamStarted": False,
+        "transportOpened": False,
+        "chunksEmitted": False,
+        "tokenContentIncluded": False,
+        "responseContentIncluded": False,
+        "tokenCount": None,
+        "stopSignalSent": False,
+        "contentPolicy": "fixture carries response stream metadata only; no prompt, token, or response body is stored",
+        "sideEffectPolicy": "no_runtime_execution_no_stream_transport_no_write",
+        "summary": "Assistant response streaming is blocked because send, runtime, model, and session evidence are missing.",
+    },
+    "streamPhases": [
+        {
+            "phaseId": "wait_for_send_result",
+            "label": "wait for send result",
+            "state": "blocked",
+            "visible": True,
+            "enabled": False,
+            "summary": "No send attempt exists, so no response stream can start.",
+            "requiredBefore": "stream_transport_opened",
+            "contentPolicy": "no_prompt_or_response_content",
+        },
+        {
+            "phaseId": "open_stream_transport",
+            "label": "open stream transport",
+            "state": "not_started",
+            "visible": True,
+            "enabled": False,
+            "summary": "No local runtime transport is implemented or opened.",
+            "requiredBefore": "response_chunks_emitted",
+            "contentPolicy": "no_runtime_log_or_transport_payload_content",
+        },
+        {
+            "phaseId": "emit_response_chunks",
+            "label": "emit response chunks",
+            "state": "not_generated",
+            "visible": True,
+            "enabled": False,
+            "summary": "No assistant response chunks are produced in this fixture.",
+            "requiredBefore": "assistant_message_available",
+            "contentPolicy": "no_generated_response_content",
+        },
+        {
+            "phaseId": "complete_stream",
+            "label": "complete stream",
+            "state": "unavailable",
+            "visible": True,
+            "enabled": False,
+            "summary": "No stream completion event exists because no stream starts.",
+            "requiredBefore": "transcript_append_enabled",
+            "contentPolicy": "no_transcript_or_summary_content",
+        },
+    ],
+    "displaySlots": [
+        {
+            "slotId": "assistant_response_placeholder",
+            "label": "assistant response placeholder",
+            "state": "available_as_data",
+            "visible": True,
+            "enabled": False,
+            "sourceRef": "chat_send_result",
+            "displayPolicy": "show unavailable response state only",
+            "contentPolicy": "no_response_content",
+        },
+        {
+            "slotId": "stream_progress_indicator",
+            "label": "stream progress indicator",
+            "state": "disabled",
+            "visible": True,
+            "enabled": False,
+            "sourceRef": "chat_readiness",
+            "displayPolicy": "show disabled progress state without runtime activity",
+            "contentPolicy": "metadata_only",
+        },
+        {
+            "slotId": "token_counter",
+            "label": "token counter",
+            "state": "unavailable",
+            "visible": False,
+            "enabled": False,
+            "sourceRef": "chat_model_status",
+            "displayPolicy": "hide until a reviewed runtime boundary exposes counts",
+            "contentPolicy": "no_token_counts_or_token_text",
+        },
+        {
+            "slotId": "stop_generation_control",
+            "label": "stop generation control",
+            "state": "disabled",
+            "visible": True,
+            "enabled": False,
+            "sourceRef": "chat_response_stream",
+            "displayPolicy": "show disabled stop control only",
+            "contentPolicy": "no_runtime_signal_payload",
+        },
+    ],
+    "blockedReasons": [
+        {
+            "reasonId": "send_result_blocked",
+            "state": "blocked",
+            "summary": "The checked send-result boundary reports no send attempt.",
+            "requiredBefore": "response_stream_started",
+        },
+        {
+            "reasonId": "runtime_not_started",
+            "state": "not_started",
+            "summary": "No local chat runtime has been implemented or started.",
+            "requiredBefore": "stream_transport_opened",
+        },
+        {
+            "reasonId": "model_not_loaded",
+            "state": "not_loaded",
+            "summary": "Model assets are not configured or loaded by this fixture.",
+            "requiredBefore": "response_chunks_emitted",
+        },
+        {
+            "reasonId": "session_inactive",
+            "state": "inactive",
+            "summary": "No launcher-owned chat session exists for streamed output.",
+            "requiredBefore": "response_display_appended",
+        },
+        {
+            "reasonId": "transcript_policy_disabled",
+            "state": "disabled",
+            "summary": "Transcript persistence and export remain disabled.",
+            "requiredBefore": "stream_result_persisted",
+        },
+    ],
+    "handoffRefs": [
+        {
+            "refId": "chat_send_result",
+            "schemaVersion": "pccx.chatSendResult.v0",
+            "fixturePath": "contracts/fixtures/chat-send-result.gemma3n-e4b-kv260-placeholder.json",
+            "state": "blocked",
+            "summary": "Blocked send-result data is consumed before stream display state.",
+        },
+        {
+            "refId": "chat_readiness",
+            "schemaVersion": "pccx.chatReadiness.v0",
+            "fixturePath": "contracts/fixtures/chat-readiness.gemma3n-e4b-kv260-placeholder.json",
+            "state": "blocked",
+            "summary": "Readiness data keeps response streaming disabled.",
+        },
+        {
+            "refId": "chat_model_status",
+            "schemaVersion": "pccx.chatModelStatus.v0",
+            "fixturePath": "contracts/fixtures/chat-model-status.gemma3n-e4b-kv260-placeholder.json",
+            "state": "available_as_data",
+            "summary": "Model status is consumed as descriptor metadata only.",
+        },
+        {
+            "refId": "chat_transcript_policy",
+            "schemaVersion": "pccx.chatTranscriptPolicy.v0",
+            "fixturePath": "contracts/fixtures/chat-transcript-policy.gemma3n-e4b-kv260-placeholder.json",
+            "state": "disabled",
+            "summary": "Transcript persistence remains unavailable for streamed output.",
+        },
+    ],
+    "safetyFlags": {
+        "dataOnly": True,
+        "readOnly": True,
+        "deterministic": True,
+        "responseStreamDisplayOnly": True,
+        "writesArtifacts": False,
+        "readsArtifacts": False,
+        "attachmentReads": False,
+        "fileUpload": False,
+        "clipboardRead": False,
+        "clipboardWrite": False,
+        "promptCapture": False,
+        "promptContentIncluded": False,
+        "promptEchoed": False,
+        "promptPersistence": False,
+        "inputAccepted": False,
+        "sendAttempted": False,
+        "responseContentIncluded": False,
+        "responseGenerated": False,
+        "responseChunkContentIncluded": False,
+        "responseChunksEmitted": False,
+        "tokenContentIncluded": False,
+        "tokenCountMeasured": False,
+        "streamStarted": False,
+        "streamTransportOpened": False,
+        "streamCancellationAttempted": False,
+        "transcriptPersistence": False,
+        "sessionPersistence": False,
+        "sessionStoreRead": False,
+        "sessionStoreWrite": False,
+        "modelAssetRead": False,
+        "modelAssetPathsIncluded": False,
+        "modelWeightPathsIncluded": False,
+        "modelLoadAttempted": False,
+        "modelLoaded": False,
+        "modelExecution": False,
+        "runtimeExecution": False,
+        "touchesHardware": False,
+        "hardwareAccess": False,
+        "kv260Access": False,
+        "opensSerialPort": False,
+        "networkCalls": False,
+        "networkScan": False,
+        "sshExecution": False,
+        "providerCalls": False,
+        "cloudCalls": False,
+        "configRead": False,
+        "environmentRead": False,
+        "providerConfigRead": False,
+        "privatePathsIncluded": False,
+        "secretsIncluded": False,
+        "tokensIncluded": False,
+        "generatedBlobsIncluded": False,
+        "hardwareDumpsIncluded": False,
+        "runtimeLogsIncluded": False,
+        "telemetry": False,
+        "automaticUpload": False,
+        "writeBack": False,
+        "executesPccxLab": False,
+        "executesSystemverilogIde": False,
+        "mcpServerImplemented": False,
+        "lspImplemented": False,
+        "stableApiAbiClaim": False,
+    },
+    "limitations": [
+        "Data-only blocked chat response-stream fixture; no prompt, token, response, transcript, summary, or runtime log content is read or written.",
+        "No stream transport is opened, no response chunks are generated, no token counts are measured, and no stop signal is sent.",
+        "No model assets, model paths, private paths, secrets, tokens, stores, logs, or artifacts are read.",
+        "No KV260 hardware access, serial access, SSH execution, network call, provider call, telemetry, upload, or write-back is performed.",
+        "This is not a release, tag, versioned compatibility commitment, MCP, LSP, IDE, marketplace, or telemetry implementation.",
+    ],
+    "issueRefs": [
+        "pccxai/pccx-llm-launcher#9",
+    ],
+}
+
+
+def create_gemma3n_e4b_kv260_chat_response_stream() -> dict:
+    """Return the checked Gemma 3N E4B plus KV260 chat response stream fixture."""
+    return copy.deepcopy(_CHAT_RESPONSE_STREAM)
+
+
+def chat_response_stream_json(stream: dict | None = None) -> str:
+    """Render a deterministic JSON representation."""
+    return json.dumps(
+        stream if stream is not None else create_gemma3n_e4b_kv260_chat_response_stream(),
+        indent=2,
+        sort_keys=True,
+    ) + "\n"
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Print data-only chat response stream JSON.",
+    )
+    parser.add_argument(
+        "--model",
+        default="gemma3n-e4b",
+        choices=("gemma3n-e4b",),
+        help="model descriptor target",
+    )
+    parser.add_argument(
+        "--target",
+        default="kv260",
+        choices=("kv260",),
+        help="target board/device",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parse_args(sys.argv[1:] if argv is None else argv)
+    sys.stdout.write(chat_response_stream_json())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contracts/fixtures/chat-response-stream.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-response-stream.gemma3n-e4b-kv260-placeholder.json
@@ -1,0 +1,257 @@
+{
+  "blockedReasons": [
+    {
+      "reasonId": "send_result_blocked",
+      "requiredBefore": "response_stream_started",
+      "state": "blocked",
+      "summary": "The checked send-result boundary reports no send attempt."
+    },
+    {
+      "reasonId": "runtime_not_started",
+      "requiredBefore": "stream_transport_opened",
+      "state": "not_started",
+      "summary": "No local chat runtime has been implemented or started."
+    },
+    {
+      "reasonId": "model_not_loaded",
+      "requiredBefore": "response_chunks_emitted",
+      "state": "not_loaded",
+      "summary": "Model assets are not configured or loaded by this fixture."
+    },
+    {
+      "reasonId": "session_inactive",
+      "requiredBefore": "response_display_appended",
+      "state": "inactive",
+      "summary": "No launcher-owned chat session exists for streamed output."
+    },
+    {
+      "reasonId": "transcript_policy_disabled",
+      "requiredBefore": "stream_result_persisted",
+      "state": "disabled",
+      "summary": "Transcript persistence and export remain disabled."
+    }
+  ],
+  "cancelState": "disabled",
+  "chatModelStatusRef": "chat_model_status_gemma3n_e4b_kv260_placeholder",
+  "chatReadinessRef": "chat_readiness_gemma3n_e4b_kv260_placeholder",
+  "chatSendResultRef": "chat_send_result_gemma3n_e4b_kv260_placeholder",
+  "chatTranscriptPolicyRef": "chat_transcript_policy_gemma3n_e4b_kv260_placeholder",
+  "displaySlots": [
+    {
+      "contentPolicy": "no_response_content",
+      "displayPolicy": "show unavailable response state only",
+      "enabled": false,
+      "label": "assistant response placeholder",
+      "slotId": "assistant_response_placeholder",
+      "sourceRef": "chat_send_result",
+      "state": "available_as_data",
+      "visible": true
+    },
+    {
+      "contentPolicy": "metadata_only",
+      "displayPolicy": "show disabled progress state without runtime activity",
+      "enabled": false,
+      "label": "stream progress indicator",
+      "slotId": "stream_progress_indicator",
+      "sourceRef": "chat_readiness",
+      "state": "disabled",
+      "visible": true
+    },
+    {
+      "contentPolicy": "no_token_counts_or_token_text",
+      "displayPolicy": "hide until a reviewed runtime boundary exposes counts",
+      "enabled": false,
+      "label": "token counter",
+      "slotId": "token_counter",
+      "sourceRef": "chat_model_status",
+      "state": "unavailable",
+      "visible": false
+    },
+    {
+      "contentPolicy": "no_runtime_signal_payload",
+      "displayPolicy": "show disabled stop control only",
+      "enabled": false,
+      "label": "stop generation control",
+      "slotId": "stop_generation_control",
+      "sourceRef": "chat_response_stream",
+      "state": "disabled",
+      "visible": true
+    }
+  ],
+  "fixtureVersion": "chat-response-stream.gemma3n-e4b-kv260.2026-05-04",
+  "handoffRefs": [
+    {
+      "fixturePath": "contracts/fixtures/chat-send-result.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_send_result",
+      "schemaVersion": "pccx.chatSendResult.v0",
+      "state": "blocked",
+      "summary": "Blocked send-result data is consumed before stream display state."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-readiness.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_readiness",
+      "schemaVersion": "pccx.chatReadiness.v0",
+      "state": "blocked",
+      "summary": "Readiness data keeps response streaming disabled."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-model-status.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_model_status",
+      "schemaVersion": "pccx.chatModelStatus.v0",
+      "state": "available_as_data",
+      "summary": "Model status is consumed as descriptor metadata only."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-transcript-policy.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_transcript_policy",
+      "schemaVersion": "pccx.chatTranscriptPolicy.v0",
+      "state": "disabled",
+      "summary": "Transcript persistence remains unavailable for streamed output."
+    }
+  ],
+  "issueRefs": [
+    "pccxai/pccx-llm-launcher#9"
+  ],
+  "lastUpdatedSource": "pccx_launcher_issue_9_chat_response_stream_boundary_2026-05-04",
+  "limitations": [
+    "Data-only blocked chat response-stream fixture; no prompt, token, response, transcript, summary, or runtime log content is read or written.",
+    "No stream transport is opened, no response chunks are generated, no token counts are measured, and no stop signal is sent.",
+    "No model assets, model paths, private paths, secrets, tokens, stores, logs, or artifacts are read.",
+    "No KV260 hardware access, serial access, SSH execution, network call, provider call, telemetry, upload, or write-back is performed.",
+    "This is not a release, tag, versioned compatibility commitment, MCP, LSP, IDE, marketplace, or telemetry implementation."
+  ],
+  "modelState": "not_loaded",
+  "progressState": "disabled",
+  "responseState": "not_generated",
+  "runtimeState": "not_started",
+  "safetyFlags": {
+    "attachmentReads": false,
+    "automaticUpload": false,
+    "clipboardRead": false,
+    "clipboardWrite": false,
+    "cloudCalls": false,
+    "configRead": false,
+    "dataOnly": true,
+    "deterministic": true,
+    "environmentRead": false,
+    "executesPccxLab": false,
+    "executesSystemverilogIde": false,
+    "fileUpload": false,
+    "generatedBlobsIncluded": false,
+    "hardwareAccess": false,
+    "hardwareDumpsIncluded": false,
+    "inputAccepted": false,
+    "kv260Access": false,
+    "lspImplemented": false,
+    "mcpServerImplemented": false,
+    "modelAssetPathsIncluded": false,
+    "modelAssetRead": false,
+    "modelExecution": false,
+    "modelLoadAttempted": false,
+    "modelLoaded": false,
+    "modelWeightPathsIncluded": false,
+    "networkCalls": false,
+    "networkScan": false,
+    "opensSerialPort": false,
+    "privatePathsIncluded": false,
+    "promptCapture": false,
+    "promptContentIncluded": false,
+    "promptEchoed": false,
+    "promptPersistence": false,
+    "providerCalls": false,
+    "providerConfigRead": false,
+    "readOnly": true,
+    "readsArtifacts": false,
+    "responseChunkContentIncluded": false,
+    "responseChunksEmitted": false,
+    "responseContentIncluded": false,
+    "responseGenerated": false,
+    "responseStreamDisplayOnly": true,
+    "runtimeExecution": false,
+    "runtimeLogsIncluded": false,
+    "secretsIncluded": false,
+    "sendAttempted": false,
+    "sessionPersistence": false,
+    "sessionStoreRead": false,
+    "sessionStoreWrite": false,
+    "sshExecution": false,
+    "stableApiAbiClaim": false,
+    "streamCancellationAttempted": false,
+    "streamStarted": false,
+    "streamTransportOpened": false,
+    "telemetry": false,
+    "tokenContentIncluded": false,
+    "tokenCountMeasured": false,
+    "tokensIncluded": false,
+    "touchesHardware": false,
+    "transcriptPersistence": false,
+    "writeBack": false,
+    "writesArtifacts": false
+  },
+  "schemaVersion": "pccx.chatResponseStream.v0",
+  "sessionState": "inactive",
+  "streamEnvelope": {
+    "chunksEmitted": false,
+    "contentPolicy": "fixture carries response stream metadata only; no prompt, token, or response body is stored",
+    "envelopeId": "blocked_response_stream_gemma3n_e4b_kv260_placeholder",
+    "responseContentIncluded": false,
+    "schemaVersion": "pccx.chatResponseStreamEnvelope.v0",
+    "sideEffectPolicy": "no_runtime_execution_no_stream_transport_no_write",
+    "state": "blocked",
+    "stopSignalSent": false,
+    "streamStarted": false,
+    "summary": "Assistant response streaming is blocked because send, runtime, model, and session evidence are missing.",
+    "tokenContentIncluded": false,
+    "tokenCount": null,
+    "transportOpened": false
+  },
+  "streamId": "chat_response_stream_gemma3n_e4b_kv260_placeholder",
+  "streamPhases": [
+    {
+      "contentPolicy": "no_prompt_or_response_content",
+      "enabled": false,
+      "label": "wait for send result",
+      "phaseId": "wait_for_send_result",
+      "requiredBefore": "stream_transport_opened",
+      "state": "blocked",
+      "summary": "No send attempt exists, so no response stream can start.",
+      "visible": true
+    },
+    {
+      "contentPolicy": "no_runtime_log_or_transport_payload_content",
+      "enabled": false,
+      "label": "open stream transport",
+      "phaseId": "open_stream_transport",
+      "requiredBefore": "response_chunks_emitted",
+      "state": "not_started",
+      "summary": "No local runtime transport is implemented or opened.",
+      "visible": true
+    },
+    {
+      "contentPolicy": "no_generated_response_content",
+      "enabled": false,
+      "label": "emit response chunks",
+      "phaseId": "emit_response_chunks",
+      "requiredBefore": "assistant_message_available",
+      "state": "not_generated",
+      "summary": "No assistant response chunks are produced in this fixture.",
+      "visible": true
+    },
+    {
+      "contentPolicy": "no_transcript_or_summary_content",
+      "enabled": false,
+      "label": "complete stream",
+      "phaseId": "complete_stream",
+      "requiredBefore": "transcript_append_enabled",
+      "state": "unavailable",
+      "summary": "No stream completion event exists because no stream starts.",
+      "visible": true
+    }
+  ],
+  "streamState": "blocked",
+  "streamTransportState": "not_started",
+  "targetBoard": "xilinx_kria_kv260",
+  "targetDevice": "kv260",
+  "targetModel": "gemma3n-e4b",
+  "tokenState": "unavailable"
+}

--- a/docs/STANDALONE_CHAT_SESSION_CONTRACT.md
+++ b/docs/STANDALONE_CHAT_SESSION_CONTRACT.md
@@ -73,6 +73,7 @@ The implementation lives in:
 - `scripts/tests/status-chat-transcript-policy.sh`
 - `scripts/tests/status-chat-audit-event.sh`
 - `scripts/tests/status-chat-error-taxonomy.sh`
+- `scripts/tests/status-chat-response-stream.sh`
 
 ## What Is Implemented
 
@@ -97,6 +98,8 @@ The chat/session contract records:
   be enabled
 - safety flags for the read-only boundary
 - grouped chat error taxonomy metadata for future banners and status rows
+- blocked chat response stream metadata for disabled progress, token,
+  stop-control, and assistant response placeholders
 
 The checked fixture is deterministic JSON. The stub command prints that
 JSON for the supported model and target pair:
@@ -233,6 +236,19 @@ It keeps the attempted-send result in blocked local data: no prompt is
 accepted, captured, echoed, stored, or persisted; no assistant response
 is generated; no model/runtime handoff is attempted; and no transcript
 or artifact is written.
+
+The chat response stream fixture records the disabled assistant response
+stream/progress shape shown after the blocked send-result boundary:
+
+```bash
+bash scripts/chat-response-stream-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/status-stub.sh --include-chat-response-stream
+```
+
+It keeps response streaming as blocked local data: no stream transport
+is opened, no response chunks are generated, no token counts are
+measured, no stop signal is sent, no prompt or response content is read,
+and no transcript or artifact is written.
 
 The chat transcript policy fixture records the retention, export,
 storage, and privacy policy shape for future transcript UI surfaces:
@@ -397,6 +413,24 @@ content and assistant output:
 - `not_loaded`: model assets are not loaded
 - `not_started`: no local chat runtime has started
 
+The response-stream states keep progress display separate from response
+content, token data, runtime transport, and transcript storage:
+
+- `available_as_data`: checked placeholder display data is available
+  without executing anything
+- `blocked`: a required send-result or runtime boundary is missing
+- `disabled`: progress or cancellation controls are intentionally
+  unavailable
+- `inactive`: no launcher-owned session exists
+- `not_configured`: no transcript/session store exists
+- `not_generated`: no assistant response chunks have been produced
+- `not_loaded`: model assets are not loaded
+- `not_started`: no runtime transport or stream has started
+- `requires_evidence`: future enablement requires evidence first
+- `target_selected`: planned target identity can be displayed
+- `unavailable`: token counts, stream completion, or response content
+  are unavailable
+
 The transcript policy states keep retention and export rules separate
 from message content:
 
@@ -476,6 +510,10 @@ reads, clipboard access, or send enablement.
 The send-result contract adds a reviewable blocked-result display shape
 without prompt acceptance, prompt echo, response generation, runtime
 execution, model loading, persistence, or writes.
+The response-stream contract adds a reviewable disabled stream/progress
+display shape without opening transport, generating response chunks,
+counting tokens, sending cancellation signals, appending transcripts,
+executing runtime code, loading models, provider calls, or target access.
 The transcript policy contract adds a reviewable retention/export
 policy shape without message content, transcript persistence, summary
 generation, artifact reads, artifact writes, runtime execution, model
@@ -505,6 +543,8 @@ This chat/session surface does not add:
   clipboard access
 - send acceptance, prompt echo, response generation, or send-result
   persistence
+- response streaming, response chunk generation, token counting, stop
+  signal delivery, or stream transport behavior
 - transcript retention, transcript export, local transcript storage,
   transcript summaries, or transcript message content
 - audit logging, audit persistence, actor identifiers, event timestamps,

--- a/scripts/chat-response-stream-stub.sh
+++ b/scripts/chat-response-stream-stub.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+# Print the data-only chat response stream contract.
+
+set -eu
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+
+python3 "$ROOT_DIR/contracts/chat_response_stream_contract.py" "$@"

--- a/scripts/status-stub.sh
+++ b/scripts/status-stub.sh
@@ -46,6 +46,9 @@
 # Chat error taxonomy display boundary (explicit opt-in, read-only local data):
 #   --include-chat-error-taxonomy
 #
+# Chat response stream display boundary (explicit opt-in, read-only local data):
+#   --include-chat-response-stream
+#
 # pccx-lab backend (explicit opt-in):
 #   --backend pccx-lab        call pccx-lab status --format json
 #   PCCX_LAB_BIN              override path to pccx-lab binary (takes priority over PATH)
@@ -75,6 +78,7 @@ INCLUDE_CHAT_SEND_RESULT="0"
 INCLUDE_CHAT_TRANSCRIPT_POLICY="0"
 INCLUDE_CHAT_AUDIT_EVENT="0"
 INCLUDE_CHAT_ERROR_TAXONOMY="0"
+INCLUDE_CHAT_RESPONSE_STREAM="0"
 
 print_chat_error_taxonomy_summary() {
     SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
@@ -168,6 +172,120 @@ print(
 
     HEAD "chat error taxonomy"
     printf '%s\n' "$CHAT_ERROR_TAXONOMY_SUMMARY"
+}
+
+print_chat_response_stream_summary() {
+    SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+    ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+    CHAT_RESPONSE_STREAM_STUB="$ROOT_DIR/scripts/chat-response-stream-stub.sh"
+
+    if [ ! -f "$CHAT_RESPONSE_STREAM_STUB" ]; then
+        ERROR "chat response stream stub not found: $CHAT_RESPONSE_STREAM_STUB"
+        return 1
+    fi
+
+    if ! CHAT_RESPONSE_STREAM_JSON="$(bash "$CHAT_RESPONSE_STREAM_STUB" --model gemma3n-e4b --target kv260 2>&1)"; then
+        ERROR "chat response stream stub failed"
+        printf '%s\n' "$CHAT_RESPONSE_STREAM_JSON" >&2
+        return 1
+    fi
+
+    if ! CHAT_RESPONSE_STREAM_SUMMARY="$(
+        printf '%s\n' "$CHAT_RESPONSE_STREAM_JSON" | python3 -c '
+import json
+import sys
+
+data = json.load(sys.stdin)
+flags = data["safetyFlags"]
+envelope = data["streamEnvelope"]
+phases = " ".join(
+    "{}={}".format(phase["phaseId"], phase["state"])
+    for phase in data["streamPhases"]
+)
+slots = " ".join(
+    "{}={}".format(slot["slotId"], slot["state"])
+    for slot in data["displaySlots"]
+)
+blocked = " ".join(
+    "{}={}".format(reason["reasonId"], reason["state"])
+    for reason in data["blockedReasons"]
+)
+token_count = envelope["tokenCount"]
+token_count_text = "none" if token_count is None else str(token_count)
+
+def b(value):
+    return "true" if value else "false"
+
+print("[INFO]  source     : scripts/chat-response-stream-stub.sh --model gemma3n-e4b --target kv260")
+print("[INFO]  boundary   : read-only data; no prompt/response stream/model/runtime/hardware/lab/IDE execution")
+print("[INFO]  target     : {}".format(data["targetDevice"]))
+print("[INFO]  model      : {}".format(data["targetModel"]))
+print("[INFO]  stream     : {}".format(data["streamState"]))
+print("[INFO]  response   : {}".format(data["responseState"]))
+print("[INFO]  transport  : {}".format(data["streamTransportState"]))
+print("[INFO]  tokens     : {}".format(data["tokenState"]))
+print("[INFO]  progress   : {}".format(data["progressState"]))
+print("[INFO]  cancel     : {}".format(data["cancelState"]))
+print(
+    "[INFO]  envelope   : {} streamStarted={} transportOpened={} "
+    "chunksEmitted={} tokenContentIncluded={} responseContentIncluded={} "
+    "tokenCount={} stopSignalSent={}".format(
+        envelope["state"],
+        b(envelope["streamStarted"]),
+        b(envelope["transportOpened"]),
+        b(envelope["chunksEmitted"]),
+        b(envelope["tokenContentIncluded"]),
+        b(envelope["responseContentIncluded"]),
+        token_count_text,
+        b(envelope["stopSignalSent"]),
+    )
+)
+print("[INFO]  phases     : {}".format(phases))
+print("[INFO]  slots      : {}".format(slots))
+print("[INFO]  blocked    : {}".format(blocked))
+print(
+    "[INFO]  flags      : readOnly={} dataOnly={} deterministic={} "
+    "responseStreamDisplayOnly={} promptContentIncluded={} "
+    "responseContentIncluded={} responseGenerated={} "
+    "responseChunksEmitted={} tokenContentIncluded={} "
+    "tokenCountMeasured={} streamStarted={} streamTransportOpened={} "
+    "streamCancellationAttempted={} sessionStoreRead={} "
+    "modelAssetRead={} modelLoadAttempted={} modelExecution={} "
+    "runtimeExecution={} kv260Access={} hardwareAccess={} "
+    "networkCalls={} providerCalls={} executesPccxLab={}".format(
+        b(flags["readOnly"]),
+        b(flags["dataOnly"]),
+        b(flags["deterministic"]),
+        b(flags["responseStreamDisplayOnly"]),
+        b(flags["promptContentIncluded"]),
+        b(flags["responseContentIncluded"]),
+        b(flags["responseGenerated"]),
+        b(flags["responseChunksEmitted"]),
+        b(flags["tokenContentIncluded"]),
+        b(flags["tokenCountMeasured"]),
+        b(flags["streamStarted"]),
+        b(flags["streamTransportOpened"]),
+        b(flags["streamCancellationAttempted"]),
+        b(flags["sessionStoreRead"]),
+        b(flags["modelAssetRead"]),
+        b(flags["modelLoadAttempted"]),
+        b(flags["modelExecution"]),
+        b(flags["runtimeExecution"]),
+        b(flags["kv260Access"]),
+        b(flags["hardwareAccess"]),
+        b(flags["networkCalls"]),
+        b(flags["providerCalls"]),
+        b(flags["executesPccxLab"]),
+    )
+)
+'
+    )"; then
+        ERROR "chat response stream JSON could not be summarized"
+        return 1
+    fi
+
+    HEAD "chat response stream"
+    printf '%s\n' "$CHAT_RESPONSE_STREAM_SUMMARY"
 }
 
 print_chat_local_only_policy_summary() {
@@ -1561,6 +1679,10 @@ while [ $# -gt 0 ]; do
             INCLUDE_CHAT_ERROR_TAXONOMY="1"
             shift
             ;;
+        --include-chat-response-stream)
+            INCLUDE_CHAT_RESPONSE_STREAM="1"
+            shift
+            ;;
         --backend)
             BACKEND="${2:-}"
             if [ -z "$BACKEND" ]; then
@@ -1576,8 +1698,8 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-if [ -n "$BACKEND" ] && { [ "$INCLUDE_RUNTIME_READINESS" = "1" ] || [ "$INCLUDE_DEVICE_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SURFACE_LAYOUT" = "1" ] || [ "$INCLUDE_CHAT_LOCAL_ONLY_POLICY" = "1" ] || [ "$INCLUDE_CHAT_PREFERENCES" = "1" ] || [ "$INCLUDE_CHAT_SESSION_INDEX" = "1" ] || [ "$INCLUDE_CHAT_MODEL_STATUS" = "1" ] || [ "$INCLUDE_CHAT_READINESS" = "1" ] || [ "$INCLUDE_CHAT_COMPOSER" = "1" ] || [ "$INCLUDE_CHAT_SEND_RESULT" = "1" ] || [ "$INCLUDE_CHAT_TRANSCRIPT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_AUDIT_EVENT" = "1" ] || [ "$INCLUDE_CHAT_ERROR_TAXONOMY" = "1" ]; }; then
-    ERROR "--include-runtime-readiness, --include-device-session, --include-chat-session, --include-chat-surface-layout, --include-chat-local-only-policy, --include-chat-preferences, --include-chat-session-index, --include-chat-model-status, --include-chat-readiness, --include-chat-composer, --include-chat-send-result, --include-chat-transcript-policy, --include-chat-audit-event, and --include-chat-error-taxonomy are only supported in local scaffold mode"
+if [ -n "$BACKEND" ] && { [ "$INCLUDE_RUNTIME_READINESS" = "1" ] || [ "$INCLUDE_DEVICE_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SURFACE_LAYOUT" = "1" ] || [ "$INCLUDE_CHAT_LOCAL_ONLY_POLICY" = "1" ] || [ "$INCLUDE_CHAT_PREFERENCES" = "1" ] || [ "$INCLUDE_CHAT_SESSION_INDEX" = "1" ] || [ "$INCLUDE_CHAT_MODEL_STATUS" = "1" ] || [ "$INCLUDE_CHAT_READINESS" = "1" ] || [ "$INCLUDE_CHAT_COMPOSER" = "1" ] || [ "$INCLUDE_CHAT_SEND_RESULT" = "1" ] || [ "$INCLUDE_CHAT_TRANSCRIPT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_AUDIT_EVENT" = "1" ] || [ "$INCLUDE_CHAT_ERROR_TAXONOMY" = "1" ] || [ "$INCLUDE_CHAT_RESPONSE_STREAM" = "1" ]; }; then
+    ERROR "--include-runtime-readiness, --include-device-session, --include-chat-session, --include-chat-surface-layout, --include-chat-local-only-policy, --include-chat-preferences, --include-chat-session-index, --include-chat-model-status, --include-chat-readiness, --include-chat-composer, --include-chat-send-result, --include-chat-transcript-policy, --include-chat-audit-event, --include-chat-error-taxonomy, and --include-chat-response-stream are only supported in local scaffold mode"
     exit 1
 fi
 
@@ -1604,10 +1726,17 @@ if [ -z "$BACKEND" ]; then
     NOTE "chat transcript: opt-in via --include-chat-transcript-policy (read-only retention/export policy data)"
     NOTE "chat audit    : opt-in via --include-chat-audit-event (read-only blocked audit metadata)"
     NOTE "chat errors   : opt-in via --include-chat-error-taxonomy (read-only error taxonomy data)"
+    NOTE "chat stream   : opt-in via --include-chat-response-stream (read-only response stream data)"
     NOTE "editor bridge  : planned (VS Code / other IDEs)"
 
     if [ "$INCLUDE_CHAT_ERROR_TAXONOMY" = "1" ]; then
         if ! print_chat_error_taxonomy_summary; then
+            exit 1
+        fi
+    fi
+
+    if [ "$INCLUDE_CHAT_RESPONSE_STREAM" = "1" ]; then
+        if ! print_chat_response_stream_summary; then
             exit 1
         fi
     fi

--- a/scripts/tests/chat_response_stream_contract_test.py
+++ b/scripts/tests/chat_response_stream_contract_test.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Fixture tests for the standalone chat response stream contract."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "contracts" / "chat_response_stream_contract.py"
+FIXTURE_PATH = (
+    ROOT
+    / "contracts"
+    / "fixtures"
+    / "chat-response-stream.gemma3n-e4b-kv260-placeholder.json"
+)
+SCRIPT_PATH = ROOT / "scripts" / "chat-response-stream-stub.sh"
+STATUS_TEST_PATH = ROOT / "scripts" / "tests" / "status-chat-response-stream.sh"
+DOC_PATH = ROOT / "docs" / "STANDALONE_CHAT_SESSION_CONTRACT.md"
+README_PATH = ROOT / "README.md"
+TEST_PATH = Path(__file__).resolve()
+CI_PATH = ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location(
+        "chat_response_stream_contract",
+        MODULE_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def iter_state_values(value):
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            if key == "state" or key.endswith("State") or key.endswith("Status"):
+                yield nested
+            yield from iter_state_values(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            yield from iter_state_values(nested)
+
+
+def iter_keys(value):
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            yield key
+            yield from iter_keys(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            yield from iter_keys(nested)
+
+
+def assert_no_private_or_generated_data(text: str) -> None:
+    forbidden_patterns = [
+        r"/home/[^\s\"']+",
+        r"/Users/[^\s\"']+",
+        r"[A-Za-z]:\\Users\\",
+        r"\b(?:api[_-]?key|authorization|bearer|client[_-]?secret|password|private[_-]?key|secret|token)\b\s*[:=]",
+        r"\.(?:gguf|safetensors|ckpt|pt|pth|onnx)\b",
+        r"(?:weights|model_weights|model-cache)/(?:[^\"'\s]+)",
+        r"(?:raw[_-]?full[_-]?logs|hardware[_-]?dump|generated[_-]?blob)\s*[:=]",
+    ]
+    for pattern in forbidden_patterns:
+        assert not re.search(pattern, text, re.IGNORECASE), pattern
+
+
+def assert_no_runtime_implementation_terms(source: str) -> None:
+    forbidden = [
+        "subprocess",
+        "os.system",
+        "popen",
+        "socket",
+        "urllib",
+        "requests",
+        "http.client",
+        "openai",
+        "anthropic",
+        "gemini",
+        "modelcontextprotocol",
+        "websocket",
+        "xmutil",
+        "xrt-smi",
+        "lsusb",
+        "dmesg",
+    ]
+    lowered = source.lower()
+    for term in forbidden:
+        assert term not in lowered, term
+
+
+def assert_no_provider_configs(value) -> None:
+    forbidden_keys = {
+        "apiKey",
+        "accessToken",
+        "refreshToken",
+        "authorization",
+        "bearerToken",
+        "provider",
+        "providers",
+        "providerConfig",
+        "providerConfigs",
+    }
+    for key in iter_keys(value):
+        assert key not in forbidden_keys, key
+
+
+def assert_no_unsupported_claims(text: str) -> None:
+    literal_claims = [
+        "production-ready",
+        "marketplace-ready",
+        "stable API",
+        "stable ABI",
+        "KV260 inference works",
+        "Gemma 3N E4B runs on KV260",
+        "20 tok/s achieved",
+        "timing closed",
+        "bitstream ready",
+        "launcher executes pccx-lab",
+        "IDE controls launcher",
+        "AI provider integration is live",
+    ]
+    lowered = text.lower()
+    for claim in literal_claims:
+        assert claim.lower() not in lowered, claim
+
+
+def assert_no_chat_invocation_flags(source: str) -> None:
+    forbidden_patterns = [
+        r"--backend\s+pccx-lab",
+        r"\bPCCX_LAB_BIN\b",
+        r"\bpccx-lab\s+(?:status|diagnostics|validate)\b",
+        r"\bsystemverilog-ide\s+--",
+        r"\bsystemverilog-ide\s+(?:open|run|status|validate|launch)\b",
+        r"\b(?:curl|wget)\b",
+        r"\b(?:upload|telemetry|write-back)\s+(?:enabled|true)\b",
+    ]
+    for pattern in forbidden_patterns:
+        assert not re.search(pattern, source, re.IGNORECASE), pattern
+
+
+def test_chat_response_stream_matches_fixture_and_is_deterministic() -> None:
+    module = load_module()
+    generated = module.create_gemma3n_e4b_kv260_chat_response_stream()
+    fixture = json.loads(read_text(FIXTURE_PATH))
+
+    assert generated == fixture
+    assert module.chat_response_stream_json(generated) == (
+        module.chat_response_stream_json(generated)
+    )
+    assert module.chat_response_stream_json(generated).endswith("\n")
+    assert json.loads(module.chat_response_stream_json(generated)) == fixture
+
+
+def test_cli_stub_outputs_deterministic_json() -> None:
+    fixture = json.loads(read_text(FIXTURE_PATH))
+    command = [
+        "bash",
+        str(SCRIPT_PATH),
+        "--model",
+        "gemma3n-e4b",
+        "--target",
+        "kv260",
+    ]
+    first = subprocess.run(command, check=True, capture_output=True, text=True)
+    second = subprocess.run(command, check=True, capture_output=True, text=True)
+
+    assert first.stderr == ""
+    assert first.stdout == second.stdout
+    assert first.stdout.endswith("\n")
+    assert json.loads(first.stdout) == fixture
+
+
+def test_required_fields_and_allowed_states() -> None:
+    module = load_module()
+    stream = module.create_gemma3n_e4b_kv260_chat_response_stream()
+    allowed = set(module.CHAT_RESPONSE_STREAM_STATE_VALUES)
+
+    assert tuple(stream.keys()) == module.CHAT_RESPONSE_STREAM_FIELDS
+    assert stream["schemaVersion"] == "pccx.chatResponseStream.v0"
+    assert tuple(stream["streamEnvelope"].keys()) == module.STREAM_ENVELOPE_FIELDS
+
+    states = list(iter_state_values(stream))
+    assert states
+    for state in states:
+        assert state in allowed, state
+
+    for phase in stream["streamPhases"]:
+        assert tuple(phase.keys()) == module.STREAM_PHASE_FIELDS
+    for slot in stream["displaySlots"]:
+        assert tuple(slot.keys()) == module.DISPLAY_SLOT_FIELDS
+    for reason in stream["blockedReasons"]:
+        assert tuple(reason.keys()) == module.BLOCKED_REASON_FIELDS
+    for ref in stream["handoffRefs"]:
+        assert tuple(ref.keys()) == module.HANDOFF_REF_FIELDS
+
+
+def test_chat_response_stream_keeps_streaming_blocked() -> None:
+    stream = load_module().create_gemma3n_e4b_kv260_chat_response_stream()
+    envelope = stream["streamEnvelope"]
+    phases = {phase["phaseId"]: phase for phase in stream["streamPhases"]}
+    slots = {slot["slotId"]: slot for slot in stream["displaySlots"]}
+    reasons = {reason["reasonId"]: reason for reason in stream["blockedReasons"]}
+    refs = {ref["refId"]: ref for ref in stream["handoffRefs"]}
+
+    assert stream["streamState"] == "blocked"
+    assert stream["responseState"] == "not_generated"
+    assert stream["streamTransportState"] == "not_started"
+    assert stream["tokenState"] == "unavailable"
+    assert stream["progressState"] == "disabled"
+    assert stream["cancelState"] == "disabled"
+    assert envelope["streamStarted"] is False
+    assert envelope["transportOpened"] is False
+    assert envelope["chunksEmitted"] is False
+    assert envelope["tokenContentIncluded"] is False
+    assert envelope["responseContentIncluded"] is False
+    assert envelope["tokenCount"] is None
+    assert envelope["stopSignalSent"] is False
+    assert phases["wait_for_send_result"]["state"] == "blocked"
+    assert phases["open_stream_transport"]["state"] == "not_started"
+    assert phases["emit_response_chunks"]["state"] == "not_generated"
+    assert phases["complete_stream"]["state"] == "unavailable"
+    assert slots["assistant_response_placeholder"]["state"] == "available_as_data"
+    assert slots["token_counter"]["visible"] is False
+    assert slots["stop_generation_control"]["enabled"] is False
+    assert reasons["send_result_blocked"]["requiredBefore"] == "response_stream_started"
+    assert reasons["runtime_not_started"]["requiredBefore"] == "stream_transport_opened"
+    assert refs["chat_send_result"]["schemaVersion"] == "pccx.chatSendResult.v0"
+    assert refs["chat_transcript_policy"]["state"] == "disabled"
+
+
+def test_safety_flags_prevent_runtime_provider_content_and_store_paths() -> None:
+    flags = load_module().create_gemma3n_e4b_kv260_chat_response_stream()[
+        "safetyFlags"
+    ]
+
+    assert flags["readOnly"] is True
+    assert flags["dataOnly"] is True
+    assert flags["deterministic"] is True
+    assert flags["responseStreamDisplayOnly"] is True
+    assert flags["promptCapture"] is False
+    assert flags["promptContentIncluded"] is False
+    assert flags["inputAccepted"] is False
+    assert flags["sendAttempted"] is False
+    assert flags["responseContentIncluded"] is False
+    assert flags["responseGenerated"] is False
+    assert flags["responseChunkContentIncluded"] is False
+    assert flags["responseChunksEmitted"] is False
+    assert flags["tokenContentIncluded"] is False
+    assert flags["tokenCountMeasured"] is False
+    assert flags["streamStarted"] is False
+    assert flags["streamTransportOpened"] is False
+    assert flags["streamCancellationAttempted"] is False
+    assert flags["sessionStoreRead"] is False
+    assert flags["sessionStoreWrite"] is False
+    assert flags["modelAssetRead"] is False
+    assert flags["modelLoadAttempted"] is False
+    assert flags["modelExecution"] is False
+    assert flags["runtimeExecution"] is False
+    assert flags["kv260Access"] is False
+    assert flags["hardwareAccess"] is False
+    assert flags["providerCalls"] is False
+    assert flags["cloudCalls"] is False
+    assert flags["networkCalls"] is False
+    assert flags["executesPccxLab"] is False
+    assert flags["executesSystemverilogIde"] is False
+
+
+def test_contract_avoids_private_data_runtime_terms_and_provider_config() -> None:
+    module_text = read_text(MODULE_PATH)
+    fixture_text = read_text(FIXTURE_PATH)
+    fixture = json.loads(fixture_text)
+
+    assert_no_private_or_generated_data(module_text)
+    assert_no_private_or_generated_data(fixture_text)
+    assert_no_runtime_implementation_terms(module_text)
+    assert_no_provider_configs(fixture)
+    assert_no_unsupported_claims(module_text)
+    assert_no_unsupported_claims(fixture_text)
+
+
+def test_docs_scripts_and_ci_reference_chat_response_stream() -> None:
+    assert "chat_response_stream_contract.py" in read_text(TEST_PATH)
+    assert "chat-response-stream-stub.sh" in read_text(TEST_PATH)
+    assert "status-chat-response-stream.sh" in read_text(TEST_PATH)
+    assert "chat-response-stream-stub.sh" in read_text(README_PATH)
+    assert "chat_response_stream_contract.py" in read_text(README_PATH)
+    assert "chat response stream" in read_text(DOC_PATH)
+    assert "chat_response_stream_contract_test.py" in read_text(CI_PATH)
+    assert "status-chat-response-stream.sh" in read_text(CI_PATH)
+    assert_no_chat_invocation_flags(read_text(SCRIPT_PATH))
+
+
+def test_source_headers_for_touched_code_files() -> None:
+    expected_headers = {
+        MODULE_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        SCRIPT_PATH: [
+            "#!/usr/bin/env bash",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        STATUS_TEST_PATH: [
+            "#!/usr/bin/env bash",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        TEST_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        CI_PATH: [
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+    }
+
+    for path, header in expected_headers.items():
+        assert read_text(path).splitlines()[: len(header)] == header, path
+
+
+if __name__ == "__main__":
+    for name, func in sorted(globals().items()):
+        if name.startswith("test_") and callable(func):
+            func()
+    print("chat response stream contract tests ok")

--- a/scripts/tests/status-chat-response-stream.sh
+++ b/scripts/tests/status-chat-response-stream.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+# scripts/tests/status-chat-response-stream.sh - status response stream tests.
+#
+# Usage: bash scripts/tests/status-chat-response-stream.sh [path/to/status-stub.sh]
+
+set -eu
+
+PASS() { printf '[PASS]  %s\n' "$*"; }
+FAIL() { printf '[FAIL] %s\n' "$*" >&2; }
+HEAD() { printf '\n=== %s ===\n' "$*"; }
+
+STUB="${1:-scripts/status-stub.sh}"
+
+if [ ! -x "$STUB" ]; then
+    chmod +x "$STUB"
+fi
+
+contains() {
+    case "$1" in
+        *"$2"*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+require_contains() {
+    local output="$1"
+    local expected="$2"
+    if ! contains "$output" "$expected"; then
+        FAIL "expected output to contain: $expected"
+        printf '%s\n' "$output" >&2
+        exit 1
+    fi
+}
+
+require_not_contains() {
+    local output="$1"
+    local forbidden="$2"
+    if contains "$output" "$forbidden"; then
+        FAIL "output contained forbidden text: $forbidden"
+        printf '%s\n' "$output" >&2
+        exit 1
+    fi
+}
+
+HEAD "1: status can include chat response stream"
+OUTPUT="$("$STUB" --include-chat-response-stream)"
+require_contains "$OUTPUT" "=== chat response stream ==="
+require_contains "$OUTPUT" "source     : scripts/chat-response-stream-stub.sh --model gemma3n-e4b --target kv260"
+require_contains "$OUTPUT" "boundary   : read-only data; no prompt/response stream/model/runtime/hardware/lab/IDE execution"
+require_contains "$OUTPUT" "target     : kv260"
+require_contains "$OUTPUT" "model      : gemma3n-e4b"
+require_contains "$OUTPUT" "stream     : blocked"
+require_contains "$OUTPUT" "response   : not_generated"
+require_contains "$OUTPUT" "transport  : not_started"
+require_contains "$OUTPUT" "tokens     : unavailable"
+require_contains "$OUTPUT" "progress   : disabled"
+require_contains "$OUTPUT" "cancel     : disabled"
+PASS "chat response stream section is present and conservative"
+
+HEAD "2: envelope and display slots stay blocked"
+require_contains "$OUTPUT" "envelope   : blocked streamStarted=false transportOpened=false chunksEmitted=false tokenContentIncluded=false responseContentIncluded=false tokenCount=none stopSignalSent=false"
+require_contains "$OUTPUT" "phases     : wait_for_send_result=blocked"
+require_contains "$OUTPUT" "open_stream_transport=not_started"
+require_contains "$OUTPUT" "emit_response_chunks=not_generated"
+require_contains "$OUTPUT" "complete_stream=unavailable"
+require_contains "$OUTPUT" "slots      : assistant_response_placeholder=available_as_data"
+require_contains "$OUTPUT" "stream_progress_indicator=disabled"
+require_contains "$OUTPUT" "token_counter=unavailable"
+require_contains "$OUTPUT" "stop_generation_control=disabled"
+require_contains "$OUTPUT" "blocked    : send_result_blocked=blocked"
+require_contains "$OUTPUT" "runtime_not_started=not_started"
+require_contains "$OUTPUT" "model_not_loaded=not_loaded"
+require_contains "$OUTPUT" "session_inactive=inactive"
+require_contains "$OUTPUT" "transcript_policy_disabled=disabled"
+PASS "response stream display metadata is summarized"
+
+HEAD "3: safety flags stay read-only and non-executing"
+require_contains "$OUTPUT" "readOnly=true"
+require_contains "$OUTPUT" "dataOnly=true"
+require_contains "$OUTPUT" "deterministic=true"
+require_contains "$OUTPUT" "responseStreamDisplayOnly=true"
+require_contains "$OUTPUT" "promptContentIncluded=false"
+require_contains "$OUTPUT" "responseContentIncluded=false"
+require_contains "$OUTPUT" "responseGenerated=false"
+require_contains "$OUTPUT" "responseChunksEmitted=false"
+require_contains "$OUTPUT" "tokenContentIncluded=false"
+require_contains "$OUTPUT" "tokenCountMeasured=false"
+require_contains "$OUTPUT" "streamStarted=false"
+require_contains "$OUTPUT" "streamTransportOpened=false"
+require_contains "$OUTPUT" "streamCancellationAttempted=false"
+require_contains "$OUTPUT" "sessionStoreRead=false"
+require_contains "$OUTPUT" "modelAssetRead=false"
+require_contains "$OUTPUT" "modelLoadAttempted=false"
+require_contains "$OUTPUT" "modelExecution=false"
+require_contains "$OUTPUT" "runtimeExecution=false"
+require_contains "$OUTPUT" "kv260Access=false"
+require_contains "$OUTPUT" "hardwareAccess=false"
+require_contains "$OUTPUT" "networkCalls=false"
+require_contains "$OUTPUT" "providerCalls=false"
+require_contains "$OUTPUT" "executesPccxLab=false"
+PASS "execution-related flags remain false"
+
+HEAD "4: output is deterministic"
+OUTPUT_AGAIN="$("$STUB" --include-chat-response-stream)"
+if [ "$OUTPUT" != "$OUTPUT_AGAIN" ]; then
+    FAIL "status chat response stream output changed between runs"
+    exit 1
+fi
+PASS "status chat response stream output is deterministic"
+
+HEAD "5: chat response stream option does not combine with pccx-lab backend"
+if "$STUB" --include-chat-response-stream --backend pccx-lab >/dev/null 2>&1; then
+    FAIL "expected combined chat-response-stream/backend mode to fail"
+    exit 1
+fi
+PASS "chat response stream remains separate from backend execution"
+
+HEAD "6: output avoids known overclaims"
+FORBIDDEN_PREFIX="KV260 inference"
+FORBIDDEN_CLAIM="${FORBIDDEN_PREFIX} works"
+require_not_contains "$OUTPUT" "$FORBIDDEN_CLAIM"
+THROUGHPUT_PREFIX="20 tok/s"
+THROUGHPUT_CLAIM="${THROUGHPUT_PREFIX} achieved"
+require_not_contains "$OUTPUT" "$THROUGHPUT_CLAIM"
+PASS "no chat response stream or throughput overclaim in status output"
+
+printf '\n[DONE]  all status-chat-response-stream tests passed\n'


### PR DESCRIPTION
Refs #9.

## Summary
- add a checked data-only chat response stream fixture for disabled assistant streaming/progress display
- add the response stream stub and opt-in status summary
- document and test that stream transport, chunks, token counts, stop signals, transcript writes, runtime/model/provider/hardware paths, and repo integrations stay unavailable

## Safety
This is a read-only fixture and status display boundary. It does not accept prompts, echo prompts, generate responses, emit response chunks, count tokens, open stream transport, send cancellation signals, read stores, write transcripts, read/write artifacts, load models, execute runtime code, call providers or networks, touch hardware/KV260, invoke pccx-lab, invoke systemverilog-ide, upload telemetry, or make compatibility or readiness claims.

## Validation
- python3 scripts/tests/chat_response_stream_contract_test.py
- bash scripts/tests/status-chat-response-stream.sh scripts/status-stub.sh
- python3 -m json.tool contracts/fixtures/chat-response-stream.gemma3n-e4b-kv260-placeholder.json
- bash scripts/chat-response-stream-stub.sh --model gemma3n-e4b --target kv260
- python3 -m py_compile contracts/*.py scripts/tests/*.py
- bash -n scripts/*.sh scripts/tests/*.sh
- bash scripts/check.sh
- for test in scripts/tests/*_test.py; do python3 "$test"; done
- for test in scripts/tests/status-*.sh; do bash "$test" scripts/status-stub.sh; done
- local claim scan matching CI pattern
- git diff --check
- git diff --cached --check