### PR TITLE
Add chat action-bar boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,7 @@ jobs:
                    scripts/chat-error-taxonomy-stub.sh \
                    scripts/chat-response-stream-stub.sh \
                    scripts/chat-message-list-stub.sh \
+                   scripts/chat-action-bar-stub.sh \
                    scripts/chat-surface-preview.sh \
                    scripts/chat-stub.sh; do
             [ -f "$f" ] && chmod +x "$f" || true
@@ -223,6 +224,10 @@ jobs:
         run: ./scripts/status-stub.sh --include-chat-message-list
       - name: run scripts/chat-message-list-stub.sh
         run: ./scripts/chat-message-list-stub.sh --model gemma3n-e4b --target kv260
+      - name: run scripts/status-stub.sh with chat action bar
+        run: ./scripts/status-stub.sh --include-chat-action-bar
+      - name: run scripts/chat-action-bar-stub.sh
+        run: ./scripts/chat-action-bar-stub.sh --model gemma3n-e4b --target kv260
       - name: run scripts/chat-surface-preview.sh
         run: ./scripts/chat-surface-preview.sh --model gemma3n-e4b --target kv260
       - name: run scripts/chat-stub.sh --dry-run
@@ -275,6 +280,8 @@ jobs:
         run: python3 scripts/tests/chat_response_stream_contract_test.py
       - name: run chat message-list contract tests
         run: python3 scripts/tests/chat_message_list_contract_test.py
+      - name: run chat action-bar contract tests
+        run: python3 scripts/tests/chat_action_bar_contract_test.py
       - name: run chat surface preview tests
         run: python3 scripts/tests/chat_surface_preview_test.py
 
@@ -302,6 +309,7 @@ jobs:
           chmod +x scripts/chat-error-taxonomy-stub.sh
           chmod +x scripts/chat-response-stream-stub.sh
           chmod +x scripts/chat-message-list-stub.sh
+          chmod +x scripts/chat-action-bar-stub.sh
           chmod +x scripts/launch-stub.sh
           chmod +x scripts/tests/status-backend.sh
           chmod +x scripts/tests/status-device-session.sh
@@ -320,6 +328,7 @@ jobs:
           chmod +x scripts/tests/status-chat-error-taxonomy.sh
           chmod +x scripts/tests/status-chat-response-stream.sh
           chmod +x scripts/tests/status-chat-message-list.sh
+          chmod +x scripts/tests/status-chat-action-bar.sh
       - name: shellcheck status-stub and test script
         run: |
           sudo apt-get update -q && sudo apt-get install -y -q shellcheck
@@ -341,6 +350,7 @@ jobs:
           shellcheck scripts/tests/status-chat-error-taxonomy.sh
           shellcheck scripts/tests/status-chat-response-stream.sh
           shellcheck scripts/tests/status-chat-message-list.sh
+          shellcheck scripts/tests/status-chat-action-bar.sh
       - name: run status-backend tests
         run: bash scripts/tests/status-backend.sh scripts/status-stub.sh
       - name: run status-device-session tests
@@ -375,3 +385,5 @@ jobs:
         run: bash scripts/tests/status-chat-response-stream.sh scripts/status-stub.sh
       - name: run status-chat-message-list tests
         run: bash scripts/tests/status-chat-message-list.sh scripts/status-stub.sh
+      - name: run status-chat-action-bar tests
+        run: bash scripts/tests/status-chat-action-bar.sh scripts/status-stub.sh

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ and verify host-side prerequisites before the real engine lands.
 | [`scripts/check.sh`](./scripts/check.sh) | Probe host info, tooling availability, edge-device hints. Always exits 0. |
 | [`scripts/check-device-stub.sh`](./scripts/check-device-stub.sh) | Narrowly scoped device-tree / FPGA-node probe (KV260 / Kria detection only). Always exits 0. |
 | [`scripts/install-stub.sh`](./scripts/install-stub.sh) | Preview of the planned install flow; reports which host runtime pieces are present, lists device-side pieces as future deliverables. Always exits 0. |
-| [`scripts/status-stub.sh`](./scripts/status-stub.sh) | Launcher state summary. Default mode: local scaffold output, always exits 0. With `--include-chat-message-list`, adds read-only empty chat message-list data. With `--include-chat-response-stream`, adds read-only blocked chat response stream data. With `--include-chat-error-taxonomy`, adds read-only chat error taxonomy data. With `--include-chat-audit-event`, adds read-only blocked chat audit-event metadata. With `--include-chat-surface-layout`, adds read-only chat surface layout data. With `--include-chat-local-only-policy`, adds read-only local-only/cloud-block policy data. With `--include-chat-preferences`, adds read-only chat preferences/settings data. With `--include-chat-session-index`, adds read-only empty chat session index data. With `--include-chat-transcript-policy`, adds read-only chat transcript retention/export policy data. With `--include-chat-send-result`, adds read-only blocked chat send-result data. With `--include-chat-composer`, adds read-only chat composer/input-control data. With `--include-chat-model-status`, adds read-only blocked chat model-status display data. With `--include-chat-session`, adds read-only blocked chat/session and lifecycle summaries. With `--include-chat-readiness`, adds read-only chat readiness checks and recovery actions. With `--include-device-session`, adds a read-only device/session status panel. With `--include-runtime-readiness`, adds a read-only runtime readiness summary. With `--backend pccx-lab`, calls `pccx-lab status --format json` and forwards the run-status envelope (exits non-zero if binary is missing or output is invalid). |
+| [`scripts/status-stub.sh`](./scripts/status-stub.sh) | Launcher state summary. Default mode: local scaffold output, always exits 0. With `--include-chat-action-bar`, adds read-only disabled chat action-bar data. With `--include-chat-message-list`, adds read-only empty chat message-list data. With `--include-chat-response-stream`, adds read-only blocked chat response stream data. With `--include-chat-error-taxonomy`, adds read-only chat error taxonomy data. With `--include-chat-audit-event`, adds read-only blocked chat audit-event metadata. With `--include-chat-surface-layout`, adds read-only chat surface layout data. With `--include-chat-local-only-policy`, adds read-only local-only/cloud-block policy data. With `--include-chat-preferences`, adds read-only chat preferences/settings data. With `--include-chat-session-index`, adds read-only empty chat session index data. With `--include-chat-transcript-policy`, adds read-only chat transcript retention/export policy data. With `--include-chat-send-result`, adds read-only blocked chat send-result data. With `--include-chat-composer`, adds read-only chat composer/input-control data. With `--include-chat-model-status`, adds read-only blocked chat model-status display data. With `--include-chat-session`, adds read-only blocked chat/session and lifecycle summaries. With `--include-chat-readiness`, adds read-only chat readiness checks and recovery actions. With `--include-device-session`, adds a read-only device/session status panel. With `--include-runtime-readiness`, adds a read-only runtime readiness summary. With `--backend pccx-lab`, calls `pccx-lab status --format json` and forwards the run-status envelope (exits non-zero if binary is missing or output is invalid). |
 | [`scripts/device-session-status-stub.sh`](./scripts/device-session-status-stub.sh) | Data-only device/session status JSON for the Gemma 3N E4B + KV260 target. Reports connection, model load, session, diagnostics, readiness, discovery paths, flow steps, and error taxonomy as placeholder / blocked. |
 | [`scripts/runtime-readiness-stub.sh`](./scripts/runtime-readiness-stub.sh) | Data-only runtime readiness JSON for the Gemma 3N E4B + KV260 target. Reports blocked / not yet evidence-backed. |
 | [`scripts/chat-session-stub.sh`](./scripts/chat-session-stub.sh) | Data-only standalone chat/session JSON for the Gemma 3N E4B + KV260 target. Reports disabled send controls, inactive session state, no prompt/response persistence, and readiness handoff references. |
@@ -102,6 +102,7 @@ and verify host-side prerequisites before the real engine lands.
 | [`scripts/chat-send-result-stub.sh`](./scripts/chat-send-result-stub.sh) | Data-only blocked chat send-result JSON for the Gemma 3N E4B + KV260 target. Reports disabled send state, no accepted input, no prompt echo, no generated response, and no runtime/model handoff. |
 | [`scripts/chat-response-stream-stub.sh`](./scripts/chat-response-stream-stub.sh) | Data-only blocked chat response stream JSON for the Gemma 3N E4B + KV260 target. Reports disabled response streaming, progress, token counter, and stop-control state without opening transport, generating chunks, counting tokens, or writing transcripts. |
 | [`scripts/chat-message-list-stub.sh`](./scripts/chat-message-list-stub.sh) | Data-only empty chat message-list JSON for the Gemma 3N E4B + KV260 target. Reports an empty conversation viewport without reading a session store, transcript, prompt, response, summary, model path, runtime log, or artifact. |
+| [`scripts/chat-action-bar-stub.sh`](./scripts/chat-action-bar-stub.sh) | Data-only disabled chat action-bar JSON for the Gemma 3N E4B + KV260 target. Reports new, clear, export, retry, copy, stop, and attach controls without reading stores, transcripts, message bodies, files, clipboard data, model paths, runtime logs, or artifacts. |
 | [`scripts/chat-transcript-policy-stub.sh`](./scripts/chat-transcript-policy-stub.sh) | Data-only chat transcript policy JSON for the Gemma 3N E4B + KV260 target. Reports retention, export, storage, and privacy policy state without reading, generating, storing, persisting, summarizing, or exporting prompt/response/transcript content. |
 | [`scripts/chat-audit-event-stub.sh`](./scripts/chat-audit-event-stub.sh) | Data-only chat audit-event JSON for the Gemma 3N E4B + KV260 target. Reports blocked send metadata, redaction policy, absent prompt/response/transcript content, and disabled audit persistence. |
 | [`scripts/chat-error-taxonomy-stub.sh`](./scripts/chat-error-taxonomy-stub.sh) | Data-only chat error taxonomy JSON for the Gemma 3N E4B + KV260 target. Groups blocked readiness, model/runtime, session, and policy errors without reading prompts, providers, configs, model paths, logs, stores, or artifacts. |
@@ -128,6 +129,7 @@ bash scripts/status-stub.sh --include-chat-audit-event
 bash scripts/status-stub.sh --include-chat-error-taxonomy
 bash scripts/status-stub.sh --include-chat-response-stream
 bash scripts/status-stub.sh --include-chat-message-list
+bash scripts/status-stub.sh --include-chat-action-bar
 bash scripts/status-stub.sh --include-device-session
 bash scripts/status-stub.sh --include-runtime-readiness
 bash scripts/device-session-status-stub.sh --model gemma3n-e4b --target kv260
@@ -147,6 +149,7 @@ bash scripts/chat-audit-event-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-error-taxonomy-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-response-stream-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-message-list-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/chat-action-bar-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-surface-preview.sh --model gemma3n-e4b --target kv260
 bash scripts/launch-stub.sh --dry-run
 bash scripts/chat-stub.sh --dry-run --prompt "hello"
@@ -317,6 +320,7 @@ python3 contracts/chat_readiness_contract.py --model gemma3n-e4b --target kv260
 python3 contracts/chat_audit_event_contract.py --model gemma3n-e4b --target kv260
 python3 contracts/chat_error_taxonomy_contract.py --model gemma3n-e4b --target kv260
 python3 contracts/chat_response_stream_contract.py --model gemma3n-e4b --target kv260
+python3 contracts/chat_action_bar_contract.py --model gemma3n-e4b --target kv260
 bash scripts/chat-model-status-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-session-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-session-lifecycle-stub.sh --model gemma3n-e4b --target kv260
@@ -324,6 +328,7 @@ bash scripts/chat-readiness-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-audit-event-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-error-taxonomy-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-response-stream-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/chat-action-bar-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-surface-preview.sh --model gemma3n-e4b --target kv260
 bash scripts/status-stub.sh --include-chat-model-status
 bash scripts/status-stub.sh --include-chat-session
@@ -331,6 +336,7 @@ bash scripts/status-stub.sh --include-chat-readiness
 bash scripts/status-stub.sh --include-chat-audit-event
 bash scripts/status-stub.sh --include-chat-error-taxonomy
 bash scripts/status-stub.sh --include-chat-response-stream
+bash scripts/status-stub.sh --include-chat-action-bar
 python3 scripts/tests/chat_session_contract_test.py
 python3 scripts/tests/chat_model_status_contract_test.py
 python3 scripts/tests/chat_session_lifecycle_contract_test.py
@@ -338,6 +344,7 @@ python3 scripts/tests/chat_readiness_contract_test.py
 python3 scripts/tests/chat_audit_event_contract_test.py
 python3 scripts/tests/chat_error_taxonomy_contract_test.py
 python3 scripts/tests/chat_response_stream_contract_test.py
+python3 scripts/tests/chat_action_bar_contract_test.py
 python3 scripts/tests/chat_surface_preview_test.py
 bash scripts/tests/status-chat-model-status.sh
 bash scripts/tests/status-chat-session.sh
@@ -345,6 +352,7 @@ bash scripts/tests/status-chat-readiness.sh
 bash scripts/tests/status-chat-audit-event.sh
 bash scripts/tests/status-chat-error-taxonomy.sh
 bash scripts/tests/status-chat-response-stream.sh
+bash scripts/tests/status-chat-action-bar.sh
 ```
 
 The checked chat/session fixture reports the chat surface as blocked,
@@ -391,6 +399,12 @@ phases, response placeholders, token-counter state, and stop-control state
 without accepting prompts, opening stream transport, generating response
 chunks, counting tokens, appending transcripts, reading stores, or writing
 artifacts.
+
+The chat action-bar fixture defines the disabled conversation action
+controls for the planned chat surface. It records new chat, clear,
+export, retry, copy, stop, and attach controls without reading session
+stores, transcripts, message bodies, files, clipboard data, model paths,
+runtime logs, or artifacts.
 
 The preview command renders that same contract as a deterministic
 terminal chat surface sketch with disabled controls, blocked reasons, and

--- a/contracts/chat_action_bar_contract.py
+++ b/contracts/chat_action_bar_contract.py
@@ -1,0 +1,515 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Data-only chat action-bar contract for the planned launcher UI.
+
+The contract describes disabled conversation action controls for the
+standalone chat surface. It does not read prompts, responses, transcripts,
+session stores, summaries, model assets, private paths, logs, or artifacts;
+it does not copy to the clipboard, export transcripts, attach files, create
+sessions, clear conversations, stop streams, start runtime code, load models,
+touch KV260 hardware, call providers, invoke pccx-lab, or persist anything.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import sys
+
+
+SCHEMA_VERSION = "pccx.chatActionBar.v0"
+
+CHAT_ACTION_BAR_FIELDS = (
+    "schemaVersion",
+    "actionBarId",
+    "fixtureVersion",
+    "lastUpdatedSource",
+    "targetDevice",
+    "targetBoard",
+    "targetModel",
+    "actionBarState",
+    "conversationState",
+    "selectionState",
+    "transcriptState",
+    "responseState",
+    "attachmentState",
+    "clipboardState",
+    "exportState",
+    "stopControlState",
+    "chatSessionRef",
+    "chatReadinessRef",
+    "chatComposerRef",
+    "chatSendResultRef",
+    "chatResponseStreamRef",
+    "chatMessageListRef",
+    "actionPolicy",
+    "actionGroups",
+    "actionControls",
+    "blockedReasons",
+    "handoffRefs",
+    "safetyFlags",
+    "limitations",
+    "issueRefs",
+)
+
+ACTION_POLICY_FIELDS = (
+    "state",
+    "renderMode",
+    "sourcePolicy",
+    "contentPolicy",
+    "interactionPolicy",
+    "sideEffectPolicy",
+    "persistencePolicy",
+)
+
+ACTION_GROUP_FIELDS = (
+    "groupId",
+    "label",
+    "state",
+    "visible",
+    "enabled",
+    "summary",
+)
+
+ACTION_CONTROL_FIELDS = (
+    "actionId",
+    "label",
+    "groupId",
+    "state",
+    "visible",
+    "enabled",
+    "requiresExplicitUserAction",
+    "sourceRef",
+    "resultState",
+    "sideEffectPolicy",
+    "blockedReasonRef",
+)
+
+BLOCKED_REASON_FIELDS = (
+    "reasonId",
+    "state",
+    "summary",
+    "requiredBefore",
+)
+
+HANDOFF_REF_FIELDS = (
+    "refId",
+    "schemaVersion",
+    "fixturePath",
+    "state",
+    "summary",
+)
+
+CHAT_ACTION_BAR_STATE_VALUES = (
+    "available_as_data",
+    "blocked",
+    "disabled",
+    "empty_not_captured",
+    "inactive",
+    "not_configured",
+    "not_generated",
+    "not_loaded",
+    "not_started",
+    "placeholder",
+    "planned",
+    "requires_evidence",
+    "summary_only",
+    "target_selected",
+    "unavailable",
+)
+
+_CHAT_ACTION_BAR = {
+    "schemaVersion": SCHEMA_VERSION,
+    "actionBarId": "chat_action_bar_gemma3n_e4b_kv260_placeholder",
+    "fixtureVersion": "chat-action-bar.gemma3n-e4b-kv260.2026-05-04",
+    "lastUpdatedSource": "pccx_launcher_issue_9_chat_action_bar_boundary_2026-05-04",
+    "targetDevice": "kv260",
+    "targetBoard": "xilinx_kria_kv260",
+    "targetModel": "gemma3n-e4b",
+    "actionBarState": "blocked",
+    "conversationState": "inactive",
+    "selectionState": "disabled",
+    "transcriptState": "not_started",
+    "responseState": "not_generated",
+    "attachmentState": "disabled",
+    "clipboardState": "disabled",
+    "exportState": "disabled",
+    "stopControlState": "disabled",
+    "chatSessionRef": "chat_session_gemma3n_e4b_kv260_placeholder",
+    "chatReadinessRef": "chat_readiness_gemma3n_e4b_kv260_placeholder",
+    "chatComposerRef": "chat_composer_gemma3n_e4b_kv260_placeholder",
+    "chatSendResultRef": "chat_send_result_gemma3n_e4b_kv260_placeholder",
+    "chatResponseStreamRef": "chat_response_stream_gemma3n_e4b_kv260_placeholder",
+    "chatMessageListRef": "chat_message_list_gemma3n_e4b_kv260_placeholder",
+    "actionPolicy": {
+        "state": "placeholder",
+        "renderMode": "future_local_chat_action_bar",
+        "sourcePolicy": "checked fixture only; no session store, transcript, prompt, response, summary, file, clipboard, or model path is read",
+        "contentPolicy": "action metadata only; no message bodies, prompt text, response text, transcript text, or session titles are included",
+        "interactionPolicy": "all conversation actions remain disabled until reviewed runtime, session-store, transcript, clipboard, and attachment boundaries exist",
+        "sideEffectPolicy": "local_render_only",
+        "persistencePolicy": "no session creation, clear, export, copy, retry, stop, attachment, transcript, or artifact write",
+    },
+    "actionGroups": [
+        {
+            "groupId": "conversation_actions",
+            "label": "conversation actions",
+            "state": "blocked",
+            "visible": True,
+            "enabled": False,
+            "summary": "New, clear, and session actions remain disabled.",
+        },
+        {
+            "groupId": "message_actions",
+            "label": "message actions",
+            "state": "disabled",
+            "visible": True,
+            "enabled": False,
+            "summary": "Retry and copy actions remain unavailable because no message content is present.",
+        },
+        {
+            "groupId": "transcript_actions",
+            "label": "transcript actions",
+            "state": "not_configured",
+            "visible": True,
+            "enabled": False,
+            "summary": "Export and transcript controls remain disabled until a reviewed local store exists.",
+        },
+        {
+            "groupId": "runtime_actions",
+            "label": "runtime actions",
+            "state": "not_started",
+            "visible": True,
+            "enabled": False,
+            "summary": "Stop and retry controls remain disabled because no local response stream exists.",
+        },
+        {
+            "groupId": "attachment_actions",
+            "label": "attachment actions",
+            "state": "planned",
+            "visible": True,
+            "enabled": False,
+            "summary": "Attachment controls require a separate reviewed artifact input boundary.",
+        },
+    ],
+    "actionControls": [
+        {
+            "actionId": "new_chat",
+            "label": "new chat",
+            "groupId": "conversation_actions",
+            "state": "blocked",
+            "visible": True,
+            "enabled": False,
+            "requiresExplicitUserAction": True,
+            "sourceRef": "chat_session_lifecycle",
+            "resultState": "unavailable",
+            "sideEffectPolicy": "no_session_create",
+            "blockedReasonRef": "session_lifecycle_not_enabled",
+        },
+        {
+            "actionId": "clear_conversation",
+            "label": "clear conversation",
+            "groupId": "conversation_actions",
+            "state": "disabled",
+            "visible": True,
+            "enabled": False,
+            "requiresExplicitUserAction": True,
+            "sourceRef": "chat_transcript_policy",
+            "resultState": "unavailable",
+            "sideEffectPolicy": "no_transcript_delete",
+            "blockedReasonRef": "transcript_store_not_configured",
+        },
+        {
+            "actionId": "export_transcript",
+            "label": "export transcript",
+            "groupId": "transcript_actions",
+            "state": "disabled",
+            "visible": True,
+            "enabled": False,
+            "requiresExplicitUserAction": True,
+            "sourceRef": "chat_transcript_policy",
+            "resultState": "unavailable",
+            "sideEffectPolicy": "no_transcript_export",
+            "blockedReasonRef": "transcript_export_not_reviewed",
+        },
+        {
+            "actionId": "retry_response",
+            "label": "retry response",
+            "groupId": "message_actions",
+            "state": "blocked",
+            "visible": True,
+            "enabled": False,
+            "requiresExplicitUserAction": True,
+            "sourceRef": "chat_send_result",
+            "resultState": "not_generated",
+            "sideEffectPolicy": "no_send_or_runtime_execution",
+            "blockedReasonRef": "response_stream_blocked",
+        },
+        {
+            "actionId": "copy_response",
+            "label": "copy response",
+            "groupId": "message_actions",
+            "state": "disabled",
+            "visible": True,
+            "enabled": False,
+            "requiresExplicitUserAction": True,
+            "sourceRef": "chat_message_list",
+            "resultState": "unavailable",
+            "sideEffectPolicy": "no_clipboard_write",
+            "blockedReasonRef": "message_content_absent",
+        },
+        {
+            "actionId": "stop_response",
+            "label": "stop response",
+            "groupId": "runtime_actions",
+            "state": "disabled",
+            "visible": True,
+            "enabled": False,
+            "requiresExplicitUserAction": True,
+            "sourceRef": "chat_response_stream",
+            "resultState": "unavailable",
+            "sideEffectPolicy": "no_stop_signal",
+            "blockedReasonRef": "runtime_stream_not_started",
+        },
+        {
+            "actionId": "attach_context",
+            "label": "attach context",
+            "groupId": "attachment_actions",
+            "state": "disabled",
+            "visible": True,
+            "enabled": False,
+            "requiresExplicitUserAction": True,
+            "sourceRef": "chat_composer",
+            "resultState": "unavailable",
+            "sideEffectPolicy": "no_file_or_artifact_read",
+            "blockedReasonRef": "attachment_boundary_absent",
+        },
+    ],
+    "blockedReasons": [
+        {
+            "reasonId": "session_lifecycle_not_enabled",
+            "state": "blocked",
+            "summary": "Session creation and lifecycle actions remain disabled.",
+            "requiredBefore": "new_chat_enabled",
+        },
+        {
+            "reasonId": "transcript_store_not_configured",
+            "state": "not_configured",
+            "summary": "No reviewed transcript store or retention rule exists.",
+            "requiredBefore": "clear_conversation_enabled",
+        },
+        {
+            "reasonId": "transcript_export_not_reviewed",
+            "state": "not_configured",
+            "summary": "Transcript export needs explicit storage and redaction boundaries.",
+            "requiredBefore": "export_transcript_enabled",
+        },
+        {
+            "reasonId": "message_content_absent",
+            "state": "empty_not_captured",
+            "summary": "No prompt, response, transcript, or message body content is present.",
+            "requiredBefore": "copy_or_retry_enabled",
+        },
+        {
+            "reasonId": "response_stream_blocked",
+            "state": "blocked",
+            "summary": "The checked response-stream boundary reports no generated chunks.",
+            "requiredBefore": "retry_response_enabled",
+        },
+        {
+            "reasonId": "runtime_stream_not_started",
+            "state": "not_started",
+            "summary": "No local response stream exists, so stop cannot send a signal.",
+            "requiredBefore": "stop_response_enabled",
+        },
+        {
+            "reasonId": "attachment_boundary_absent",
+            "state": "planned",
+            "summary": "No reviewed local artifact input boundary exists for attachments.",
+            "requiredBefore": "attach_context_enabled",
+        },
+    ],
+    "handoffRefs": [
+        {
+            "refId": "chat_session",
+            "schemaVersion": "pccx.chatSession.v0",
+            "fixturePath": "contracts/fixtures/chat-session.gemma3n-e4b-kv260-placeholder.json",
+            "state": "inactive",
+            "summary": "Session state is consumed as local metadata only.",
+        },
+        {
+            "refId": "chat_session_lifecycle",
+            "schemaVersion": "pccx.chatSessionLifecycle.v0",
+            "fixturePath": "contracts/fixtures/chat-session-lifecycle.gemma3n-e4b-kv260-placeholder.json",
+            "state": "blocked",
+            "summary": "Session lifecycle actions remain disabled or blocked.",
+        },
+        {
+            "refId": "chat_readiness",
+            "schemaVersion": "pccx.chatReadiness.v0",
+            "fixturePath": "contracts/fixtures/chat-readiness.gemma3n-e4b-kv260-placeholder.json",
+            "state": "blocked",
+            "summary": "Readiness data keeps action controls disabled.",
+        },
+        {
+            "refId": "chat_composer",
+            "schemaVersion": "pccx.chatComposer.v0",
+            "fixturePath": "contracts/fixtures/chat-composer.gemma3n-e4b-kv260-placeholder.json",
+            "state": "blocked",
+            "summary": "Composer data keeps attach and send-adjacent actions disabled.",
+        },
+        {
+            "refId": "chat_send_result",
+            "schemaVersion": "pccx.chatSendResult.v0",
+            "fixturePath": "contracts/fixtures/chat-send-result.gemma3n-e4b-kv260-placeholder.json",
+            "state": "blocked",
+            "summary": "Blocked send-result data prevents retry actions.",
+        },
+        {
+            "refId": "chat_response_stream",
+            "schemaVersion": "pccx.chatResponseStream.v0",
+            "fixturePath": "contracts/fixtures/chat-response-stream.gemma3n-e4b-kv260-placeholder.json",
+            "state": "blocked",
+            "summary": "Blocked stream data prevents stop and retry controls.",
+        },
+        {
+            "refId": "chat_message_list",
+            "schemaVersion": "pccx.chatMessageList.v0",
+            "fixturePath": "contracts/fixtures/chat-message-list.gemma3n-e4b-kv260-placeholder.json",
+            "state": "empty_not_captured",
+            "summary": "Empty message-list data prevents copy actions.",
+        },
+        {
+            "refId": "chat_transcript_policy",
+            "schemaVersion": "pccx.chatTranscriptPolicy.v0",
+            "fixturePath": "contracts/fixtures/chat-transcript-policy.gemma3n-e4b-kv260-placeholder.json",
+            "state": "disabled",
+            "summary": "Transcript persistence and export remain unavailable.",
+        },
+    ],
+    "safetyFlags": {
+        "dataOnly": True,
+        "readOnly": True,
+        "deterministic": True,
+        "actionBarDisplayOnly": True,
+        "actionMetadataOnly": True,
+        "writesArtifacts": False,
+        "readsArtifacts": False,
+        "readsSessionStore": False,
+        "readsTranscript": False,
+        "transcriptPersistence": False,
+        "transcriptExport": False,
+        "sessionPersistence": False,
+        "sessionStoreRead": False,
+        "sessionStoreWrite": False,
+        "conversationCreated": False,
+        "conversationCleared": False,
+        "messageDeleted": False,
+        "attachmentReads": False,
+        "fileUpload": False,
+        "clipboardRead": False,
+        "clipboardWrite": False,
+        "promptCapture": False,
+        "promptContentIncluded": False,
+        "promptEchoed": False,
+        "promptPersistence": False,
+        "inputAccepted": False,
+        "sendAttempted": False,
+        "retryAttempted": False,
+        "stopSignalSent": False,
+        "responseContentIncluded": False,
+        "responseGenerated": False,
+        "responseChunksEmitted": False,
+        "messageBodiesIncluded": False,
+        "modelAssetRead": False,
+        "modelAssetPathsIncluded": False,
+        "modelWeightPathsIncluded": False,
+        "modelLoadAttempted": False,
+        "modelLoaded": False,
+        "modelExecution": False,
+        "runtimeExecution": False,
+        "touchesHardware": False,
+        "hardwareAccess": False,
+        "kv260Access": False,
+        "opensSerialPort": False,
+        "networkCalls": False,
+        "networkScan": False,
+        "sshExecution": False,
+        "providerCalls": False,
+        "cloudCalls": False,
+        "configRead": False,
+        "environmentRead": False,
+        "providerConfigRead": False,
+        "privatePathsIncluded": False,
+        "secretsIncluded": False,
+        "tokensIncluded": False,
+        "generatedBlobsIncluded": False,
+        "hardwareDumpsIncluded": False,
+        "runtimeLogsIncluded": False,
+        "telemetry": False,
+        "automaticUpload": False,
+        "writeBack": False,
+        "executesPccxLab": False,
+        "executesSystemverilogIde": False,
+        "mcpServerImplemented": False,
+        "lspImplemented": False,
+        "stableApiAbiClaim": False,
+    },
+    "limitations": [
+        "Data-only chat action-bar fixture; no prompt, response, transcript, summary, session title, model path, runtime log, file, or clipboard content is read or written.",
+        "New chat, clear, export, retry, copy, stop, and attach controls remain disabled, blocked, unavailable, or planned.",
+        "No session store, transcript, message bodies, attachments, artifacts, private paths, secrets, tokens, logs, or hardware dumps are read or written.",
+        "No send attempt, retry, stop signal, response stream, model load, runtime execution, provider call, network call, or KV260 hardware access is performed.",
+        "This is not a release, tag, compatibility commitment, MCP, LSP, IDE, marketplace, telemetry, or runtime implementation.",
+    ],
+    "issueRefs": [
+        "pccxai/pccx-llm-launcher#9",
+    ],
+}
+
+
+def create_gemma3n_e4b_kv260_chat_action_bar() -> dict:
+    """Return the checked Gemma 3N E4B plus KV260 chat action-bar fixture."""
+    return copy.deepcopy(_CHAT_ACTION_BAR)
+
+
+def chat_action_bar_json(action_bar: dict | None = None) -> str:
+    """Render a deterministic JSON representation."""
+    return json.dumps(
+        action_bar
+        if action_bar is not None
+        else create_gemma3n_e4b_kv260_chat_action_bar(),
+        indent=2,
+        sort_keys=True,
+    ) + "\n"
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Print data-only chat action-bar JSON.",
+    )
+    parser.add_argument(
+        "--model",
+        default="gemma3n-e4b",
+        choices=("gemma3n-e4b",),
+        help="model descriptor target",
+    )
+    parser.add_argument(
+        "--target",
+        default="kv260",
+        choices=("kv260",),
+        help="target board/device",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parse_args(sys.argv[1:] if argv is None else argv)
+    sys.stdout.write(chat_action_bar_json())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contracts/fixtures/chat-action-bar.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-action-bar.gemma3n-e4b-kv260-placeholder.json
@@ -1,0 +1,348 @@
+{
+  "actionBarId": "chat_action_bar_gemma3n_e4b_kv260_placeholder",
+  "actionBarState": "blocked",
+  "actionControls": [
+    {
+      "actionId": "new_chat",
+      "blockedReasonRef": "session_lifecycle_not_enabled",
+      "enabled": false,
+      "groupId": "conversation_actions",
+      "label": "new chat",
+      "requiresExplicitUserAction": true,
+      "resultState": "unavailable",
+      "sideEffectPolicy": "no_session_create",
+      "sourceRef": "chat_session_lifecycle",
+      "state": "blocked",
+      "visible": true
+    },
+    {
+      "actionId": "clear_conversation",
+      "blockedReasonRef": "transcript_store_not_configured",
+      "enabled": false,
+      "groupId": "conversation_actions",
+      "label": "clear conversation",
+      "requiresExplicitUserAction": true,
+      "resultState": "unavailable",
+      "sideEffectPolicy": "no_transcript_delete",
+      "sourceRef": "chat_transcript_policy",
+      "state": "disabled",
+      "visible": true
+    },
+    {
+      "actionId": "export_transcript",
+      "blockedReasonRef": "transcript_export_not_reviewed",
+      "enabled": false,
+      "groupId": "transcript_actions",
+      "label": "export transcript",
+      "requiresExplicitUserAction": true,
+      "resultState": "unavailable",
+      "sideEffectPolicy": "no_transcript_export",
+      "sourceRef": "chat_transcript_policy",
+      "state": "disabled",
+      "visible": true
+    },
+    {
+      "actionId": "retry_response",
+      "blockedReasonRef": "response_stream_blocked",
+      "enabled": false,
+      "groupId": "message_actions",
+      "label": "retry response",
+      "requiresExplicitUserAction": true,
+      "resultState": "not_generated",
+      "sideEffectPolicy": "no_send_or_runtime_execution",
+      "sourceRef": "chat_send_result",
+      "state": "blocked",
+      "visible": true
+    },
+    {
+      "actionId": "copy_response",
+      "blockedReasonRef": "message_content_absent",
+      "enabled": false,
+      "groupId": "message_actions",
+      "label": "copy response",
+      "requiresExplicitUserAction": true,
+      "resultState": "unavailable",
+      "sideEffectPolicy": "no_clipboard_write",
+      "sourceRef": "chat_message_list",
+      "state": "disabled",
+      "visible": true
+    },
+    {
+      "actionId": "stop_response",
+      "blockedReasonRef": "runtime_stream_not_started",
+      "enabled": false,
+      "groupId": "runtime_actions",
+      "label": "stop response",
+      "requiresExplicitUserAction": true,
+      "resultState": "unavailable",
+      "sideEffectPolicy": "no_stop_signal",
+      "sourceRef": "chat_response_stream",
+      "state": "disabled",
+      "visible": true
+    },
+    {
+      "actionId": "attach_context",
+      "blockedReasonRef": "attachment_boundary_absent",
+      "enabled": false,
+      "groupId": "attachment_actions",
+      "label": "attach context",
+      "requiresExplicitUserAction": true,
+      "resultState": "unavailable",
+      "sideEffectPolicy": "no_file_or_artifact_read",
+      "sourceRef": "chat_composer",
+      "state": "disabled",
+      "visible": true
+    }
+  ],
+  "actionGroups": [
+    {
+      "enabled": false,
+      "groupId": "conversation_actions",
+      "label": "conversation actions",
+      "state": "blocked",
+      "summary": "New, clear, and session actions remain disabled.",
+      "visible": true
+    },
+    {
+      "enabled": false,
+      "groupId": "message_actions",
+      "label": "message actions",
+      "state": "disabled",
+      "summary": "Retry and copy actions remain unavailable because no message content is present.",
+      "visible": true
+    },
+    {
+      "enabled": false,
+      "groupId": "transcript_actions",
+      "label": "transcript actions",
+      "state": "not_configured",
+      "summary": "Export and transcript controls remain disabled until a reviewed local store exists.",
+      "visible": true
+    },
+    {
+      "enabled": false,
+      "groupId": "runtime_actions",
+      "label": "runtime actions",
+      "state": "not_started",
+      "summary": "Stop and retry controls remain disabled because no local response stream exists.",
+      "visible": true
+    },
+    {
+      "enabled": false,
+      "groupId": "attachment_actions",
+      "label": "attachment actions",
+      "state": "planned",
+      "summary": "Attachment controls require a separate reviewed artifact input boundary.",
+      "visible": true
+    }
+  ],
+  "actionPolicy": {
+    "contentPolicy": "action metadata only; no message bodies, prompt text, response text, transcript text, or session titles are included",
+    "interactionPolicy": "all conversation actions remain disabled until reviewed runtime, session-store, transcript, clipboard, and attachment boundaries exist",
+    "persistencePolicy": "no session creation, clear, export, copy, retry, stop, attachment, transcript, or artifact write",
+    "renderMode": "future_local_chat_action_bar",
+    "sideEffectPolicy": "local_render_only",
+    "sourcePolicy": "checked fixture only; no session store, transcript, prompt, response, summary, file, clipboard, or model path is read",
+    "state": "placeholder"
+  },
+  "attachmentState": "disabled",
+  "blockedReasons": [
+    {
+      "reasonId": "session_lifecycle_not_enabled",
+      "requiredBefore": "new_chat_enabled",
+      "state": "blocked",
+      "summary": "Session creation and lifecycle actions remain disabled."
+    },
+    {
+      "reasonId": "transcript_store_not_configured",
+      "requiredBefore": "clear_conversation_enabled",
+      "state": "not_configured",
+      "summary": "No reviewed transcript store or retention rule exists."
+    },
+    {
+      "reasonId": "transcript_export_not_reviewed",
+      "requiredBefore": "export_transcript_enabled",
+      "state": "not_configured",
+      "summary": "Transcript export needs explicit storage and redaction boundaries."
+    },
+    {
+      "reasonId": "message_content_absent",
+      "requiredBefore": "copy_or_retry_enabled",
+      "state": "empty_not_captured",
+      "summary": "No prompt, response, transcript, or message body content is present."
+    },
+    {
+      "reasonId": "response_stream_blocked",
+      "requiredBefore": "retry_response_enabled",
+      "state": "blocked",
+      "summary": "The checked response-stream boundary reports no generated chunks."
+    },
+    {
+      "reasonId": "runtime_stream_not_started",
+      "requiredBefore": "stop_response_enabled",
+      "state": "not_started",
+      "summary": "No local response stream exists, so stop cannot send a signal."
+    },
+    {
+      "reasonId": "attachment_boundary_absent",
+      "requiredBefore": "attach_context_enabled",
+      "state": "planned",
+      "summary": "No reviewed local artifact input boundary exists for attachments."
+    }
+  ],
+  "chatComposerRef": "chat_composer_gemma3n_e4b_kv260_placeholder",
+  "chatMessageListRef": "chat_message_list_gemma3n_e4b_kv260_placeholder",
+  "chatReadinessRef": "chat_readiness_gemma3n_e4b_kv260_placeholder",
+  "chatResponseStreamRef": "chat_response_stream_gemma3n_e4b_kv260_placeholder",
+  "chatSendResultRef": "chat_send_result_gemma3n_e4b_kv260_placeholder",
+  "chatSessionRef": "chat_session_gemma3n_e4b_kv260_placeholder",
+  "clipboardState": "disabled",
+  "conversationState": "inactive",
+  "exportState": "disabled",
+  "fixtureVersion": "chat-action-bar.gemma3n-e4b-kv260.2026-05-04",
+  "handoffRefs": [
+    {
+      "fixturePath": "contracts/fixtures/chat-session.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_session",
+      "schemaVersion": "pccx.chatSession.v0",
+      "state": "inactive",
+      "summary": "Session state is consumed as local metadata only."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-session-lifecycle.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_session_lifecycle",
+      "schemaVersion": "pccx.chatSessionLifecycle.v0",
+      "state": "blocked",
+      "summary": "Session lifecycle actions remain disabled or blocked."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-readiness.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_readiness",
+      "schemaVersion": "pccx.chatReadiness.v0",
+      "state": "blocked",
+      "summary": "Readiness data keeps action controls disabled."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-composer.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_composer",
+      "schemaVersion": "pccx.chatComposer.v0",
+      "state": "blocked",
+      "summary": "Composer data keeps attach and send-adjacent actions disabled."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-send-result.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_send_result",
+      "schemaVersion": "pccx.chatSendResult.v0",
+      "state": "blocked",
+      "summary": "Blocked send-result data prevents retry actions."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-response-stream.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_response_stream",
+      "schemaVersion": "pccx.chatResponseStream.v0",
+      "state": "blocked",
+      "summary": "Blocked stream data prevents stop and retry controls."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-message-list.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_message_list",
+      "schemaVersion": "pccx.chatMessageList.v0",
+      "state": "empty_not_captured",
+      "summary": "Empty message-list data prevents copy actions."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-transcript-policy.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_transcript_policy",
+      "schemaVersion": "pccx.chatTranscriptPolicy.v0",
+      "state": "disabled",
+      "summary": "Transcript persistence and export remain unavailable."
+    }
+  ],
+  "issueRefs": [
+    "pccxai/pccx-llm-launcher#9"
+  ],
+  "lastUpdatedSource": "pccx_launcher_issue_9_chat_action_bar_boundary_2026-05-04",
+  "limitations": [
+    "Data-only chat action-bar fixture; no prompt, response, transcript, summary, session title, model path, runtime log, file, or clipboard content is read or written.",
+    "New chat, clear, export, retry, copy, stop, and attach controls remain disabled, blocked, unavailable, or planned.",
+    "No session store, transcript, message bodies, attachments, artifacts, private paths, secrets, tokens, logs, or hardware dumps are read or written.",
+    "No send attempt, retry, stop signal, response stream, model load, runtime execution, provider call, network call, or KV260 hardware access is performed.",
+    "This is not a release, tag, compatibility commitment, MCP, LSP, IDE, marketplace, telemetry, or runtime implementation."
+  ],
+  "responseState": "not_generated",
+  "safetyFlags": {
+    "actionBarDisplayOnly": true,
+    "actionMetadataOnly": true,
+    "attachmentReads": false,
+    "automaticUpload": false,
+    "clipboardRead": false,
+    "clipboardWrite": false,
+    "cloudCalls": false,
+    "configRead": false,
+    "conversationCleared": false,
+    "conversationCreated": false,
+    "dataOnly": true,
+    "deterministic": true,
+    "environmentRead": false,
+    "executesPccxLab": false,
+    "executesSystemverilogIde": false,
+    "fileUpload": false,
+    "generatedBlobsIncluded": false,
+    "hardwareAccess": false,
+    "hardwareDumpsIncluded": false,
+    "inputAccepted": false,
+    "kv260Access": false,
+    "lspImplemented": false,
+    "mcpServerImplemented": false,
+    "messageBodiesIncluded": false,
+    "messageDeleted": false,
+    "modelAssetPathsIncluded": false,
+    "modelAssetRead": false,
+    "modelExecution": false,
+    "modelLoadAttempted": false,
+    "modelLoaded": false,
+    "modelWeightPathsIncluded": false,
+    "networkCalls": false,
+    "networkScan": false,
+    "opensSerialPort": false,
+    "privatePathsIncluded": false,
+    "promptCapture": false,
+    "promptContentIncluded": false,
+    "promptEchoed": false,
+    "promptPersistence": false,
+    "providerCalls": false,
+    "providerConfigRead": false,
+    "readOnly": true,
+    "readsArtifacts": false,
+    "readsSessionStore": false,
+    "readsTranscript": false,
+    "responseChunksEmitted": false,
+    "responseContentIncluded": false,
+    "responseGenerated": false,
+    "retryAttempted": false,
+    "runtimeExecution": false,
+    "runtimeLogsIncluded": false,
+    "secretsIncluded": false,
+    "sendAttempted": false,
+    "sessionPersistence": false,
+    "sessionStoreRead": false,
+    "sessionStoreWrite": false,
+    "sshExecution": false,
+    "stableApiAbiClaim": false,
+    "stopSignalSent": false,
+    "telemetry": false,
+    "tokensIncluded": false,
+    "touchesHardware": false,
+    "transcriptExport": false,
+    "transcriptPersistence": false,
+    "writeBack": false,
+    "writesArtifacts": false
+  },
+  "schemaVersion": "pccx.chatActionBar.v0",
+  "selectionState": "disabled",
+  "stopControlState": "disabled",
+  "targetBoard": "xilinx_kria_kv260",
+  "targetDevice": "kv260",
+  "targetModel": "gemma3n-e4b",
+  "transcriptState": "not_started"
+}

--- a/docs/STANDALONE_CHAT_SESSION_CONTRACT.md
+++ b/docs/STANDALONE_CHAT_SESSION_CONTRACT.md
@@ -22,6 +22,7 @@ The implementation lives in:
 - `contracts/chat_audit_event_contract.py`
 - `contracts/chat_error_taxonomy_contract.py`
 - `contracts/chat_message_list_contract.py`
+- `contracts/chat_action_bar_contract.py`
 - `contracts/fixtures/chat-session.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-model-status.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-session-lifecycle.gemma3n-e4b-kv260-placeholder.json`
@@ -36,6 +37,7 @@ The implementation lives in:
 - `contracts/fixtures/chat-audit-event.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-error-taxonomy.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-message-list.gemma3n-e4b-kv260-placeholder.json`
+- `contracts/fixtures/chat-action-bar.gemma3n-e4b-kv260-placeholder.json`
 - `scripts/chat-session-stub.sh`
 - `scripts/chat-model-status-stub.sh`
 - `scripts/chat-session-lifecycle-stub.sh`
@@ -50,6 +52,7 @@ The implementation lives in:
 - `scripts/chat-audit-event-stub.sh`
 - `scripts/chat-error-taxonomy-stub.sh`
 - `scripts/chat-message-list-stub.sh`
+- `scripts/chat-action-bar-stub.sh`
 - `scripts/chat-surface-preview.sh`
 - `scripts/tests/chat_session_contract_test.py`
 - `scripts/tests/chat_model_status_contract_test.py`
@@ -65,6 +68,7 @@ The implementation lives in:
 - `scripts/tests/chat_audit_event_contract_test.py`
 - `scripts/tests/chat_error_taxonomy_contract_test.py`
 - `scripts/tests/chat_message_list_contract_test.py`
+- `scripts/tests/chat_action_bar_contract_test.py`
 - `scripts/tests/chat_surface_preview_test.py`
 - `scripts/tests/status-chat-model-status.sh`
 - `scripts/tests/status-chat-surface-layout.sh`
@@ -79,6 +83,7 @@ The implementation lives in:
 - `scripts/tests/status-chat-error-taxonomy.sh`
 - `scripts/tests/status-chat-response-stream.sh`
 - `scripts/tests/status-chat-message-list.sh`
+- `scripts/tests/status-chat-action-bar.sh`
 
 ## What Is Implemented
 
@@ -107,6 +112,8 @@ The chat/session contract records:
   stop-control, and assistant response placeholders
 - empty chat message-list metadata for the conversation viewport without
   message bodies or transcript reads
+- disabled action-bar metadata for new, clear, export, retry, copy, stop,
+  and attach controls without side effects
 
 The checked fixture is deterministic JSON. The stub command prints that
 JSON for the supported model and target pair:
@@ -269,6 +276,21 @@ It keeps the message list as empty local data: no session store or
 transcript is read, no message bodies are included, no prompt or
 response content is displayed, no response stream is appended, no model
 or runtime path is started, and no transcript or artifact is written.
+
+The chat action-bar fixture records the disabled conversation action
+controls used by the planned standalone chat surface:
+
+```bash
+bash scripts/chat-action-bar-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/status-stub.sh --include-chat-action-bar
+```
+
+It keeps action controls as local metadata: new chat, clear, export,
+retry, copy, stop, and attach controls remain disabled, blocked,
+unavailable, or planned. No session store or transcript is read, no
+message body is included, no transcript is exported, no clipboard or file
+operation is performed, no stop signal is sent, no model or runtime path
+is started, and no artifact is written.
 
 The chat transcript policy fixture records the retention, export,
 storage, and privacy policy shape for future transcript UI surfaces:
@@ -451,6 +473,26 @@ content, token data, runtime transport, and transcript storage:
 - `unavailable`: token counts, stream completion, or response content
   are unavailable
 
+The action-bar states keep user-visible conversation controls separate
+from session storage, transcripts, clipboard access, file access, runtime
+transport, and message content:
+
+- `available_as_data`: checked action metadata is available without
+  executing anything
+- `blocked`: a required lifecycle, transcript, send-result, or stream
+  boundary is missing
+- `disabled`: a visible control is intentionally unavailable
+- `empty_not_captured`: no prompt, response, transcript, or message body
+  content is present
+- `inactive`: no launcher-owned chat session exists
+- `not_configured`: no local store, retention rule, or export/redaction
+  boundary exists
+- `not_generated`: no assistant response exists for copy or retry
+- `not_started`: no local response stream exists
+- `planned`: described for a future reviewed boundary
+- `placeholder`: deterministic local action-bar metadata only
+- `unavailable`: action output is unavailable
+
 The transcript policy states keep retention and export rules separate
 from message content:
 
@@ -548,6 +590,11 @@ without prompt capture, response content, transcript content, provider
 configuration reads, model asset reads, session-store reads, artifact
 reads, artifact writes, runtime execution, model loading, provider calls,
 or target access.
+The action-bar contract adds a reviewable disabled control shape without
+session creation, conversation clearing, transcript export, clipboard
+writes, attachment reads, retry attempts, stop signals, runtime
+execution, model loading, provider calls, artifact writes, or target
+access.
 
 pccx-lab remains a separate CLI/core diagnostics and verification
 backend. systemverilog-ide may consume launcher data later as read-only
@@ -565,6 +612,9 @@ This chat/session surface does not add:
   persistence
 - response streaming, response chunk generation, token counting, stop
   signal delivery, or stream transport behavior
+- action-bar execution, session creation, conversation clearing,
+  transcript export, clipboard writes, retry attempts, stop signals, file
+  attachment reads, or action persistence
 - transcript retention, transcript export, local transcript storage,
   transcript summaries, or transcript message content
 - audit logging, audit persistence, actor identifiers, event timestamps,

--- a/scripts/chat-action-bar-stub.sh
+++ b/scripts/chat-action-bar-stub.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+# Print the data-only chat action-bar contract.
+
+set -eu
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+
+python3 "$ROOT_DIR/contracts/chat_action_bar_contract.py" "$@"

--- a/scripts/status-stub.sh
+++ b/scripts/status-stub.sh
@@ -52,6 +52,9 @@
 # Chat message-list display boundary (explicit opt-in, read-only local data):
 #   --include-chat-message-list
 #
+# Chat action-bar controls boundary (explicit opt-in, read-only local data):
+#   --include-chat-action-bar
+#
 # pccx-lab backend (explicit opt-in):
 #   --backend pccx-lab        call pccx-lab status --format json
 #   PCCX_LAB_BIN              override path to pccx-lab binary (takes priority over PATH)
@@ -83,6 +86,7 @@ INCLUDE_CHAT_AUDIT_EVENT="0"
 INCLUDE_CHAT_ERROR_TAXONOMY="0"
 INCLUDE_CHAT_RESPONSE_STREAM="0"
 INCLUDE_CHAT_MESSAGE_LIST="0"
+INCLUDE_CHAT_ACTION_BAR="0"
 
 print_chat_error_taxonomy_summary() {
     SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
@@ -394,6 +398,110 @@ print(
 
     HEAD "chat message list"
     printf '%s\n' "$CHAT_MESSAGE_LIST_SUMMARY"
+}
+
+print_chat_action_bar_summary() {
+    SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+    ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+    CHAT_ACTION_BAR_STUB="$ROOT_DIR/scripts/chat-action-bar-stub.sh"
+
+    if [ ! -f "$CHAT_ACTION_BAR_STUB" ]; then
+        ERROR "chat action-bar stub not found: $CHAT_ACTION_BAR_STUB"
+        return 1
+    fi
+
+    if ! CHAT_ACTION_BAR_JSON="$(bash "$CHAT_ACTION_BAR_STUB" --model gemma3n-e4b --target kv260 2>&1)"; then
+        ERROR "chat action-bar stub failed"
+        printf '%s\n' "$CHAT_ACTION_BAR_JSON" >&2
+        return 1
+    fi
+
+    if ! CHAT_ACTION_BAR_SUMMARY="$(
+        printf '%s\n' "$CHAT_ACTION_BAR_JSON" | python3 -c '
+import json
+import sys
+
+data = json.load(sys.stdin)
+flags = data["safetyFlags"]
+
+def b(value):
+    return "true" if value else "false"
+
+groups = " ".join(
+    "{}={}".format(group["groupId"], group["state"])
+    for group in data["actionGroups"]
+)
+controls = " ".join(
+    "{}={}:{}".format(control["actionId"], control["state"], b(control["enabled"]))
+    for control in data["actionControls"]
+)
+blocked = " ".join(
+    "{}={}".format(reason["reasonId"], reason["state"])
+    for reason in data["blockedReasons"]
+)
+
+print("[INFO]  source     : scripts/chat-action-bar-stub.sh --model gemma3n-e4b --target kv260")
+print("[INFO]  boundary   : read-only data; no action execution/session-store/transcript/clipboard/file/model/runtime/hardware/lab/IDE execution")
+print("[INFO]  target     : {}".format(data["targetDevice"]))
+print("[INFO]  model      : {}".format(data["targetModel"]))
+print("[INFO]  actions    : {}".format(data["actionBarState"]))
+print("[INFO]  conversation: {}".format(data["conversationState"]))
+print("[INFO]  selection  : {}".format(data["selectionState"]))
+print("[INFO]  transcript : {}".format(data["transcriptState"]))
+print("[INFO]  response   : {}".format(data["responseState"]))
+print("[INFO]  attachment : {}".format(data["attachmentState"]))
+print("[INFO]  clipboard  : {}".format(data["clipboardState"]))
+print("[INFO]  export     : {}".format(data["exportState"]))
+print("[INFO]  stop       : {}".format(data["stopControlState"]))
+print("[INFO]  groups     : {}".format(groups))
+print("[INFO]  controls   : {}".format(controls))
+print("[INFO]  blocked    : {}".format(blocked))
+print(
+    "[INFO]  flags      : readOnly={} dataOnly={} deterministic={} "
+    "actionBarDisplayOnly={} actionMetadataOnly={} "
+    "readsSessionStore={} readsTranscript={} transcriptExport={} "
+    "sessionStoreRead={} sessionStoreWrite={} conversationCreated={} "
+    "conversationCleared={} attachmentReads={} fileUpload={} "
+    "clipboardWrite={} sendAttempted={} retryAttempted={} "
+    "stopSignalSent={} responseGenerated={} modelExecution={} "
+    "runtimeExecution={} kv260Access={} hardwareAccess={} "
+    "networkCalls={} providerCalls={} executesPccxLab={}".format(
+        b(flags["readOnly"]),
+        b(flags["dataOnly"]),
+        b(flags["deterministic"]),
+        b(flags["actionBarDisplayOnly"]),
+        b(flags["actionMetadataOnly"]),
+        b(flags["readsSessionStore"]),
+        b(flags["readsTranscript"]),
+        b(flags["transcriptExport"]),
+        b(flags["sessionStoreRead"]),
+        b(flags["sessionStoreWrite"]),
+        b(flags["conversationCreated"]),
+        b(flags["conversationCleared"]),
+        b(flags["attachmentReads"]),
+        b(flags["fileUpload"]),
+        b(flags["clipboardWrite"]),
+        b(flags["sendAttempted"]),
+        b(flags["retryAttempted"]),
+        b(flags["stopSignalSent"]),
+        b(flags["responseGenerated"]),
+        b(flags["modelExecution"]),
+        b(flags["runtimeExecution"]),
+        b(flags["kv260Access"]),
+        b(flags["hardwareAccess"]),
+        b(flags["networkCalls"]),
+        b(flags["providerCalls"]),
+        b(flags["executesPccxLab"]),
+    )
+)
+'
+    )"; then
+        ERROR "chat action-bar JSON could not be summarized"
+        return 1
+    fi
+
+    HEAD "chat action bar"
+    printf '%s\n' "$CHAT_ACTION_BAR_SUMMARY"
 }
 
 print_chat_local_only_policy_summary() {
@@ -1795,6 +1903,10 @@ while [ $# -gt 0 ]; do
             INCLUDE_CHAT_MESSAGE_LIST="1"
             shift
             ;;
+        --include-chat-action-bar)
+            INCLUDE_CHAT_ACTION_BAR="1"
+            shift
+            ;;
         --backend)
             BACKEND="${2:-}"
             if [ -z "$BACKEND" ]; then
@@ -1810,8 +1922,8 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-if [ -n "$BACKEND" ] && { [ "$INCLUDE_RUNTIME_READINESS" = "1" ] || [ "$INCLUDE_DEVICE_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SURFACE_LAYOUT" = "1" ] || [ "$INCLUDE_CHAT_LOCAL_ONLY_POLICY" = "1" ] || [ "$INCLUDE_CHAT_PREFERENCES" = "1" ] || [ "$INCLUDE_CHAT_SESSION_INDEX" = "1" ] || [ "$INCLUDE_CHAT_MODEL_STATUS" = "1" ] || [ "$INCLUDE_CHAT_READINESS" = "1" ] || [ "$INCLUDE_CHAT_COMPOSER" = "1" ] || [ "$INCLUDE_CHAT_SEND_RESULT" = "1" ] || [ "$INCLUDE_CHAT_TRANSCRIPT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_AUDIT_EVENT" = "1" ] || [ "$INCLUDE_CHAT_ERROR_TAXONOMY" = "1" ] || [ "$INCLUDE_CHAT_RESPONSE_STREAM" = "1" ] || [ "$INCLUDE_CHAT_MESSAGE_LIST" = "1" ]; }; then
-    ERROR "--include-runtime-readiness, --include-device-session, --include-chat-session, --include-chat-surface-layout, --include-chat-local-only-policy, --include-chat-preferences, --include-chat-session-index, --include-chat-model-status, --include-chat-readiness, --include-chat-composer, --include-chat-send-result, --include-chat-transcript-policy, --include-chat-audit-event, --include-chat-error-taxonomy, --include-chat-response-stream, and --include-chat-message-list are only supported in local scaffold mode"
+if [ -n "$BACKEND" ] && { [ "$INCLUDE_RUNTIME_READINESS" = "1" ] || [ "$INCLUDE_DEVICE_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SURFACE_LAYOUT" = "1" ] || [ "$INCLUDE_CHAT_LOCAL_ONLY_POLICY" = "1" ] || [ "$INCLUDE_CHAT_PREFERENCES" = "1" ] || [ "$INCLUDE_CHAT_SESSION_INDEX" = "1" ] || [ "$INCLUDE_CHAT_MODEL_STATUS" = "1" ] || [ "$INCLUDE_CHAT_READINESS" = "1" ] || [ "$INCLUDE_CHAT_COMPOSER" = "1" ] || [ "$INCLUDE_CHAT_SEND_RESULT" = "1" ] || [ "$INCLUDE_CHAT_TRANSCRIPT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_AUDIT_EVENT" = "1" ] || [ "$INCLUDE_CHAT_ERROR_TAXONOMY" = "1" ] || [ "$INCLUDE_CHAT_RESPONSE_STREAM" = "1" ] || [ "$INCLUDE_CHAT_MESSAGE_LIST" = "1" ] || [ "$INCLUDE_CHAT_ACTION_BAR" = "1" ]; }; then
+    ERROR "--include-runtime-readiness, --include-device-session, --include-chat-session, --include-chat-surface-layout, --include-chat-local-only-policy, --include-chat-preferences, --include-chat-session-index, --include-chat-model-status, --include-chat-readiness, --include-chat-composer, --include-chat-send-result, --include-chat-transcript-policy, --include-chat-audit-event, --include-chat-error-taxonomy, --include-chat-response-stream, --include-chat-message-list, and --include-chat-action-bar are only supported in local scaffold mode"
     exit 1
 fi
 
@@ -1840,6 +1952,7 @@ if [ -z "$BACKEND" ]; then
     NOTE "chat errors   : opt-in via --include-chat-error-taxonomy (read-only error taxonomy data)"
     NOTE "chat stream   : opt-in via --include-chat-response-stream (read-only response stream data)"
     NOTE "chat messages : opt-in via --include-chat-message-list (read-only empty message-list data)"
+    NOTE "chat actions  : opt-in via --include-chat-action-bar (read-only disabled action-bar data)"
     NOTE "editor bridge  : planned (VS Code / other IDEs)"
 
     if [ "$INCLUDE_CHAT_ERROR_TAXONOMY" = "1" ]; then
@@ -1856,6 +1969,12 @@ if [ -z "$BACKEND" ]; then
 
     if [ "$INCLUDE_CHAT_MESSAGE_LIST" = "1" ]; then
         if ! print_chat_message_list_summary; then
+            exit 1
+        fi
+    fi
+
+    if [ "$INCLUDE_CHAT_ACTION_BAR" = "1" ]; then
+        if ! print_chat_action_bar_summary; then
             exit 1
         fi
     fi

--- a/scripts/tests/chat_action_bar_contract_test.py
+++ b/scripts/tests/chat_action_bar_contract_test.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Fixture tests for the standalone chat action-bar contract."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "contracts" / "chat_action_bar_contract.py"
+FIXTURE_PATH = (
+    ROOT
+    / "contracts"
+    / "fixtures"
+    / "chat-action-bar.gemma3n-e4b-kv260-placeholder.json"
+)
+SCRIPT_PATH = ROOT / "scripts" / "chat-action-bar-stub.sh"
+STATUS_TEST_PATH = ROOT / "scripts" / "tests" / "status-chat-action-bar.sh"
+DOC_PATH = ROOT / "docs" / "STANDALONE_CHAT_SESSION_CONTRACT.md"
+README_PATH = ROOT / "README.md"
+TEST_PATH = Path(__file__).resolve()
+CI_PATH = ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location(
+        "chat_action_bar_contract",
+        MODULE_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def iter_state_values(value):
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            if (
+                key == "state"
+                or key.endswith("State")
+                or key.endswith("Status")
+            ) and isinstance(nested, str):
+                yield nested
+            yield from iter_state_values(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            yield from iter_state_values(nested)
+
+
+def iter_keys(value):
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            yield key
+            yield from iter_keys(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            yield from iter_keys(nested)
+
+
+def assert_no_private_or_generated_data(text: str) -> None:
+    forbidden_patterns = [
+        r"/home/[^\s\"']+",
+        r"/Users/[^\s\"']+",
+        r"[A-Za-z]:\\Users\\",
+        r"\b(?:api[_-]?key|authorization|bearer|client[_-]?secret|password|private[_-]?key|secret|token)\b\s*[:=]",
+        r"\.(?:gguf|safetensors|ckpt|pt|pth|onnx)\b",
+        r"(?:weights|model_weights|model-cache)/(?:[^\"'\s]+)",
+        r"(?:raw[_-]?full[_-]?logs|hardware[_-]?dump|generated[_-]?blob)\s*[:=]",
+    ]
+    for pattern in forbidden_patterns:
+        assert not re.search(pattern, text, re.IGNORECASE), pattern
+
+
+def assert_no_runtime_implementation_terms(source: str) -> None:
+    forbidden = [
+        "subprocess",
+        "os.system",
+        "popen",
+        "socket",
+        "urllib",
+        "requests",
+        "http.client",
+        "openai",
+        "anthropic",
+        "gem" + "ini",
+        "modelcontextprotocol",
+        "websocket",
+        "xmutil",
+        "xrt-smi",
+        "lsusb",
+        "dmesg",
+    ]
+    lowered = source.lower()
+    for term in forbidden:
+        assert term not in lowered, term
+
+
+def assert_no_provider_configs(value) -> None:
+    forbidden_keys = {
+        "apiKey",
+        "accessToken",
+        "refreshToken",
+        "authorization",
+        "bearerToken",
+        "provider",
+        "providers",
+        "providerConfig",
+        "providerConfigs",
+    }
+    for key in iter_keys(value):
+        assert key not in forbidden_keys, key
+
+
+def assert_no_unsupported_claims(text: str) -> None:
+    literal_claims = [
+        "production" + "-ready",
+        "marketplace" + "-ready",
+        "stable " + "API",
+        "stable " + "ABI",
+        "KV260 inference " + "works",
+        "Gemma 3N E4B " + "runs on KV260",
+        "20 tok/s " + "achieved",
+        "timing " + "closed",
+        "bitstream " + "ready",
+        "launcher executes " + "pccx-lab",
+        "IDE controls " + "launcher",
+        "AI provider integration " + "is live",
+    ]
+    lowered = text.lower()
+    for claim in literal_claims:
+        assert claim.lower() not in lowered, claim
+
+
+def test_chat_action_bar_matches_fixture_and_is_deterministic() -> None:
+    module = load_module()
+    generated = module.create_gemma3n_e4b_kv260_chat_action_bar()
+    fixture = json.loads(read_text(FIXTURE_PATH))
+
+    assert generated == fixture
+    assert module.chat_action_bar_json(generated) == (
+        module.chat_action_bar_json(generated)
+    )
+    assert module.chat_action_bar_json(generated).endswith("\n")
+    assert json.loads(module.chat_action_bar_json(generated)) == fixture
+
+
+def test_cli_stub_outputs_deterministic_json() -> None:
+    fixture = json.loads(read_text(FIXTURE_PATH))
+    command = [
+        "bash",
+        str(SCRIPT_PATH),
+        "--model",
+        "gemma3n-e4b",
+        "--target",
+        "kv260",
+    ]
+    first = subprocess.run(command, check=True, capture_output=True, text=True)
+    second = subprocess.run(command, check=True, capture_output=True, text=True)
+
+    assert first.stderr == ""
+    assert first.stdout == second.stdout
+    assert first.stdout.endswith("\n")
+    assert json.loads(first.stdout) == fixture
+
+
+def test_required_fields_and_allowed_states() -> None:
+    module = load_module()
+    action_bar = module.create_gemma3n_e4b_kv260_chat_action_bar()
+    allowed = set(module.CHAT_ACTION_BAR_STATE_VALUES)
+
+    assert tuple(action_bar.keys()) == module.CHAT_ACTION_BAR_FIELDS
+    assert action_bar["schemaVersion"] == "pccx.chatActionBar.v0"
+    assert tuple(action_bar["actionPolicy"].keys()) == module.ACTION_POLICY_FIELDS
+
+    states = list(iter_state_values(action_bar))
+    assert states
+    for state in states:
+        assert state in allowed, state
+
+    for group in action_bar["actionGroups"]:
+        assert tuple(group.keys()) == module.ACTION_GROUP_FIELDS
+    for control in action_bar["actionControls"]:
+        assert tuple(control.keys()) == module.ACTION_CONTROL_FIELDS
+    for reason in action_bar["blockedReasons"]:
+        assert tuple(reason.keys()) == module.BLOCKED_REASON_FIELDS
+    for ref in action_bar["handoffRefs"]:
+        assert tuple(ref.keys()) == module.HANDOFF_REF_FIELDS
+
+
+def test_chat_action_bar_keeps_actions_disabled() -> None:
+    action_bar = load_module().create_gemma3n_e4b_kv260_chat_action_bar()
+    policy = action_bar["actionPolicy"]
+    flags = action_bar["safetyFlags"]
+    groups = {group["groupId"]: group for group in action_bar["actionGroups"]}
+    controls = {
+        control["actionId"]: control
+        for control in action_bar["actionControls"]
+    }
+    reasons = {reason["reasonId"]: reason for reason in action_bar["blockedReasons"]}
+    refs = {ref["refId"]: ref for ref in action_bar["handoffRefs"]}
+
+    assert action_bar["actionBarState"] == "blocked"
+    assert action_bar["conversationState"] == "inactive"
+    assert action_bar["selectionState"] == "disabled"
+    assert action_bar["transcriptState"] == "not_started"
+    assert action_bar["responseState"] == "not_generated"
+    assert action_bar["attachmentState"] == "disabled"
+    assert action_bar["clipboardState"] == "disabled"
+    assert action_bar["exportState"] == "disabled"
+    assert action_bar["stopControlState"] == "disabled"
+    assert policy["sideEffectPolicy"] == "local_render_only"
+    assert set(groups) == {
+        "conversation_actions",
+        "message_actions",
+        "transcript_actions",
+        "runtime_actions",
+        "attachment_actions",
+    }
+    assert all(group["enabled"] is False for group in groups.values())
+    assert set(controls) == {
+        "new_chat",
+        "clear_conversation",
+        "export_transcript",
+        "retry_response",
+        "copy_response",
+        "stop_response",
+        "attach_context",
+    }
+    assert all(control["enabled"] is False for control in controls.values())
+    assert controls["new_chat"]["state"] == "blocked"
+    assert controls["clear_conversation"]["state"] == "disabled"
+    assert controls["export_transcript"]["sideEffectPolicy"] == "no_transcript_export"
+    assert controls["retry_response"]["resultState"] == "not_generated"
+    assert controls["copy_response"]["sideEffectPolicy"] == "no_clipboard_write"
+    assert controls["stop_response"]["sideEffectPolicy"] == "no_stop_signal"
+    assert controls["attach_context"]["sideEffectPolicy"] == "no_file_or_artifact_read"
+    assert set(reasons) == {
+        "session_lifecycle_not_enabled",
+        "transcript_store_not_configured",
+        "transcript_export_not_reviewed",
+        "message_content_absent",
+        "response_stream_blocked",
+        "runtime_stream_not_started",
+        "attachment_boundary_absent",
+    }
+    assert set(refs) == {
+        "chat_session",
+        "chat_session_lifecycle",
+        "chat_readiness",
+        "chat_composer",
+        "chat_send_result",
+        "chat_response_stream",
+        "chat_message_list",
+        "chat_transcript_policy",
+    }
+    assert flags["readOnly"] is True
+    assert flags["dataOnly"] is True
+    assert flags["actionBarDisplayOnly"] is True
+    assert flags["actionMetadataOnly"] is True
+    assert flags["readsSessionStore"] is False
+    assert flags["readsTranscript"] is False
+    assert flags["transcriptExport"] is False
+    assert flags["sessionStoreRead"] is False
+    assert flags["sessionStoreWrite"] is False
+    assert flags["conversationCreated"] is False
+    assert flags["conversationCleared"] is False
+    assert flags["attachmentReads"] is False
+    assert flags["fileUpload"] is False
+    assert flags["clipboardWrite"] is False
+    assert flags["sendAttempted"] is False
+    assert flags["retryAttempted"] is False
+    assert flags["stopSignalSent"] is False
+    assert flags["responseGenerated"] is False
+    assert flags["modelExecution"] is False
+    assert flags["runtimeExecution"] is False
+    assert flags["kv260Access"] is False
+    assert flags["networkCalls"] is False
+    assert flags["providerCalls"] is False
+    assert flags["executesPccxLab"] is False
+
+
+def test_chat_action_bar_docs_and_ci_are_wired() -> None:
+    doc = read_text(DOC_PATH)
+    readme = read_text(README_PATH)
+    status_test = read_text(STATUS_TEST_PATH)
+    ci = read_text(CI_PATH)
+
+    assert "contracts/chat_action_bar_contract.py" in doc
+    assert (
+        "contracts/fixtures/chat-action-bar.gemma3n-e4b-kv260-placeholder.json"
+        in doc
+    )
+    assert "scripts/chat-action-bar-stub.sh" in doc
+    assert "scripts/tests/chat_action_bar_contract_test.py" in doc
+    assert "scripts/tests/status-chat-action-bar.sh" in doc
+    assert "chat-action-bar-stub.sh" in readme
+    assert "--include-chat-action-bar" in readme
+    assert "chat_action_bar_contract_test.py" in ci
+    assert "status-chat-action-bar.sh" in ci
+    assert "--include-chat-action-bar" in status_test
+
+
+def test_chat_action_bar_has_no_runtime_or_private_surface() -> None:
+    module = load_module()
+    action_bar = module.create_gemma3n_e4b_kv260_chat_action_bar()
+    fixture_text = read_text(FIXTURE_PATH)
+    contract_source = read_text(MODULE_PATH)
+    stub_source = read_text(SCRIPT_PATH)
+    docs = "\n".join(
+        [
+            fixture_text,
+            contract_source,
+            stub_source,
+            read_text(DOC_PATH),
+            read_text(README_PATH),
+            read_text(STATUS_TEST_PATH),
+        ]
+    )
+
+    assert_no_provider_configs(action_bar)
+    assert_no_private_or_generated_data(docs)
+    assert_no_unsupported_claims(docs)
+    assert_no_runtime_implementation_terms(contract_source)
+    assert_no_runtime_implementation_terms(stub_source)
+
+
+def test_source_headers_for_touched_code_files() -> None:
+    expected_headers = {
+        MODULE_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        SCRIPT_PATH: [
+            "#!/usr/bin/env bash",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        STATUS_TEST_PATH: [
+            "#!/usr/bin/env bash",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        TEST_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        CI_PATH: [
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+    }
+
+    for path, header in expected_headers.items():
+        assert read_text(path).splitlines()[: len(header)] == header, path
+
+
+if __name__ == "__main__":
+    for name, func in sorted(globals().items()):
+        if name.startswith("test_") and callable(func):
+            func()
+    print("chat action-bar contract tests ok")

--- a/scripts/tests/status-chat-action-bar.sh
+++ b/scripts/tests/status-chat-action-bar.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+# scripts/tests/status-chat-action-bar.sh - status action-bar tests.
+#
+# Usage: bash scripts/tests/status-chat-action-bar.sh [path/to/status-stub.sh]
+
+set -eu
+
+PASS() { printf '[PASS]  %s\n' "$*"; }
+FAIL() { printf '[FAIL] %s\n' "$*" >&2; }
+HEAD() { printf '\n=== %s ===\n' "$*"; }
+
+STUB="${1:-scripts/status-stub.sh}"
+
+if [ ! -x "$STUB" ]; then
+    chmod +x "$STUB"
+fi
+
+contains() {
+    case "$1" in
+        *"$2"*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+require_contains() {
+    local output="$1"
+    local expected="$2"
+    if ! contains "$output" "$expected"; then
+        FAIL "expected output to contain: $expected"
+        printf '%s\n' "$output" >&2
+        exit 1
+    fi
+}
+
+require_not_contains() {
+    local output="$1"
+    local forbidden="$2"
+    if contains "$output" "$forbidden"; then
+        FAIL "output contained forbidden text: $forbidden"
+        printf '%s\n' "$output" >&2
+        exit 1
+    fi
+}
+
+HEAD "1: status can include chat action bar"
+OUTPUT="$("$STUB" --include-chat-action-bar)"
+require_contains "$OUTPUT" "=== chat action bar ==="
+require_contains "$OUTPUT" "source     : scripts/chat-action-bar-stub.sh --model gemma3n-e4b --target kv260"
+require_contains "$OUTPUT" "boundary   : read-only data; no action execution/session-store/transcript/clipboard/file/model/runtime/hardware/lab/IDE execution"
+require_contains "$OUTPUT" "target     : kv260"
+require_contains "$OUTPUT" "model      : gemma3n-e4b"
+require_contains "$OUTPUT" "actions    : blocked"
+require_contains "$OUTPUT" "conversation: inactive"
+require_contains "$OUTPUT" "selection  : disabled"
+require_contains "$OUTPUT" "transcript : not_started"
+require_contains "$OUTPUT" "response   : not_generated"
+require_contains "$OUTPUT" "attachment : disabled"
+require_contains "$OUTPUT" "clipboard  : disabled"
+require_contains "$OUTPUT" "export     : disabled"
+require_contains "$OUTPUT" "stop       : disabled"
+PASS "chat action-bar section is present and conservative"
+
+HEAD "2: groups and controls stay disabled"
+require_contains "$OUTPUT" "groups     : conversation_actions=blocked"
+require_contains "$OUTPUT" "message_actions=disabled"
+require_contains "$OUTPUT" "transcript_actions=not_configured"
+require_contains "$OUTPUT" "runtime_actions=not_started"
+require_contains "$OUTPUT" "attachment_actions=planned"
+require_contains "$OUTPUT" "controls   : new_chat=blocked:false"
+require_contains "$OUTPUT" "clear_conversation=disabled:false"
+require_contains "$OUTPUT" "export_transcript=disabled:false"
+require_contains "$OUTPUT" "retry_response=blocked:false"
+require_contains "$OUTPUT" "copy_response=disabled:false"
+require_contains "$OUTPUT" "stop_response=disabled:false"
+require_contains "$OUTPUT" "attach_context=disabled:false"
+require_contains "$OUTPUT" "blocked    : session_lifecycle_not_enabled=blocked"
+require_contains "$OUTPUT" "transcript_store_not_configured=not_configured"
+require_contains "$OUTPUT" "transcript_export_not_reviewed=not_configured"
+require_contains "$OUTPUT" "message_content_absent=empty_not_captured"
+require_contains "$OUTPUT" "response_stream_blocked=blocked"
+require_contains "$OUTPUT" "runtime_stream_not_started=not_started"
+require_contains "$OUTPUT" "attachment_boundary_absent=planned"
+PASS "disabled action-bar metadata is summarized"
+
+HEAD "3: safety flags stay read-only and non-executing"
+require_contains "$OUTPUT" "readOnly=true"
+require_contains "$OUTPUT" "dataOnly=true"
+require_contains "$OUTPUT" "deterministic=true"
+require_contains "$OUTPUT" "actionBarDisplayOnly=true"
+require_contains "$OUTPUT" "actionMetadataOnly=true"
+require_contains "$OUTPUT" "readsSessionStore=false"
+require_contains "$OUTPUT" "readsTranscript=false"
+require_contains "$OUTPUT" "transcriptExport=false"
+require_contains "$OUTPUT" "sessionStoreRead=false"
+require_contains "$OUTPUT" "sessionStoreWrite=false"
+require_contains "$OUTPUT" "conversationCreated=false"
+require_contains "$OUTPUT" "conversationCleared=false"
+require_contains "$OUTPUT" "attachmentReads=false"
+require_contains "$OUTPUT" "fileUpload=false"
+require_contains "$OUTPUT" "clipboardWrite=false"
+require_contains "$OUTPUT" "sendAttempted=false"
+require_contains "$OUTPUT" "retryAttempted=false"
+require_contains "$OUTPUT" "stopSignalSent=false"
+require_contains "$OUTPUT" "responseGenerated=false"
+require_contains "$OUTPUT" "modelExecution=false"
+require_contains "$OUTPUT" "runtimeExecution=false"
+require_contains "$OUTPUT" "kv260Access=false"
+require_contains "$OUTPUT" "hardwareAccess=false"
+require_contains "$OUTPUT" "networkCalls=false"
+require_contains "$OUTPUT" "providerCalls=false"
+require_contains "$OUTPUT" "executesPccxLab=false"
+PASS "execution-related flags remain false"
+
+HEAD "4: output is deterministic"
+OUTPUT_AGAIN="$("$STUB" --include-chat-action-bar)"
+if [ "$OUTPUT" != "$OUTPUT_AGAIN" ]; then
+    FAIL "status chat action-bar output changed between runs"
+    exit 1
+fi
+PASS "status chat action-bar output is deterministic"
+
+HEAD "5: chat action-bar option does not combine with pccx-lab backend"
+if "$STUB" --include-chat-action-bar --backend pccx-lab >/dev/null 2>&1; then
+    FAIL "expected combined chat-action-bar/backend mode to fail"
+    exit 1
+fi
+PASS "chat action-bar remains separate from backend execution"
+
+HEAD "6: output avoids known overclaims"
+FORBIDDEN_PREFIX="KV260 inference"
+FORBIDDEN_CLAIM="${FORBIDDEN_PREFIX} works"
+require_not_contains "$OUTPUT" "$FORBIDDEN_CLAIM"
+THROUGHPUT_PREFIX="20 tok/s"
+THROUGHPUT_CLAIM="${THROUGHPUT_PREFIX} achieved"
+require_not_contains "$OUTPUT" "$THROUGHPUT_CLAIM"
+PASS "no chat action-bar or throughput overclaim in status output"
+
+printf '\n[DONE]  all status-chat-action-bar tests passed\n'


### PR DESCRIPTION
## Summary
- Add a data-only chat action-bar contract, fixture, and stub for disabled conversation controls.
- Wire the new --include-chat-action-bar status summary, CI entries, docs, and status tests.
- Keep new, clear, export, retry, copy, stop, and attach controls as local metadata without session-store reads, transcript export, clipboard/file actions, provider calls, runtime execution, model loading, or target access.

Refs #9

## Validation
- python3 -m py_compile contracts/*.py scripts/tests/*.py
- bash -n scripts/*.sh scripts/tests/*.sh
- python3 -m json.tool contracts/fixtures/chat-action-bar.gemma3n-e4b-kv260-placeholder.json
- bash scripts/chat-action-bar-stub.sh --model gemma3n-e4b --target kv260
- python3 scripts/tests/chat_action_bar_contract_test.py
- bash scripts/tests/status-chat-action-bar.sh scripts/status-stub.sh
- bash scripts/check.sh
- all scripts/tests/*_test.py contract tests
- all scripts/tests/status-*.sh status tests
- git diff --check
- git diff --cached --check
- local claim-scan equivalent