### PR TITLE
Add chat shortcut-map boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,7 @@ jobs:
                    scripts/chat-response-stream-stub.sh \
                    scripts/chat-message-list-stub.sh \
                    scripts/chat-action-bar-stub.sh \
+                   scripts/chat-shortcut-map-stub.sh \
                    scripts/chat-surface-preview.sh \
                    scripts/chat-stub.sh; do
             [ -f "$f" ] && chmod +x "$f" || true
@@ -228,6 +229,10 @@ jobs:
         run: ./scripts/status-stub.sh --include-chat-action-bar
       - name: run scripts/chat-action-bar-stub.sh
         run: ./scripts/chat-action-bar-stub.sh --model gemma3n-e4b --target kv260
+      - name: run scripts/status-stub.sh with chat shortcut map
+        run: ./scripts/status-stub.sh --include-chat-shortcut-map
+      - name: run scripts/chat-shortcut-map-stub.sh
+        run: ./scripts/chat-shortcut-map-stub.sh --model gemma3n-e4b --target kv260
       - name: run scripts/chat-surface-preview.sh
         run: ./scripts/chat-surface-preview.sh --model gemma3n-e4b --target kv260
       - name: run scripts/chat-stub.sh --dry-run
@@ -282,6 +287,8 @@ jobs:
         run: python3 scripts/tests/chat_message_list_contract_test.py
       - name: run chat action-bar contract tests
         run: python3 scripts/tests/chat_action_bar_contract_test.py
+      - name: run chat shortcut-map contract tests
+        run: python3 scripts/tests/chat_shortcut_map_contract_test.py
       - name: run chat surface preview tests
         run: python3 scripts/tests/chat_surface_preview_test.py
 
@@ -310,6 +317,7 @@ jobs:
           chmod +x scripts/chat-response-stream-stub.sh
           chmod +x scripts/chat-message-list-stub.sh
           chmod +x scripts/chat-action-bar-stub.sh
+          chmod +x scripts/chat-shortcut-map-stub.sh
           chmod +x scripts/launch-stub.sh
           chmod +x scripts/tests/status-backend.sh
           chmod +x scripts/tests/status-device-session.sh
@@ -329,6 +337,7 @@ jobs:
           chmod +x scripts/tests/status-chat-response-stream.sh
           chmod +x scripts/tests/status-chat-message-list.sh
           chmod +x scripts/tests/status-chat-action-bar.sh
+          chmod +x scripts/tests/status-chat-shortcut-map.sh
       - name: shellcheck status-stub and test script
         run: |
           sudo apt-get update -q && sudo apt-get install -y -q shellcheck
@@ -351,6 +360,7 @@ jobs:
           shellcheck scripts/tests/status-chat-response-stream.sh
           shellcheck scripts/tests/status-chat-message-list.sh
           shellcheck scripts/tests/status-chat-action-bar.sh
+          shellcheck scripts/tests/status-chat-shortcut-map.sh
       - name: run status-backend tests
         run: bash scripts/tests/status-backend.sh scripts/status-stub.sh
       - name: run status-device-session tests
@@ -387,3 +397,5 @@ jobs:
         run: bash scripts/tests/status-chat-message-list.sh scripts/status-stub.sh
       - name: run status-chat-action-bar tests
         run: bash scripts/tests/status-chat-action-bar.sh scripts/status-stub.sh
+      - name: run status-chat-shortcut-map tests
+        run: bash scripts/tests/status-chat-shortcut-map.sh scripts/status-stub.sh

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ and verify host-side prerequisites before the real engine lands.
 | [`scripts/check.sh`](./scripts/check.sh) | Probe host info, tooling availability, edge-device hints. Always exits 0. |
 | [`scripts/check-device-stub.sh`](./scripts/check-device-stub.sh) | Narrowly scoped device-tree / FPGA-node probe (KV260 / Kria detection only). Always exits 0. |
 | [`scripts/install-stub.sh`](./scripts/install-stub.sh) | Preview of the planned install flow; reports which host runtime pieces are present, lists device-side pieces as future deliverables. Always exits 0. |
-| [`scripts/status-stub.sh`](./scripts/status-stub.sh) | Launcher state summary. Default mode: local scaffold output, always exits 0. With `--include-chat-action-bar`, adds read-only disabled chat action-bar data. With `--include-chat-message-list`, adds read-only empty chat message-list data. With `--include-chat-response-stream`, adds read-only blocked chat response stream data. With `--include-chat-error-taxonomy`, adds read-only chat error taxonomy data. With `--include-chat-audit-event`, adds read-only blocked chat audit-event metadata. With `--include-chat-surface-layout`, adds read-only chat surface layout data. With `--include-chat-local-only-policy`, adds read-only local-only/cloud-block policy data. With `--include-chat-preferences`, adds read-only chat preferences/settings data. With `--include-chat-session-index`, adds read-only empty chat session index data. With `--include-chat-transcript-policy`, adds read-only chat transcript retention/export policy data. With `--include-chat-send-result`, adds read-only blocked chat send-result data. With `--include-chat-composer`, adds read-only chat composer/input-control data. With `--include-chat-model-status`, adds read-only blocked chat model-status display data. With `--include-chat-session`, adds read-only blocked chat/session and lifecycle summaries. With `--include-chat-readiness`, adds read-only chat readiness checks and recovery actions. With `--include-device-session`, adds a read-only device/session status panel. With `--include-runtime-readiness`, adds a read-only runtime readiness summary. With `--backend pccx-lab`, calls `pccx-lab status --format json` and forwards the run-status envelope (exits non-zero if binary is missing or output is invalid). |
+| [`scripts/status-stub.sh`](./scripts/status-stub.sh) | Launcher state summary. Default mode: local scaffold output, always exits 0. With `--include-chat-action-bar`, adds read-only disabled chat action-bar data. With `--include-chat-shortcut-map`, adds read-only disabled chat shortcut-map data. With `--include-chat-message-list`, adds read-only empty chat message-list data. With `--include-chat-response-stream`, adds read-only blocked chat response stream data. With `--include-chat-error-taxonomy`, adds read-only chat error taxonomy data. With `--include-chat-audit-event`, adds read-only blocked chat audit-event metadata. With `--include-chat-surface-layout`, adds read-only chat surface layout data. With `--include-chat-local-only-policy`, adds read-only local-only/cloud-block policy data. With `--include-chat-preferences`, adds read-only chat preferences/settings data. With `--include-chat-session-index`, adds read-only empty chat session index data. With `--include-chat-transcript-policy`, adds read-only chat transcript retention/export policy data. With `--include-chat-send-result`, adds read-only blocked chat send-result data. With `--include-chat-composer`, adds read-only chat composer/input-control data. With `--include-chat-model-status`, adds read-only blocked chat model-status display data. With `--include-chat-session`, adds read-only blocked chat/session and lifecycle summaries. With `--include-chat-readiness`, adds read-only chat readiness checks and recovery actions. With `--include-device-session`, adds a read-only device/session status panel. With `--include-runtime-readiness`, adds a read-only runtime readiness summary. With `--backend pccx-lab`, calls `pccx-lab status --format json` and forwards the run-status envelope (exits non-zero if binary is missing or output is invalid). |
 | [`scripts/device-session-status-stub.sh`](./scripts/device-session-status-stub.sh) | Data-only device/session status JSON for the Gemma 3N E4B + KV260 target. Reports connection, model load, session, diagnostics, readiness, discovery paths, flow steps, and error taxonomy as placeholder / blocked. |
 | [`scripts/runtime-readiness-stub.sh`](./scripts/runtime-readiness-stub.sh) | Data-only runtime readiness JSON for the Gemma 3N E4B + KV260 target. Reports blocked / not yet evidence-backed. |
 | [`scripts/chat-session-stub.sh`](./scripts/chat-session-stub.sh) | Data-only standalone chat/session JSON for the Gemma 3N E4B + KV260 target. Reports disabled send controls, inactive session state, no prompt/response persistence, and readiness handoff references. |
@@ -103,6 +103,7 @@ and verify host-side prerequisites before the real engine lands.
 | [`scripts/chat-response-stream-stub.sh`](./scripts/chat-response-stream-stub.sh) | Data-only blocked chat response stream JSON for the Gemma 3N E4B + KV260 target. Reports disabled response streaming, progress, token counter, and stop-control state without opening transport, generating chunks, counting tokens, or writing transcripts. |
 | [`scripts/chat-message-list-stub.sh`](./scripts/chat-message-list-stub.sh) | Data-only empty chat message-list JSON for the Gemma 3N E4B + KV260 target. Reports an empty conversation viewport without reading a session store, transcript, prompt, response, summary, model path, runtime log, or artifact. |
 | [`scripts/chat-action-bar-stub.sh`](./scripts/chat-action-bar-stub.sh) | Data-only disabled chat action-bar JSON for the Gemma 3N E4B + KV260 target. Reports new, clear, export, retry, copy, stop, and attach controls without reading stores, transcripts, message bodies, files, clipboard data, model paths, runtime logs, or artifacts. |
+| [`scripts/chat-shortcut-map-stub.sh`](./scripts/chat-shortcut-map-stub.sh) | Data-only disabled chat shortcut-map JSON for the Gemma 3N E4B + KV260 target. Reports planned keyboard accelerator and focus metadata without installing listeners, capturing key events, dispatching commands, changing focus, reading prompts, sessions, transcripts, messages, files, or clipboard data, or starting runtime paths. |
 | [`scripts/chat-transcript-policy-stub.sh`](./scripts/chat-transcript-policy-stub.sh) | Data-only chat transcript policy JSON for the Gemma 3N E4B + KV260 target. Reports retention, export, storage, and privacy policy state without reading, generating, storing, persisting, summarizing, or exporting prompt/response/transcript content. |
 | [`scripts/chat-audit-event-stub.sh`](./scripts/chat-audit-event-stub.sh) | Data-only chat audit-event JSON for the Gemma 3N E4B + KV260 target. Reports blocked send metadata, redaction policy, absent prompt/response/transcript content, and disabled audit persistence. |
 | [`scripts/chat-error-taxonomy-stub.sh`](./scripts/chat-error-taxonomy-stub.sh) | Data-only chat error taxonomy JSON for the Gemma 3N E4B + KV260 target. Groups blocked readiness, model/runtime, session, and policy errors without reading prompts, providers, configs, model paths, logs, stores, or artifacts. |
@@ -130,6 +131,7 @@ bash scripts/status-stub.sh --include-chat-error-taxonomy
 bash scripts/status-stub.sh --include-chat-response-stream
 bash scripts/status-stub.sh --include-chat-message-list
 bash scripts/status-stub.sh --include-chat-action-bar
+bash scripts/status-stub.sh --include-chat-shortcut-map
 bash scripts/status-stub.sh --include-device-session
 bash scripts/status-stub.sh --include-runtime-readiness
 bash scripts/device-session-status-stub.sh --model gemma3n-e4b --target kv260
@@ -150,6 +152,7 @@ bash scripts/chat-error-taxonomy-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-response-stream-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-message-list-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-action-bar-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/chat-shortcut-map-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-surface-preview.sh --model gemma3n-e4b --target kv260
 bash scripts/launch-stub.sh --dry-run
 bash scripts/chat-stub.sh --dry-run --prompt "hello"
@@ -321,6 +324,7 @@ python3 contracts/chat_audit_event_contract.py --model gemma3n-e4b --target kv26
 python3 contracts/chat_error_taxonomy_contract.py --model gemma3n-e4b --target kv260
 python3 contracts/chat_response_stream_contract.py --model gemma3n-e4b --target kv260
 python3 contracts/chat_action_bar_contract.py --model gemma3n-e4b --target kv260
+python3 contracts/chat_shortcut_map_contract.py --model gemma3n-e4b --target kv260
 bash scripts/chat-model-status-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-session-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-session-lifecycle-stub.sh --model gemma3n-e4b --target kv260
@@ -329,6 +333,7 @@ bash scripts/chat-audit-event-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-error-taxonomy-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-response-stream-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-action-bar-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/chat-shortcut-map-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-surface-preview.sh --model gemma3n-e4b --target kv260
 bash scripts/status-stub.sh --include-chat-model-status
 bash scripts/status-stub.sh --include-chat-session
@@ -337,6 +342,7 @@ bash scripts/status-stub.sh --include-chat-audit-event
 bash scripts/status-stub.sh --include-chat-error-taxonomy
 bash scripts/status-stub.sh --include-chat-response-stream
 bash scripts/status-stub.sh --include-chat-action-bar
+bash scripts/status-stub.sh --include-chat-shortcut-map
 python3 scripts/tests/chat_session_contract_test.py
 python3 scripts/tests/chat_model_status_contract_test.py
 python3 scripts/tests/chat_session_lifecycle_contract_test.py
@@ -345,6 +351,7 @@ python3 scripts/tests/chat_audit_event_contract_test.py
 python3 scripts/tests/chat_error_taxonomy_contract_test.py
 python3 scripts/tests/chat_response_stream_contract_test.py
 python3 scripts/tests/chat_action_bar_contract_test.py
+python3 scripts/tests/chat_shortcut_map_contract_test.py
 python3 scripts/tests/chat_surface_preview_test.py
 bash scripts/tests/status-chat-model-status.sh
 bash scripts/tests/status-chat-session.sh
@@ -353,6 +360,7 @@ bash scripts/tests/status-chat-audit-event.sh
 bash scripts/tests/status-chat-error-taxonomy.sh
 bash scripts/tests/status-chat-response-stream.sh
 bash scripts/tests/status-chat-action-bar.sh
+bash scripts/tests/status-chat-shortcut-map.sh
 ```
 
 The checked chat/session fixture reports the chat surface as blocked,

--- a/contracts/chat_shortcut_map_contract.py
+++ b/contracts/chat_shortcut_map_contract.py
@@ -1,0 +1,535 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Data-only chat shortcut-map contract for the planned launcher UI.
+
+The contract describes disabled keyboard shortcuts for the standalone chat
+surface. It does not install keyboard listeners, capture key events, dispatch
+commands, focus controls, read prompts, read responses, read transcripts, read
+session stores, copy clipboard data, attach files, start runtime code, load
+models, touch KV260 hardware, call providers, invoke pccx-lab, or persist
+anything.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import sys
+
+
+SCHEMA_VERSION = "pccx.chatShortcutMap.v0"
+
+CHAT_SHORTCUT_MAP_FIELDS = (
+    "schemaVersion",
+    "shortcutMapId",
+    "fixtureVersion",
+    "lastUpdatedSource",
+    "targetDevice",
+    "targetBoard",
+    "targetModel",
+    "shortcutMapState",
+    "focusState",
+    "keyboardCaptureState",
+    "commandDispatchState",
+    "actionExecutionState",
+    "chatSessionRef",
+    "chatComposerRef",
+    "chatMessageListRef",
+    "chatActionBarRef",
+    "shortcutPolicy",
+    "shortcutScopes",
+    "shortcutBindings",
+    "blockedReasons",
+    "handoffRefs",
+    "safetyFlags",
+    "limitations",
+    "issueRefs",
+)
+
+SHORTCUT_POLICY_FIELDS = (
+    "state",
+    "renderMode",
+    "sourcePolicy",
+    "contentPolicy",
+    "keyboardPolicy",
+    "dispatchPolicy",
+    "sideEffectPolicy",
+    "persistencePolicy",
+)
+
+SHORTCUT_SCOPE_FIELDS = (
+    "scopeId",
+    "label",
+    "state",
+    "visible",
+    "enabled",
+    "summary",
+)
+
+SHORTCUT_BINDING_FIELDS = (
+    "shortcutId",
+    "label",
+    "scopeId",
+    "keyChord",
+    "state",
+    "visible",
+    "enabled",
+    "requiresExplicitUserAction",
+    "sourceRef",
+    "resultState",
+    "sideEffectPolicy",
+    "blockedReasonRef",
+)
+
+BLOCKED_REASON_FIELDS = (
+    "reasonId",
+    "state",
+    "summary",
+    "requiredBefore",
+)
+
+HANDOFF_REF_FIELDS = (
+    "refId",
+    "schemaVersion",
+    "fixturePath",
+    "state",
+    "summary",
+)
+
+CHAT_SHORTCUT_MAP_STATE_VALUES = (
+    "available_as_data",
+    "blocked",
+    "disabled",
+    "empty_not_captured",
+    "inactive",
+    "not_configured",
+    "not_generated",
+    "not_installed",
+    "not_invoked",
+    "not_started",
+    "planned",
+    "read_only",
+    "summary_only",
+    "unavailable",
+)
+
+_CHAT_SHORTCUT_MAP = {
+    "schemaVersion": SCHEMA_VERSION,
+    "shortcutMapId": "chat_shortcut_map_gemma3n_e4b_kv260_placeholder",
+    "fixtureVersion": "chat-shortcut-map.gemma3n-e4b-kv260.2026-05-04",
+    "lastUpdatedSource": "pccx_launcher_issue_9_chat_shortcut_map_boundary_2026-05-04",
+    "targetDevice": "kv260",
+    "targetBoard": "xilinx_kria_kv260",
+    "targetModel": "gemma3n-e4b",
+    "shortcutMapState": "blocked",
+    "focusState": "inactive",
+    "keyboardCaptureState": "not_installed",
+    "commandDispatchState": "blocked",
+    "actionExecutionState": "not_invoked",
+    "chatSessionRef": "chat_session_gemma3n_e4b_kv260_placeholder",
+    "chatComposerRef": "chat_composer_gemma3n_e4b_kv260_placeholder",
+    "chatMessageListRef": "chat_message_list_gemma3n_e4b_kv260_placeholder",
+    "chatActionBarRef": "chat_action_bar_gemma3n_e4b_kv260_placeholder",
+    "shortcutPolicy": {
+        "state": "planned",
+        "renderMode": "future_local_chat_shortcut_map",
+        "sourcePolicy": "checked fixture only; no keyboard listener, session store, transcript, prompt, response, clipboard, file, or model path is read",
+        "contentPolicy": "shortcut metadata only; no key-event stream, prompt text, response text, message body, transcript text, or session title is included",
+        "keyboardPolicy": "all key chords are display metadata until a reviewed UI input boundary exists",
+        "dispatchPolicy": "no command dispatch, focus change, send attempt, retry, stop signal, copy, attach, session creation, clear, or export action is performed",
+        "sideEffectPolicy": "local_render_only",
+        "persistencePolicy": "no shortcut settings, key events, prompts, responses, transcripts, clipboard data, attachments, or artifacts are read or written",
+    },
+    "shortcutScopes": [
+        {
+            "scopeId": "global_chat_shell",
+            "label": "global chat shell",
+            "state": "blocked",
+            "visible": True,
+            "enabled": False,
+            "summary": "Global chat-shell shortcuts remain disabled until the standalone surface has a reviewed input boundary.",
+        },
+        {
+            "scopeId": "composer_focus",
+            "label": "composer focus",
+            "state": "inactive",
+            "visible": True,
+            "enabled": False,
+            "summary": "Composer focus shortcuts remain inactive because prompt capture is disabled.",
+        },
+        {
+            "scopeId": "message_list",
+            "label": "message list",
+            "state": "empty_not_captured",
+            "visible": True,
+            "enabled": False,
+            "summary": "Message navigation shortcuts remain disabled because no messages are present.",
+        },
+        {
+            "scopeId": "action_bar",
+            "label": "action bar",
+            "state": "disabled",
+            "visible": True,
+            "enabled": False,
+            "summary": "Action-bar shortcuts mirror disabled conversation controls.",
+        },
+    ],
+    "shortcutBindings": [
+        {
+            "shortcutId": "focus_composer",
+            "label": "focus composer",
+            "scopeId": "composer_focus",
+            "keyChord": "Ctrl+L",
+            "state": "inactive",
+            "visible": True,
+            "enabled": False,
+            "requiresExplicitUserAction": True,
+            "sourceRef": "chat_composer",
+            "resultState": "not_invoked",
+            "sideEffectPolicy": "no_focus_change",
+            "blockedReasonRef": "keyboard_listener_not_installed",
+        },
+        {
+            "shortcutId": "submit_message",
+            "label": "submit message",
+            "scopeId": "composer_focus",
+            "keyChord": "Ctrl+Enter",
+            "state": "blocked",
+            "visible": True,
+            "enabled": False,
+            "requiresExplicitUserAction": True,
+            "sourceRef": "chat_send_result",
+            "resultState": "not_invoked",
+            "sideEffectPolicy": "no_send_attempt",
+            "blockedReasonRef": "send_boundary_blocked",
+        },
+        {
+            "shortcutId": "stop_response",
+            "label": "stop response",
+            "scopeId": "action_bar",
+            "keyChord": "Esc",
+            "state": "disabled",
+            "visible": True,
+            "enabled": False,
+            "requiresExplicitUserAction": True,
+            "sourceRef": "chat_action_bar",
+            "resultState": "unavailable",
+            "sideEffectPolicy": "no_stop_signal",
+            "blockedReasonRef": "response_stream_not_started",
+        },
+        {
+            "shortcutId": "copy_response",
+            "label": "copy response",
+            "scopeId": "message_list",
+            "keyChord": "Ctrl+Shift+C",
+            "state": "disabled",
+            "visible": True,
+            "enabled": False,
+            "requiresExplicitUserAction": True,
+            "sourceRef": "chat_message_list",
+            "resultState": "unavailable",
+            "sideEffectPolicy": "no_clipboard_write",
+            "blockedReasonRef": "message_content_absent",
+        },
+        {
+            "shortcutId": "new_chat",
+            "label": "new chat",
+            "scopeId": "global_chat_shell",
+            "keyChord": "Ctrl+N",
+            "state": "blocked",
+            "visible": True,
+            "enabled": False,
+            "requiresExplicitUserAction": True,
+            "sourceRef": "chat_session_lifecycle",
+            "resultState": "unavailable",
+            "sideEffectPolicy": "no_session_create",
+            "blockedReasonRef": "session_lifecycle_not_enabled",
+        },
+        {
+            "shortcutId": "clear_conversation",
+            "label": "clear conversation",
+            "scopeId": "action_bar",
+            "keyChord": "Ctrl+Shift+Backspace",
+            "state": "disabled",
+            "visible": True,
+            "enabled": False,
+            "requiresExplicitUserAction": True,
+            "sourceRef": "chat_transcript_policy",
+            "resultState": "unavailable",
+            "sideEffectPolicy": "no_transcript_delete",
+            "blockedReasonRef": "transcript_store_not_configured",
+        },
+        {
+            "shortcutId": "export_transcript",
+            "label": "export transcript",
+            "scopeId": "action_bar",
+            "keyChord": "Ctrl+Shift+E",
+            "state": "disabled",
+            "visible": True,
+            "enabled": False,
+            "requiresExplicitUserAction": True,
+            "sourceRef": "chat_transcript_policy",
+            "resultState": "unavailable",
+            "sideEffectPolicy": "no_transcript_export",
+            "blockedReasonRef": "transcript_export_not_reviewed",
+        },
+        {
+            "shortcutId": "attach_context",
+            "label": "attach context",
+            "scopeId": "action_bar",
+            "keyChord": "Ctrl+Shift+A",
+            "state": "planned",
+            "visible": True,
+            "enabled": False,
+            "requiresExplicitUserAction": True,
+            "sourceRef": "chat_action_bar",
+            "resultState": "unavailable",
+            "sideEffectPolicy": "no_file_or_artifact_read",
+            "blockedReasonRef": "attachment_boundary_absent",
+        },
+        {
+            "shortcutId": "next_message",
+            "label": "next message",
+            "scopeId": "message_list",
+            "keyChord": "Alt+Down",
+            "state": "empty_not_captured",
+            "visible": True,
+            "enabled": False,
+            "requiresExplicitUserAction": True,
+            "sourceRef": "chat_message_list",
+            "resultState": "unavailable",
+            "sideEffectPolicy": "no_message_selection",
+            "blockedReasonRef": "message_list_empty",
+        },
+        {
+            "shortcutId": "previous_message",
+            "label": "previous message",
+            "scopeId": "message_list",
+            "keyChord": "Alt+Up",
+            "state": "empty_not_captured",
+            "visible": True,
+            "enabled": False,
+            "requiresExplicitUserAction": True,
+            "sourceRef": "chat_message_list",
+            "resultState": "unavailable",
+            "sideEffectPolicy": "no_message_selection",
+            "blockedReasonRef": "message_list_empty",
+        },
+    ],
+    "blockedReasons": [
+        {
+            "reasonId": "keyboard_listener_not_installed",
+            "state": "not_installed",
+            "summary": "No keyboard listener or focus manager exists in this boundary.",
+            "requiredBefore": "keyboard_shortcuts_enabled",
+        },
+        {
+            "reasonId": "send_boundary_blocked",
+            "state": "blocked",
+            "summary": "The send-result boundary remains blocked and no prompt can be accepted.",
+            "requiredBefore": "submit_message_enabled",
+        },
+        {
+            "reasonId": "response_stream_not_started",
+            "state": "not_started",
+            "summary": "No local response stream exists, so stop controls have no target.",
+            "requiredBefore": "stop_response_enabled",
+        },
+        {
+            "reasonId": "message_content_absent",
+            "state": "empty_not_captured",
+            "summary": "The message-list boundary contains no message bodies or response content.",
+            "requiredBefore": "message_shortcuts_enabled",
+        },
+        {
+            "reasonId": "session_lifecycle_not_enabled",
+            "state": "blocked",
+            "summary": "Session create/restore/clear operations remain disabled.",
+            "requiredBefore": "session_shortcuts_enabled",
+        },
+        {
+            "reasonId": "transcript_store_not_configured",
+            "state": "not_configured",
+            "summary": "No reviewed local transcript store exists.",
+            "requiredBefore": "clear_conversation_enabled",
+        },
+        {
+            "reasonId": "transcript_export_not_reviewed",
+            "state": "not_configured",
+            "summary": "Transcript export requires a separate reviewed storage and redaction boundary.",
+            "requiredBefore": "export_transcript_enabled",
+        },
+        {
+            "reasonId": "attachment_boundary_absent",
+            "state": "planned",
+            "summary": "Attachment shortcuts require a separate reviewed file/artifact input boundary.",
+            "requiredBefore": "attach_context_enabled",
+        },
+        {
+            "reasonId": "message_list_empty",
+            "state": "empty_not_captured",
+            "summary": "Message navigation has no message rows to select.",
+            "requiredBefore": "message_navigation_enabled",
+        },
+    ],
+    "handoffRefs": [
+        {
+            "refId": "chat_session",
+            "schemaVersion": "pccx.chatSession.v0",
+            "fixturePath": "contracts/fixtures/chat-session.gemma3n-e4b-kv260-placeholder.json",
+            "state": "available_as_data",
+            "summary": "Blocked standalone chat/session state.",
+        },
+        {
+            "refId": "chat_composer",
+            "schemaVersion": "pccx.chatComposer.v0",
+            "fixturePath": "contracts/fixtures/chat-composer.gemma3n-e4b-kv260-placeholder.json",
+            "state": "available_as_data",
+            "summary": "Disabled composer and prompt-capture boundary.",
+        },
+        {
+            "refId": "chat_message_list",
+            "schemaVersion": "pccx.chatMessageList.v0",
+            "fixturePath": "contracts/fixtures/chat-message-list.gemma3n-e4b-kv260-placeholder.json",
+            "state": "available_as_data",
+            "summary": "Empty message-list display boundary.",
+        },
+        {
+            "refId": "chat_action_bar",
+            "schemaVersion": "pccx.chatActionBar.v0",
+            "fixturePath": "contracts/fixtures/chat-action-bar.gemma3n-e4b-kv260-placeholder.json",
+            "state": "available_as_data",
+            "summary": "Disabled conversation action-bar boundary.",
+        },
+        {
+            "refId": "chat_transcript_policy",
+            "schemaVersion": "pccx.chatTranscriptPolicy.v0",
+            "fixturePath": "contracts/fixtures/chat-transcript-policy.gemma3n-e4b-kv260-placeholder.json",
+            "state": "available_as_data",
+            "summary": "Transcript retention/export policy boundary.",
+        },
+    ],
+    "safetyFlags": {
+        "readOnly": True,
+        "dataOnly": True,
+        "deterministic": True,
+        "shortcutMapDisplayOnly": True,
+        "shortcutMetadataOnly": True,
+        "writesArtifacts": False,
+        "readsArtifacts": False,
+        "keyboardListenerInstalled": False,
+        "keyboardCaptureEnabled": False,
+        "commandDispatchEnabled": False,
+        "shortcutExecuted": False,
+        "shortcutPersistence": False,
+        "focusChanged": False,
+        "readsSessionStore": False,
+        "readsTranscript": False,
+        "readsMessages": False,
+        "readsPrompt": False,
+        "writesPrompt": False,
+        "promptCapture": False,
+        "promptContentIncluded": False,
+        "promptEchoed": False,
+        "promptPersistence": False,
+        "inputAccepted": False,
+        "sendAttempted": False,
+        "retryAttempted": False,
+        "stopSignalSent": False,
+        "responseContentIncluded": False,
+        "responseGenerated": False,
+        "messageBodiesIncluded": False,
+        "transcriptExport": False,
+        "sessionStoreRead": False,
+        "sessionStoreWrite": False,
+        "conversationCreated": False,
+        "conversationCleared": False,
+        "attachmentReads": False,
+        "fileUpload": False,
+        "clipboardRead": False,
+        "clipboardWrite": False,
+        "modelAssetRead": False,
+        "modelLoadAttempted": False,
+        "modelLoaded": False,
+        "modelExecution": False,
+        "runtimeExecution": False,
+        "hardwareAccess": False,
+        "kv260Access": False,
+        "networkCalls": False,
+        "providerCalls": False,
+        "cloudCalls": False,
+        "configRead": False,
+        "environmentRead": False,
+        "providerConfigRead": False,
+        "privatePathsIncluded": False,
+        "secretsIncluded": False,
+        "tokensIncluded": False,
+        "runtimeLogsIncluded": False,
+        "telemetry": False,
+        "automaticUpload": False,
+        "writeBack": False,
+        "executesPccxLab": False,
+        "executesSystemverilogIde": False,
+        "mcpServerImplemented": False,
+        "lspImplemented": False,
+        "stableApiAbiClaim": False,
+        "marketplaceClaim": False,
+    },
+    "limitations": [
+        "Data-only chat shortcut-map fixture; no keyboard listener, focus manager, prompt, response, transcript, message body, session title, model path, runtime log, file, or clipboard content is read or written.",
+        "Shortcut bindings remain disabled, blocked, inactive, unavailable, or planned until reviewed UI input and command-dispatch boundaries exist.",
+        "No focus change, send attempt, retry, stop signal, session creation, conversation clear, transcript export, clipboard write, attachment read, or file upload is performed.",
+        "No model load, runtime execution, provider call, network call, pccx-lab call, editor call, KV260 hardware access, telemetry, artifact read, or artifact write is performed.",
+        "This is not a release, tag, compatibility commitment, MCP, LSP, IDE, marketplace, telemetry, or runtime implementation.",
+    ],
+    "issueRefs": [
+        "pccxai/pccx-llm-launcher#9",
+    ],
+}
+
+
+def create_gemma3n_e4b_kv260_chat_shortcut_map() -> dict:
+    """Return the checked Gemma 3N E4B plus KV260 chat shortcut-map fixture."""
+    return copy.deepcopy(_CHAT_SHORTCUT_MAP)
+
+
+def chat_shortcut_map_json(shortcut_map: dict | None = None) -> str:
+    """Render a deterministic JSON representation."""
+    return json.dumps(
+        shortcut_map
+        if shortcut_map is not None
+        else create_gemma3n_e4b_kv260_chat_shortcut_map(),
+        indent=2,
+        sort_keys=True,
+    ) + "\n"
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Print data-only chat shortcut-map JSON.",
+    )
+    parser.add_argument(
+        "--model",
+        default="gemma3n-e4b",
+        choices=("gemma3n-e4b",),
+        help="model descriptor target",
+    )
+    parser.add_argument(
+        "--target",
+        default="kv260",
+        choices=("kv260",),
+        help="target board/device",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parse_args(sys.argv[1:] if argv is None else argv)
+    sys.stdout.write(chat_shortcut_map_json())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contracts/fixtures/chat-shortcut-map.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-shortcut-map.gemma3n-e4b-kv260-placeholder.json
@@ -1,0 +1,373 @@
+{
+  "actionExecutionState": "not_invoked",
+  "blockedReasons": [
+    {
+      "reasonId": "keyboard_listener_not_installed",
+      "requiredBefore": "keyboard_shortcuts_enabled",
+      "state": "not_installed",
+      "summary": "No keyboard listener or focus manager exists in this boundary."
+    },
+    {
+      "reasonId": "send_boundary_blocked",
+      "requiredBefore": "submit_message_enabled",
+      "state": "blocked",
+      "summary": "The send-result boundary remains blocked and no prompt can be accepted."
+    },
+    {
+      "reasonId": "response_stream_not_started",
+      "requiredBefore": "stop_response_enabled",
+      "state": "not_started",
+      "summary": "No local response stream exists, so stop controls have no target."
+    },
+    {
+      "reasonId": "message_content_absent",
+      "requiredBefore": "message_shortcuts_enabled",
+      "state": "empty_not_captured",
+      "summary": "The message-list boundary contains no message bodies or response content."
+    },
+    {
+      "reasonId": "session_lifecycle_not_enabled",
+      "requiredBefore": "session_shortcuts_enabled",
+      "state": "blocked",
+      "summary": "Session create/restore/clear operations remain disabled."
+    },
+    {
+      "reasonId": "transcript_store_not_configured",
+      "requiredBefore": "clear_conversation_enabled",
+      "state": "not_configured",
+      "summary": "No reviewed local transcript store exists."
+    },
+    {
+      "reasonId": "transcript_export_not_reviewed",
+      "requiredBefore": "export_transcript_enabled",
+      "state": "not_configured",
+      "summary": "Transcript export requires a separate reviewed storage and redaction boundary."
+    },
+    {
+      "reasonId": "attachment_boundary_absent",
+      "requiredBefore": "attach_context_enabled",
+      "state": "planned",
+      "summary": "Attachment shortcuts require a separate reviewed file/artifact input boundary."
+    },
+    {
+      "reasonId": "message_list_empty",
+      "requiredBefore": "message_navigation_enabled",
+      "state": "empty_not_captured",
+      "summary": "Message navigation has no message rows to select."
+    }
+  ],
+  "chatActionBarRef": "chat_action_bar_gemma3n_e4b_kv260_placeholder",
+  "chatComposerRef": "chat_composer_gemma3n_e4b_kv260_placeholder",
+  "chatMessageListRef": "chat_message_list_gemma3n_e4b_kv260_placeholder",
+  "chatSessionRef": "chat_session_gemma3n_e4b_kv260_placeholder",
+  "commandDispatchState": "blocked",
+  "fixtureVersion": "chat-shortcut-map.gemma3n-e4b-kv260.2026-05-04",
+  "focusState": "inactive",
+  "handoffRefs": [
+    {
+      "fixturePath": "contracts/fixtures/chat-session.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_session",
+      "schemaVersion": "pccx.chatSession.v0",
+      "state": "available_as_data",
+      "summary": "Blocked standalone chat/session state."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-composer.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_composer",
+      "schemaVersion": "pccx.chatComposer.v0",
+      "state": "available_as_data",
+      "summary": "Disabled composer and prompt-capture boundary."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-message-list.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_message_list",
+      "schemaVersion": "pccx.chatMessageList.v0",
+      "state": "available_as_data",
+      "summary": "Empty message-list display boundary."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-action-bar.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_action_bar",
+      "schemaVersion": "pccx.chatActionBar.v0",
+      "state": "available_as_data",
+      "summary": "Disabled conversation action-bar boundary."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-transcript-policy.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_transcript_policy",
+      "schemaVersion": "pccx.chatTranscriptPolicy.v0",
+      "state": "available_as_data",
+      "summary": "Transcript retention/export policy boundary."
+    }
+  ],
+  "issueRefs": [
+    "pccxai/pccx-llm-launcher#9"
+  ],
+  "keyboardCaptureState": "not_installed",
+  "lastUpdatedSource": "pccx_launcher_issue_9_chat_shortcut_map_boundary_2026-05-04",
+  "limitations": [
+    "Data-only chat shortcut-map fixture; no keyboard listener, focus manager, prompt, response, transcript, message body, session title, model path, runtime log, file, or clipboard content is read or written.",
+    "Shortcut bindings remain disabled, blocked, inactive, unavailable, or planned until reviewed UI input and command-dispatch boundaries exist.",
+    "No focus change, send attempt, retry, stop signal, session creation, conversation clear, transcript export, clipboard write, attachment read, or file upload is performed.",
+    "No model load, runtime execution, provider call, network call, pccx-lab call, editor call, KV260 hardware access, telemetry, artifact read, or artifact write is performed.",
+    "This is not a release, tag, compatibility commitment, MCP, LSP, IDE, marketplace, telemetry, or runtime implementation."
+  ],
+  "safetyFlags": {
+    "attachmentReads": false,
+    "automaticUpload": false,
+    "clipboardRead": false,
+    "clipboardWrite": false,
+    "cloudCalls": false,
+    "commandDispatchEnabled": false,
+    "configRead": false,
+    "conversationCleared": false,
+    "conversationCreated": false,
+    "dataOnly": true,
+    "deterministic": true,
+    "environmentRead": false,
+    "executesPccxLab": false,
+    "executesSystemverilogIde": false,
+    "fileUpload": false,
+    "focusChanged": false,
+    "hardwareAccess": false,
+    "inputAccepted": false,
+    "keyboardCaptureEnabled": false,
+    "keyboardListenerInstalled": false,
+    "kv260Access": false,
+    "lspImplemented": false,
+    "marketplaceClaim": false,
+    "mcpServerImplemented": false,
+    "messageBodiesIncluded": false,
+    "modelAssetRead": false,
+    "modelExecution": false,
+    "modelLoadAttempted": false,
+    "modelLoaded": false,
+    "networkCalls": false,
+    "privatePathsIncluded": false,
+    "promptCapture": false,
+    "promptContentIncluded": false,
+    "promptEchoed": false,
+    "promptPersistence": false,
+    "providerCalls": false,
+    "providerConfigRead": false,
+    "readOnly": true,
+    "readsArtifacts": false,
+    "readsMessages": false,
+    "readsPrompt": false,
+    "readsSessionStore": false,
+    "readsTranscript": false,
+    "responseContentIncluded": false,
+    "responseGenerated": false,
+    "retryAttempted": false,
+    "runtimeExecution": false,
+    "runtimeLogsIncluded": false,
+    "secretsIncluded": false,
+    "sendAttempted": false,
+    "sessionStoreRead": false,
+    "sessionStoreWrite": false,
+    "shortcutExecuted": false,
+    "shortcutMapDisplayOnly": true,
+    "shortcutMetadataOnly": true,
+    "shortcutPersistence": false,
+    "stableApiAbiClaim": false,
+    "stopSignalSent": false,
+    "telemetry": false,
+    "tokensIncluded": false,
+    "transcriptExport": false,
+    "writeBack": false,
+    "writesArtifacts": false,
+    "writesPrompt": false
+  },
+  "schemaVersion": "pccx.chatShortcutMap.v0",
+  "shortcutBindings": [
+    {
+      "blockedReasonRef": "keyboard_listener_not_installed",
+      "enabled": false,
+      "keyChord": "Ctrl+L",
+      "label": "focus composer",
+      "requiresExplicitUserAction": true,
+      "resultState": "not_invoked",
+      "scopeId": "composer_focus",
+      "shortcutId": "focus_composer",
+      "sideEffectPolicy": "no_focus_change",
+      "sourceRef": "chat_composer",
+      "state": "inactive",
+      "visible": true
+    },
+    {
+      "blockedReasonRef": "send_boundary_blocked",
+      "enabled": false,
+      "keyChord": "Ctrl+Enter",
+      "label": "submit message",
+      "requiresExplicitUserAction": true,
+      "resultState": "not_invoked",
+      "scopeId": "composer_focus",
+      "shortcutId": "submit_message",
+      "sideEffectPolicy": "no_send_attempt",
+      "sourceRef": "chat_send_result",
+      "state": "blocked",
+      "visible": true
+    },
+    {
+      "blockedReasonRef": "response_stream_not_started",
+      "enabled": false,
+      "keyChord": "Esc",
+      "label": "stop response",
+      "requiresExplicitUserAction": true,
+      "resultState": "unavailable",
+      "scopeId": "action_bar",
+      "shortcutId": "stop_response",
+      "sideEffectPolicy": "no_stop_signal",
+      "sourceRef": "chat_action_bar",
+      "state": "disabled",
+      "visible": true
+    },
+    {
+      "blockedReasonRef": "message_content_absent",
+      "enabled": false,
+      "keyChord": "Ctrl+Shift+C",
+      "label": "copy response",
+      "requiresExplicitUserAction": true,
+      "resultState": "unavailable",
+      "scopeId": "message_list",
+      "shortcutId": "copy_response",
+      "sideEffectPolicy": "no_clipboard_write",
+      "sourceRef": "chat_message_list",
+      "state": "disabled",
+      "visible": true
+    },
+    {
+      "blockedReasonRef": "session_lifecycle_not_enabled",
+      "enabled": false,
+      "keyChord": "Ctrl+N",
+      "label": "new chat",
+      "requiresExplicitUserAction": true,
+      "resultState": "unavailable",
+      "scopeId": "global_chat_shell",
+      "shortcutId": "new_chat",
+      "sideEffectPolicy": "no_session_create",
+      "sourceRef": "chat_session_lifecycle",
+      "state": "blocked",
+      "visible": true
+    },
+    {
+      "blockedReasonRef": "transcript_store_not_configured",
+      "enabled": false,
+      "keyChord": "Ctrl+Shift+Backspace",
+      "label": "clear conversation",
+      "requiresExplicitUserAction": true,
+      "resultState": "unavailable",
+      "scopeId": "action_bar",
+      "shortcutId": "clear_conversation",
+      "sideEffectPolicy": "no_transcript_delete",
+      "sourceRef": "chat_transcript_policy",
+      "state": "disabled",
+      "visible": true
+    },
+    {
+      "blockedReasonRef": "transcript_export_not_reviewed",
+      "enabled": false,
+      "keyChord": "Ctrl+Shift+E",
+      "label": "export transcript",
+      "requiresExplicitUserAction": true,
+      "resultState": "unavailable",
+      "scopeId": "action_bar",
+      "shortcutId": "export_transcript",
+      "sideEffectPolicy": "no_transcript_export",
+      "sourceRef": "chat_transcript_policy",
+      "state": "disabled",
+      "visible": true
+    },
+    {
+      "blockedReasonRef": "attachment_boundary_absent",
+      "enabled": false,
+      "keyChord": "Ctrl+Shift+A",
+      "label": "attach context",
+      "requiresExplicitUserAction": true,
+      "resultState": "unavailable",
+      "scopeId": "action_bar",
+      "shortcutId": "attach_context",
+      "sideEffectPolicy": "no_file_or_artifact_read",
+      "sourceRef": "chat_action_bar",
+      "state": "planned",
+      "visible": true
+    },
+    {
+      "blockedReasonRef": "message_list_empty",
+      "enabled": false,
+      "keyChord": "Alt+Down",
+      "label": "next message",
+      "requiresExplicitUserAction": true,
+      "resultState": "unavailable",
+      "scopeId": "message_list",
+      "shortcutId": "next_message",
+      "sideEffectPolicy": "no_message_selection",
+      "sourceRef": "chat_message_list",
+      "state": "empty_not_captured",
+      "visible": true
+    },
+    {
+      "blockedReasonRef": "message_list_empty",
+      "enabled": false,
+      "keyChord": "Alt+Up",
+      "label": "previous message",
+      "requiresExplicitUserAction": true,
+      "resultState": "unavailable",
+      "scopeId": "message_list",
+      "shortcutId": "previous_message",
+      "sideEffectPolicy": "no_message_selection",
+      "sourceRef": "chat_message_list",
+      "state": "empty_not_captured",
+      "visible": true
+    }
+  ],
+  "shortcutMapId": "chat_shortcut_map_gemma3n_e4b_kv260_placeholder",
+  "shortcutMapState": "blocked",
+  "shortcutPolicy": {
+    "contentPolicy": "shortcut metadata only; no key-event stream, prompt text, response text, message body, transcript text, or session title is included",
+    "dispatchPolicy": "no command dispatch, focus change, send attempt, retry, stop signal, copy, attach, session creation, clear, or export action is performed",
+    "keyboardPolicy": "all key chords are display metadata until a reviewed UI input boundary exists",
+    "persistencePolicy": "no shortcut settings, key events, prompts, responses, transcripts, clipboard data, attachments, or artifacts are read or written",
+    "renderMode": "future_local_chat_shortcut_map",
+    "sideEffectPolicy": "local_render_only",
+    "sourcePolicy": "checked fixture only; no keyboard listener, session store, transcript, prompt, response, clipboard, file, or model path is read",
+    "state": "planned"
+  },
+  "shortcutScopes": [
+    {
+      "enabled": false,
+      "label": "global chat shell",
+      "scopeId": "global_chat_shell",
+      "state": "blocked",
+      "summary": "Global chat-shell shortcuts remain disabled until the standalone surface has a reviewed input boundary.",
+      "visible": true
+    },
+    {
+      "enabled": false,
+      "label": "composer focus",
+      "scopeId": "composer_focus",
+      "state": "inactive",
+      "summary": "Composer focus shortcuts remain inactive because prompt capture is disabled.",
+      "visible": true
+    },
+    {
+      "enabled": false,
+      "label": "message list",
+      "scopeId": "message_list",
+      "state": "empty_not_captured",
+      "summary": "Message navigation shortcuts remain disabled because no messages are present.",
+      "visible": true
+    },
+    {
+      "enabled": false,
+      "label": "action bar",
+      "scopeId": "action_bar",
+      "state": "disabled",
+      "summary": "Action-bar shortcuts mirror disabled conversation controls.",
+      "visible": true
+    }
+  ],
+  "targetBoard": "xilinx_kria_kv260",
+  "targetDevice": "kv260",
+  "targetModel": "gemma3n-e4b"
+}

--- a/docs/STANDALONE_CHAT_SESSION_CONTRACT.md
+++ b/docs/STANDALONE_CHAT_SESSION_CONTRACT.md
@@ -23,6 +23,7 @@ The implementation lives in:
 - `contracts/chat_error_taxonomy_contract.py`
 - `contracts/chat_message_list_contract.py`
 - `contracts/chat_action_bar_contract.py`
+- `contracts/chat_shortcut_map_contract.py`
 - `contracts/fixtures/chat-session.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-model-status.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-session-lifecycle.gemma3n-e4b-kv260-placeholder.json`
@@ -38,6 +39,7 @@ The implementation lives in:
 - `contracts/fixtures/chat-error-taxonomy.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-message-list.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-action-bar.gemma3n-e4b-kv260-placeholder.json`
+- `contracts/fixtures/chat-shortcut-map.gemma3n-e4b-kv260-placeholder.json`
 - `scripts/chat-session-stub.sh`
 - `scripts/chat-model-status-stub.sh`
 - `scripts/chat-session-lifecycle-stub.sh`
@@ -53,6 +55,7 @@ The implementation lives in:
 - `scripts/chat-error-taxonomy-stub.sh`
 - `scripts/chat-message-list-stub.sh`
 - `scripts/chat-action-bar-stub.sh`
+- `scripts/chat-shortcut-map-stub.sh`
 - `scripts/chat-surface-preview.sh`
 - `scripts/tests/chat_session_contract_test.py`
 - `scripts/tests/chat_model_status_contract_test.py`
@@ -69,6 +72,7 @@ The implementation lives in:
 - `scripts/tests/chat_error_taxonomy_contract_test.py`
 - `scripts/tests/chat_message_list_contract_test.py`
 - `scripts/tests/chat_action_bar_contract_test.py`
+- `scripts/tests/chat_shortcut_map_contract_test.py`
 - `scripts/tests/chat_surface_preview_test.py`
 - `scripts/tests/status-chat-model-status.sh`
 - `scripts/tests/status-chat-surface-layout.sh`
@@ -84,6 +88,7 @@ The implementation lives in:
 - `scripts/tests/status-chat-response-stream.sh`
 - `scripts/tests/status-chat-message-list.sh`
 - `scripts/tests/status-chat-action-bar.sh`
+- `scripts/tests/status-chat-shortcut-map.sh`
 
 ## What Is Implemented
 
@@ -114,6 +119,9 @@ The chat/session contract records:
   message bodies or transcript reads
 - disabled action-bar metadata for new, clear, export, retry, copy, stop,
   and attach controls without side effects
+- disabled shortcut-map metadata for planned keyboard accelerators,
+  focus, and navigation without listeners, capture, dispatch, or side
+  effects
 
 The checked fixture is deterministic JSON. The stub command prints that
 JSON for the supported model and target pair:
@@ -291,6 +299,22 @@ unavailable, or planned. No session store or transcript is read, no
 message body is included, no transcript is exported, no clipboard or file
 operation is performed, no stop signal is sent, no model or runtime path
 is started, and no artifact is written.
+
+The chat shortcut-map fixture records the disabled keyboard shortcut map
+for the planned standalone chat surface:
+
+```bash
+bash scripts/chat-shortcut-map-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/status-stub.sh --include-chat-shortcut-map
+```
+
+It keeps shortcuts as local metadata: focus composer, submit, stop, copy,
+new chat, clear, export, attach, and message navigation bindings remain
+disabled, blocked, inactive, unavailable, or planned. No keyboard
+listener is installed, no key event is captured, no command is
+dispatched, no focus change occurs, no prompt, session, transcript,
+message, clipboard, or file content is read or written, no model/runtime
+path is started, and no artifact is written.
 
 The chat transcript policy fixture records the retention, export,
 storage, and privacy policy shape for future transcript UI surfaces:

--- a/scripts/chat-shortcut-map-stub.sh
+++ b/scripts/chat-shortcut-map-stub.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+# Print the data-only chat shortcut-map contract.
+
+set -eu
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+
+python3 "$ROOT_DIR/contracts/chat_shortcut_map_contract.py" "$@"

--- a/scripts/status-stub.sh
+++ b/scripts/status-stub.sh
@@ -55,6 +55,9 @@
 # Chat action-bar controls boundary (explicit opt-in, read-only local data):
 #   --include-chat-action-bar
 #
+# Chat shortcut-map boundary (explicit opt-in, read-only local data):
+#   --include-chat-shortcut-map
+#
 # pccx-lab backend (explicit opt-in):
 #   --backend pccx-lab        call pccx-lab status --format json
 #   PCCX_LAB_BIN              override path to pccx-lab binary (takes priority over PATH)
@@ -87,6 +90,7 @@ INCLUDE_CHAT_ERROR_TAXONOMY="0"
 INCLUDE_CHAT_RESPONSE_STREAM="0"
 INCLUDE_CHAT_MESSAGE_LIST="0"
 INCLUDE_CHAT_ACTION_BAR="0"
+INCLUDE_CHAT_SHORTCUT_MAP="0"
 
 print_chat_error_taxonomy_summary() {
     SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
@@ -502,6 +506,105 @@ print(
 
     HEAD "chat action bar"
     printf '%s\n' "$CHAT_ACTION_BAR_SUMMARY"
+}
+
+print_chat_shortcut_map_summary() {
+    SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+    ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+    CHAT_SHORTCUT_MAP_STUB="$ROOT_DIR/scripts/chat-shortcut-map-stub.sh"
+
+    if [ ! -f "$CHAT_SHORTCUT_MAP_STUB" ]; then
+        ERROR "chat shortcut-map stub not found: $CHAT_SHORTCUT_MAP_STUB"
+        return 1
+    fi
+
+    if ! CHAT_SHORTCUT_MAP_JSON="$(bash "$CHAT_SHORTCUT_MAP_STUB" --model gemma3n-e4b --target kv260 2>&1)"; then
+        ERROR "chat shortcut-map stub failed"
+        printf '%s\n' "$CHAT_SHORTCUT_MAP_JSON" >&2
+        return 1
+    fi
+
+    if ! CHAT_SHORTCUT_MAP_SUMMARY="$(
+        printf '%s\n' "$CHAT_SHORTCUT_MAP_JSON" | python3 -c '
+import json
+import sys
+
+data = json.load(sys.stdin)
+flags = data["safetyFlags"]
+
+def b(value):
+    return "true" if value else "false"
+
+scopes = " ".join(
+    "{}={}".format(scope["scopeId"], scope["state"])
+    for scope in data["shortcutScopes"]
+)
+bindings = " ".join(
+    "{}={}:{}".format(binding["shortcutId"], binding["state"], b(binding["enabled"]))
+    for binding in data["shortcutBindings"]
+)
+blocked = " ".join(
+    "{}={}".format(reason["reasonId"], reason["state"])
+    for reason in data["blockedReasons"]
+)
+
+print("[INFO]  source     : scripts/chat-shortcut-map-stub.sh --model gemma3n-e4b --target kv260")
+print("[INFO]  boundary   : read-only data; no keyboard listener/command dispatch/session-store/transcript/clipboard/file/model/runtime/hardware/lab/IDE execution")
+print("[INFO]  target     : {}".format(data["targetDevice"]))
+print("[INFO]  model      : {}".format(data["targetModel"]))
+print("[INFO]  shortcuts  : {}".format(data["shortcutMapState"]))
+print("[INFO]  focus      : {}".format(data["focusState"]))
+print("[INFO]  keyboard   : {}".format(data["keyboardCaptureState"]))
+print("[INFO]  dispatch   : {}".format(data["commandDispatchState"]))
+print("[INFO]  execution  : {}".format(data["actionExecutionState"]))
+print("[INFO]  scopes     : {}".format(scopes))
+print("[INFO]  bindings   : {}".format(bindings))
+print("[INFO]  blocked    : {}".format(blocked))
+print(
+    "[INFO]  flags      : readOnly={} dataOnly={} deterministic={} "
+    "shortcutMapDisplayOnly={} shortcutMetadataOnly={} "
+    "keyboardListenerInstalled={} keyboardCaptureEnabled={} "
+    "commandDispatchEnabled={} shortcutExecuted={} focusChanged={} "
+    "readsSessionStore={} readsTranscript={} readsMessages={} "
+    "promptCapture={} sendAttempted={} stopSignalSent={} "
+    "clipboardWrite={} attachmentReads={} modelExecution={} "
+    "runtimeExecution={} kv260Access={} hardwareAccess={} "
+    "networkCalls={} providerCalls={} executesPccxLab={}".format(
+        b(flags["readOnly"]),
+        b(flags["dataOnly"]),
+        b(flags["deterministic"]),
+        b(flags["shortcutMapDisplayOnly"]),
+        b(flags["shortcutMetadataOnly"]),
+        b(flags["keyboardListenerInstalled"]),
+        b(flags["keyboardCaptureEnabled"]),
+        b(flags["commandDispatchEnabled"]),
+        b(flags["shortcutExecuted"]),
+        b(flags["focusChanged"]),
+        b(flags["readsSessionStore"]),
+        b(flags["readsTranscript"]),
+        b(flags["readsMessages"]),
+        b(flags["promptCapture"]),
+        b(flags["sendAttempted"]),
+        b(flags["stopSignalSent"]),
+        b(flags["clipboardWrite"]),
+        b(flags["attachmentReads"]),
+        b(flags["modelExecution"]),
+        b(flags["runtimeExecution"]),
+        b(flags["kv260Access"]),
+        b(flags["hardwareAccess"]),
+        b(flags["networkCalls"]),
+        b(flags["providerCalls"]),
+        b(flags["executesPccxLab"]),
+    )
+)
+'
+    )"; then
+        ERROR "chat shortcut-map JSON could not be summarized"
+        return 1
+    fi
+
+    HEAD "chat shortcut map"
+    printf '%s\n' "$CHAT_SHORTCUT_MAP_SUMMARY"
 }
 
 print_chat_local_only_policy_summary() {
@@ -1907,6 +2010,10 @@ while [ $# -gt 0 ]; do
             INCLUDE_CHAT_ACTION_BAR="1"
             shift
             ;;
+        --include-chat-shortcut-map)
+            INCLUDE_CHAT_SHORTCUT_MAP="1"
+            shift
+            ;;
         --backend)
             BACKEND="${2:-}"
             if [ -z "$BACKEND" ]; then
@@ -1922,8 +2029,8 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-if [ -n "$BACKEND" ] && { [ "$INCLUDE_RUNTIME_READINESS" = "1" ] || [ "$INCLUDE_DEVICE_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SURFACE_LAYOUT" = "1" ] || [ "$INCLUDE_CHAT_LOCAL_ONLY_POLICY" = "1" ] || [ "$INCLUDE_CHAT_PREFERENCES" = "1" ] || [ "$INCLUDE_CHAT_SESSION_INDEX" = "1" ] || [ "$INCLUDE_CHAT_MODEL_STATUS" = "1" ] || [ "$INCLUDE_CHAT_READINESS" = "1" ] || [ "$INCLUDE_CHAT_COMPOSER" = "1" ] || [ "$INCLUDE_CHAT_SEND_RESULT" = "1" ] || [ "$INCLUDE_CHAT_TRANSCRIPT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_AUDIT_EVENT" = "1" ] || [ "$INCLUDE_CHAT_ERROR_TAXONOMY" = "1" ] || [ "$INCLUDE_CHAT_RESPONSE_STREAM" = "1" ] || [ "$INCLUDE_CHAT_MESSAGE_LIST" = "1" ] || [ "$INCLUDE_CHAT_ACTION_BAR" = "1" ]; }; then
-    ERROR "--include-runtime-readiness, --include-device-session, --include-chat-session, --include-chat-surface-layout, --include-chat-local-only-policy, --include-chat-preferences, --include-chat-session-index, --include-chat-model-status, --include-chat-readiness, --include-chat-composer, --include-chat-send-result, --include-chat-transcript-policy, --include-chat-audit-event, --include-chat-error-taxonomy, --include-chat-response-stream, --include-chat-message-list, and --include-chat-action-bar are only supported in local scaffold mode"
+if [ -n "$BACKEND" ] && { [ "$INCLUDE_RUNTIME_READINESS" = "1" ] || [ "$INCLUDE_DEVICE_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SURFACE_LAYOUT" = "1" ] || [ "$INCLUDE_CHAT_LOCAL_ONLY_POLICY" = "1" ] || [ "$INCLUDE_CHAT_PREFERENCES" = "1" ] || [ "$INCLUDE_CHAT_SESSION_INDEX" = "1" ] || [ "$INCLUDE_CHAT_MODEL_STATUS" = "1" ] || [ "$INCLUDE_CHAT_READINESS" = "1" ] || [ "$INCLUDE_CHAT_COMPOSER" = "1" ] || [ "$INCLUDE_CHAT_SEND_RESULT" = "1" ] || [ "$INCLUDE_CHAT_TRANSCRIPT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_AUDIT_EVENT" = "1" ] || [ "$INCLUDE_CHAT_ERROR_TAXONOMY" = "1" ] || [ "$INCLUDE_CHAT_RESPONSE_STREAM" = "1" ] || [ "$INCLUDE_CHAT_MESSAGE_LIST" = "1" ] || [ "$INCLUDE_CHAT_ACTION_BAR" = "1" ] || [ "$INCLUDE_CHAT_SHORTCUT_MAP" = "1" ]; }; then
+    ERROR "--include-runtime-readiness, --include-device-session, --include-chat-session, --include-chat-surface-layout, --include-chat-local-only-policy, --include-chat-preferences, --include-chat-session-index, --include-chat-model-status, --include-chat-readiness, --include-chat-composer, --include-chat-send-result, --include-chat-transcript-policy, --include-chat-audit-event, --include-chat-error-taxonomy, --include-chat-response-stream, --include-chat-message-list, --include-chat-action-bar, and --include-chat-shortcut-map are only supported in local scaffold mode"
     exit 1
 fi
 
@@ -1953,6 +2060,7 @@ if [ -z "$BACKEND" ]; then
     NOTE "chat stream   : opt-in via --include-chat-response-stream (read-only response stream data)"
     NOTE "chat messages : opt-in via --include-chat-message-list (read-only empty message-list data)"
     NOTE "chat actions  : opt-in via --include-chat-action-bar (read-only disabled action-bar data)"
+    NOTE "chat shortcuts: opt-in via --include-chat-shortcut-map (read-only disabled shortcut-map data)"
     NOTE "editor bridge  : planned (VS Code / other IDEs)"
 
     if [ "$INCLUDE_CHAT_ERROR_TAXONOMY" = "1" ]; then
@@ -1975,6 +2083,12 @@ if [ -z "$BACKEND" ]; then
 
     if [ "$INCLUDE_CHAT_ACTION_BAR" = "1" ]; then
         if ! print_chat_action_bar_summary; then
+            exit 1
+        fi
+    fi
+
+    if [ "$INCLUDE_CHAT_SHORTCUT_MAP" = "1" ]; then
+        if ! print_chat_shortcut_map_summary; then
             exit 1
         fi
     fi

--- a/scripts/tests/chat_shortcut_map_contract_test.py
+++ b/scripts/tests/chat_shortcut_map_contract_test.py
@@ -1,0 +1,367 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Fixture tests for the standalone chat shortcut-map contract."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "contracts" / "chat_shortcut_map_contract.py"
+FIXTURE_PATH = (
+    ROOT
+    / "contracts"
+    / "fixtures"
+    / "chat-shortcut-map.gemma3n-e4b-kv260-placeholder.json"
+)
+SCRIPT_PATH = ROOT / "scripts" / "chat-shortcut-map-stub.sh"
+STATUS_TEST_PATH = ROOT / "scripts" / "tests" / "status-chat-shortcut-map.sh"
+DOC_PATH = ROOT / "docs" / "STANDALONE_CHAT_SESSION_CONTRACT.md"
+README_PATH = ROOT / "README.md"
+TEST_PATH = Path(__file__).resolve()
+CI_PATH = ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location(
+        "chat_shortcut_map_contract",
+        MODULE_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def iter_state_values(value):
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            if (
+                key == "state"
+                or key.endswith("State")
+                or key.endswith("Status")
+            ) and isinstance(nested, str):
+                yield nested
+            yield from iter_state_values(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            yield from iter_state_values(nested)
+
+
+def iter_keys(value):
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            yield key
+            yield from iter_keys(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            yield from iter_keys(nested)
+
+
+def assert_no_private_or_generated_data(text: str) -> None:
+    forbidden_patterns = [
+        r"/home/[^\s\"']+",
+        r"/Users/[^\s\"']+",
+        r"[A-Za-z]:\\Users\\",
+        r"\b(?:api[_-]?key|authorization|bearer|client[_-]?secret|password|private[_-]?key|secret|token)\b\s*[:=]",
+        r"\.(?:gguf|safetensors|ckpt|pt|pth|onnx)\b",
+        r"(?:weights|model_weights|model-cache)/(?:[^\"'\s]+)",
+        r"(?:raw[_-]?full[_-]?logs|hardware[_-]?dump|generated[_-]?blob)\s*[:=]",
+    ]
+    for pattern in forbidden_patterns:
+        assert not re.search(pattern, text, re.IGNORECASE), pattern
+
+
+def assert_no_runtime_implementation_terms(source: str) -> None:
+    forbidden = [
+        "subprocess",
+        "os.system",
+        "popen",
+        "socket",
+        "urllib",
+        "requests",
+        "http.client",
+        "openai",
+        "anthropic",
+        "gem" + "ini",
+        "modelcontextprotocol",
+        "websocket",
+        "xmutil",
+        "xrt-smi",
+        "lsusb",
+        "dmesg",
+    ]
+    lowered = source.lower()
+    for term in forbidden:
+        assert term not in lowered, term
+
+
+def assert_no_provider_configs(value) -> None:
+    forbidden_keys = {
+        "apiKey",
+        "accessToken",
+        "refreshToken",
+        "authorization",
+        "bearerToken",
+        "provider",
+        "providers",
+        "providerConfig",
+        "providerConfigs",
+    }
+    for key in iter_keys(value):
+        assert key not in forbidden_keys, key
+
+
+def assert_no_unsupported_claims(text: str) -> None:
+    literal_claims = [
+        "production" + "-ready",
+        "marketplace" + "-ready",
+        "stable " + "API",
+        "stable " + "ABI",
+        "KV260 inference " + "works",
+        "Gemma 3N E4B " + "runs on KV260",
+        "20 tok/s " + "achieved",
+        "timing " + "closed",
+        "bitstream " + "ready",
+        "launcher executes " + "pccx-lab",
+        "IDE controls " + "launcher",
+        "AI provider integration " + "is live",
+    ]
+    lowered = text.lower()
+    for claim in literal_claims:
+        assert claim.lower() not in lowered, claim
+
+
+def test_chat_shortcut_map_matches_fixture_and_is_deterministic() -> None:
+    module = load_module()
+    generated = module.create_gemma3n_e4b_kv260_chat_shortcut_map()
+    fixture = json.loads(read_text(FIXTURE_PATH))
+
+    assert generated == fixture
+    assert module.chat_shortcut_map_json(generated) == (
+        module.chat_shortcut_map_json(generated)
+    )
+    assert module.chat_shortcut_map_json(generated).endswith("\n")
+    assert json.loads(module.chat_shortcut_map_json(generated)) == fixture
+
+
+def test_cli_stub_outputs_deterministic_json() -> None:
+    fixture = json.loads(read_text(FIXTURE_PATH))
+    command = [
+        "bash",
+        str(SCRIPT_PATH),
+        "--model",
+        "gemma3n-e4b",
+        "--target",
+        "kv260",
+    ]
+    first = subprocess.run(command, check=True, capture_output=True, text=True)
+    second = subprocess.run(command, check=True, capture_output=True, text=True)
+
+    assert first.stderr == ""
+    assert first.stdout == second.stdout
+    assert first.stdout.endswith("\n")
+    assert json.loads(first.stdout) == fixture
+
+
+def test_required_fields_and_allowed_states() -> None:
+    module = load_module()
+    shortcut_map = module.create_gemma3n_e4b_kv260_chat_shortcut_map()
+    allowed = set(module.CHAT_SHORTCUT_MAP_STATE_VALUES)
+
+    assert tuple(shortcut_map.keys()) == module.CHAT_SHORTCUT_MAP_FIELDS
+    assert shortcut_map["schemaVersion"] == "pccx.chatShortcutMap.v0"
+    assert tuple(shortcut_map["shortcutPolicy"].keys()) == module.SHORTCUT_POLICY_FIELDS
+
+    states = list(iter_state_values(shortcut_map))
+    assert states
+    for state in states:
+        assert state in allowed, state
+
+    for scope in shortcut_map["shortcutScopes"]:
+        assert tuple(scope.keys()) == module.SHORTCUT_SCOPE_FIELDS
+    for binding in shortcut_map["shortcutBindings"]:
+        assert tuple(binding.keys()) == module.SHORTCUT_BINDING_FIELDS
+    for reason in shortcut_map["blockedReasons"]:
+        assert tuple(reason.keys()) == module.BLOCKED_REASON_FIELDS
+    for ref in shortcut_map["handoffRefs"]:
+        assert tuple(ref.keys()) == module.HANDOFF_REF_FIELDS
+
+
+def test_chat_shortcut_map_keeps_shortcuts_disabled() -> None:
+    shortcut_map = load_module().create_gemma3n_e4b_kv260_chat_shortcut_map()
+    policy = shortcut_map["shortcutPolicy"]
+    flags = shortcut_map["safetyFlags"]
+    scopes = {scope["scopeId"]: scope for scope in shortcut_map["shortcutScopes"]}
+    bindings = {
+        binding["shortcutId"]: binding
+        for binding in shortcut_map["shortcutBindings"]
+    }
+    reasons = {reason["reasonId"]: reason for reason in shortcut_map["blockedReasons"]}
+    refs = {ref["refId"]: ref for ref in shortcut_map["handoffRefs"]}
+
+    assert shortcut_map["shortcutMapState"] == "blocked"
+    assert shortcut_map["focusState"] == "inactive"
+    assert shortcut_map["keyboardCaptureState"] == "not_installed"
+    assert shortcut_map["commandDispatchState"] == "blocked"
+    assert shortcut_map["actionExecutionState"] == "not_invoked"
+    assert policy["sideEffectPolicy"] == "local_render_only"
+    assert set(scopes) == {
+        "global_chat_shell",
+        "composer_focus",
+        "message_list",
+        "action_bar",
+    }
+    assert all(scope["enabled"] is False for scope in scopes.values())
+    assert set(bindings) == {
+        "focus_composer",
+        "submit_message",
+        "stop_response",
+        "copy_response",
+        "new_chat",
+        "clear_conversation",
+        "export_transcript",
+        "attach_context",
+        "next_message",
+        "previous_message",
+    }
+    assert all(binding["enabled"] is False for binding in bindings.values())
+    assert bindings["submit_message"]["sideEffectPolicy"] == "no_send_attempt"
+    assert bindings["stop_response"]["sideEffectPolicy"] == "no_stop_signal"
+    assert bindings["copy_response"]["sideEffectPolicy"] == "no_clipboard_write"
+    assert bindings["attach_context"]["sideEffectPolicy"] == "no_file_or_artifact_read"
+    assert set(reasons) == {
+        "keyboard_listener_not_installed",
+        "send_boundary_blocked",
+        "response_stream_not_started",
+        "message_content_absent",
+        "session_lifecycle_not_enabled",
+        "transcript_store_not_configured",
+        "transcript_export_not_reviewed",
+        "attachment_boundary_absent",
+        "message_list_empty",
+    }
+    assert set(refs) == {
+        "chat_session",
+        "chat_composer",
+        "chat_message_list",
+        "chat_action_bar",
+        "chat_transcript_policy",
+    }
+    assert flags["readOnly"] is True
+    assert flags["dataOnly"] is True
+    assert flags["shortcutMapDisplayOnly"] is True
+    assert flags["shortcutMetadataOnly"] is True
+    assert flags["keyboardListenerInstalled"] is False
+    assert flags["keyboardCaptureEnabled"] is False
+    assert flags["commandDispatchEnabled"] is False
+    assert flags["shortcutExecuted"] is False
+    assert flags["focusChanged"] is False
+    assert flags["readsSessionStore"] is False
+    assert flags["readsTranscript"] is False
+    assert flags["readsMessages"] is False
+    assert flags["promptCapture"] is False
+    assert flags["sendAttempted"] is False
+    assert flags["stopSignalSent"] is False
+    assert flags["clipboardWrite"] is False
+    assert flags["attachmentReads"] is False
+    assert flags["modelExecution"] is False
+    assert flags["runtimeExecution"] is False
+    assert flags["kv260Access"] is False
+    assert flags["networkCalls"] is False
+    assert flags["providerCalls"] is False
+    assert flags["executesPccxLab"] is False
+
+
+def test_chat_shortcut_map_docs_and_ci_are_wired() -> None:
+    doc = read_text(DOC_PATH)
+    readme = read_text(README_PATH)
+    status_test = read_text(STATUS_TEST_PATH)
+    ci = read_text(CI_PATH)
+
+    assert "contracts/chat_shortcut_map_contract.py" in doc
+    assert (
+        "contracts/fixtures/chat-shortcut-map.gemma3n-e4b-kv260-placeholder.json"
+        in doc
+    )
+    assert "scripts/chat-shortcut-map-stub.sh" in doc
+    assert "scripts/tests/chat_shortcut_map_contract_test.py" in doc
+    assert "scripts/tests/status-chat-shortcut-map.sh" in doc
+    assert "chat-shortcut-map-stub.sh" in readme
+    assert "--include-chat-shortcut-map" in readme
+    assert "chat_shortcut_map_contract_test.py" in ci
+    assert "status-chat-shortcut-map.sh" in ci
+    assert "--include-chat-shortcut-map" in status_test
+
+
+def test_chat_shortcut_map_has_no_runtime_or_private_surface() -> None:
+    module = load_module()
+    shortcut_map = module.create_gemma3n_e4b_kv260_chat_shortcut_map()
+    fixture_text = read_text(FIXTURE_PATH)
+    contract_source = read_text(MODULE_PATH)
+    stub_source = read_text(SCRIPT_PATH)
+    docs = "\n".join(
+        [
+            fixture_text,
+            contract_source,
+            stub_source,
+            read_text(DOC_PATH),
+            read_text(README_PATH),
+            read_text(STATUS_TEST_PATH),
+        ]
+    )
+
+    assert_no_provider_configs(shortcut_map)
+    assert_no_private_or_generated_data(docs)
+    assert_no_unsupported_claims(docs)
+    assert_no_runtime_implementation_terms(contract_source)
+    assert_no_runtime_implementation_terms(stub_source)
+
+
+def test_source_headers_for_touched_code_files() -> None:
+    expected_headers = {
+        MODULE_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        SCRIPT_PATH: [
+            "#!/usr/bin/env bash",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        STATUS_TEST_PATH: [
+            "#!/usr/bin/env bash",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        TEST_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        CI_PATH: [
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+    }
+
+    for path, header in expected_headers.items():
+        assert read_text(path).splitlines()[: len(header)] == header, path
+
+
+if __name__ == "__main__":
+    for name, func in sorted(globals().items()):
+        if name.startswith("test_") and callable(func):
+            func()
+    print("chat shortcut-map contract tests ok")

--- a/scripts/tests/status-chat-shortcut-map.sh
+++ b/scripts/tests/status-chat-shortcut-map.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+# scripts/tests/status-chat-shortcut-map.sh - status shortcut-map tests.
+#
+# Usage: bash scripts/tests/status-chat-shortcut-map.sh [path/to/status-stub.sh]
+
+set -eu
+
+PASS() { printf '[PASS]  %s\n' "$*"; }
+FAIL() { printf '[FAIL] %s\n' "$*" >&2; }
+HEAD() { printf '\n=== %s ===\n' "$*"; }
+
+STUB="${1:-scripts/status-stub.sh}"
+
+if [ ! -x "$STUB" ]; then
+    chmod +x "$STUB"
+fi
+
+contains() {
+    case "$1" in
+        *"$2"*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+require_contains() {
+    local output="$1"
+    local expected="$2"
+    if ! contains "$output" "$expected"; then
+        FAIL "expected output to contain: $expected"
+        printf '%s\n' "$output" >&2
+        exit 1
+    fi
+}
+
+require_not_contains() {
+    local output="$1"
+    local forbidden="$2"
+    if contains "$output" "$forbidden"; then
+        FAIL "output contained forbidden text: $forbidden"
+        printf '%s\n' "$output" >&2
+        exit 1
+    fi
+}
+
+HEAD "1: status can include chat shortcut map"
+OUTPUT="$("$STUB" --include-chat-shortcut-map)"
+require_contains "$OUTPUT" "=== chat shortcut map ==="
+require_contains "$OUTPUT" "source     : scripts/chat-shortcut-map-stub.sh --model gemma3n-e4b --target kv260"
+require_contains "$OUTPUT" "boundary   : read-only data; no keyboard listener/command dispatch/session-store/transcript/clipboard/file/model/runtime/hardware/lab/IDE execution"
+require_contains "$OUTPUT" "target     : kv260"
+require_contains "$OUTPUT" "model      : gemma3n-e4b"
+require_contains "$OUTPUT" "shortcuts  : blocked"
+require_contains "$OUTPUT" "focus      : inactive"
+require_contains "$OUTPUT" "keyboard   : not_installed"
+require_contains "$OUTPUT" "dispatch   : blocked"
+require_contains "$OUTPUT" "execution  : not_invoked"
+PASS "chat shortcut-map section is present and conservative"
+
+HEAD "2: scopes and bindings stay disabled"
+require_contains "$OUTPUT" "scopes     : global_chat_shell=blocked"
+require_contains "$OUTPUT" "composer_focus=inactive"
+require_contains "$OUTPUT" "message_list=empty_not_captured"
+require_contains "$OUTPUT" "action_bar=disabled"
+require_contains "$OUTPUT" "bindings   : focus_composer=inactive:false"
+require_contains "$OUTPUT" "submit_message=blocked:false"
+require_contains "$OUTPUT" "stop_response=disabled:false"
+require_contains "$OUTPUT" "copy_response=disabled:false"
+require_contains "$OUTPUT" "new_chat=blocked:false"
+require_contains "$OUTPUT" "clear_conversation=disabled:false"
+require_contains "$OUTPUT" "export_transcript=disabled:false"
+require_contains "$OUTPUT" "attach_context=planned:false"
+require_contains "$OUTPUT" "next_message=empty_not_captured:false"
+require_contains "$OUTPUT" "previous_message=empty_not_captured:false"
+require_contains "$OUTPUT" "blocked    : keyboard_listener_not_installed=not_installed"
+require_contains "$OUTPUT" "send_boundary_blocked=blocked"
+require_contains "$OUTPUT" "message_list_empty=empty_not_captured"
+PASS "disabled shortcut metadata is summarized"
+
+HEAD "3: safety flags stay read-only and non-executing"
+require_contains "$OUTPUT" "readOnly=true"
+require_contains "$OUTPUT" "dataOnly=true"
+require_contains "$OUTPUT" "deterministic=true"
+require_contains "$OUTPUT" "shortcutMapDisplayOnly=true"
+require_contains "$OUTPUT" "shortcutMetadataOnly=true"
+require_contains "$OUTPUT" "keyboardListenerInstalled=false"
+require_contains "$OUTPUT" "keyboardCaptureEnabled=false"
+require_contains "$OUTPUT" "commandDispatchEnabled=false"
+require_contains "$OUTPUT" "shortcutExecuted=false"
+require_contains "$OUTPUT" "focusChanged=false"
+require_contains "$OUTPUT" "readsSessionStore=false"
+require_contains "$OUTPUT" "readsTranscript=false"
+require_contains "$OUTPUT" "readsMessages=false"
+require_contains "$OUTPUT" "promptCapture=false"
+require_contains "$OUTPUT" "sendAttempted=false"
+require_contains "$OUTPUT" "stopSignalSent=false"
+require_contains "$OUTPUT" "clipboardWrite=false"
+require_contains "$OUTPUT" "attachmentReads=false"
+require_contains "$OUTPUT" "modelExecution=false"
+require_contains "$OUTPUT" "runtimeExecution=false"
+require_contains "$OUTPUT" "kv260Access=false"
+require_contains "$OUTPUT" "hardwareAccess=false"
+require_contains "$OUTPUT" "networkCalls=false"
+require_contains "$OUTPUT" "providerCalls=false"
+require_contains "$OUTPUT" "executesPccxLab=false"
+PASS "execution-related flags remain false"
+
+HEAD "4: output is deterministic"
+OUTPUT_AGAIN="$("$STUB" --include-chat-shortcut-map)"
+if [ "$OUTPUT" != "$OUTPUT_AGAIN" ]; then
+    FAIL "status chat shortcut-map output changed between runs"
+    exit 1
+fi
+PASS "status chat shortcut-map output is deterministic"
+
+HEAD "5: chat shortcut-map option does not combine with pccx-lab backend"
+if "$STUB" --include-chat-shortcut-map --backend pccx-lab >/dev/null 2>&1; then
+    FAIL "expected combined chat-shortcut-map/backend mode to fail"
+    exit 1
+fi
+PASS "chat shortcut map remains separate from backend execution"
+
+HEAD "6: output avoids known overclaims"
+FORBIDDEN_PREFIX="KV260 inference"
+FORBIDDEN_CLAIM="${FORBIDDEN_PREFIX} works"
+require_not_contains "$OUTPUT" "$FORBIDDEN_CLAIM"
+THROUGHPUT_PREFIX="20 tok/s"
+THROUGHPUT_CLAIM="${THROUGHPUT_PREFIX} achieved"
+require_not_contains "$OUTPUT" "$THROUGHPUT_CLAIM"
+PASS "no chat shortcut-map or throughput overclaim in status output"
+
+printf '\n[DONE]  all status-chat-shortcut-map tests passed\n'


### PR DESCRIPTION
Summary:
- Add a data-only pccx.chatShortcutMap.v0 contract, fixture, and stub for disabled chat shortcut metadata.
- Wire status-stub --include-chat-shortcut-map with conservative summary output.
- Document the boundary and add CI/status/contract test coverage.

Validation:
- python3 -m py_compile contracts/*.py scripts/tests/*.py
- bash -n scripts/*.sh scripts/tests/*.sh
- python3 -m json.tool contracts/fixtures/chat-shortcut-map.gemma3n-e4b-kv260-placeholder.json
- bash scripts/chat-shortcut-map-stub.sh --model gemma3n-e4b --target kv260
- bash scripts/status-stub.sh --include-chat-shortcut-map
- python3 scripts/tests/chat_shortcut_map_contract_test.py
- bash scripts/tests/status-chat-shortcut-map.sh scripts/status-stub.sh
- all Python contract tests under scripts/tests/*_test.py
- all status tests under scripts/tests/status-*.sh
- workflow-style script command run
- local claim-scan clean
- git diff --check
- git diff --cached --check

Note: local shellcheck is not installed in this environment; the GitHub Actions shell-lint job installs and runs it.

Refs #9