### PR TITLE
Add chat session title-policy boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,7 @@ jobs:
                    scripts/chat-local-only-policy-stub.sh \
                    scripts/chat-preferences-stub.sh \
                    scripts/chat-session-index-stub.sh \
+                   scripts/chat-session-title-policy-stub.sh \
                    scripts/chat-readiness-stub.sh \
                    scripts/chat-composer-stub.sh \
                    scripts/chat-send-result-stub.sh \
@@ -193,6 +194,10 @@ jobs:
         run: ./scripts/status-stub.sh --include-chat-session-index
       - name: run scripts/chat-session-index-stub.sh
         run: ./scripts/chat-session-index-stub.sh --model gemma3n-e4b --target kv260
+      - name: run scripts/status-stub.sh with chat session title policy
+        run: ./scripts/status-stub.sh --include-chat-session-title-policy
+      - name: run scripts/chat-session-title-policy-stub.sh
+        run: ./scripts/chat-session-title-policy-stub.sh --model gemma3n-e4b --target kv260
       - name: run scripts/status-stub.sh with chat readiness
         run: ./scripts/status-stub.sh --include-chat-readiness
       - name: run scripts/chat-readiness-stub.sh
@@ -269,6 +274,8 @@ jobs:
         run: python3 scripts/tests/chat_preferences_contract_test.py
       - name: run chat session-index contract tests
         run: python3 scripts/tests/chat_session_index_contract_test.py
+      - name: run chat session-title policy contract tests
+        run: python3 scripts/tests/chat_session_title_policy_contract_test.py
       - name: run chat readiness contract tests
         run: python3 scripts/tests/chat_readiness_contract_test.py
       - name: run chat composer contract tests
@@ -308,6 +315,7 @@ jobs:
           chmod +x scripts/chat-local-only-policy-stub.sh
           chmod +x scripts/chat-preferences-stub.sh
           chmod +x scripts/chat-session-index-stub.sh
+          chmod +x scripts/chat-session-title-policy-stub.sh
           chmod +x scripts/chat-readiness-stub.sh
           chmod +x scripts/chat-composer-stub.sh
           chmod +x scripts/chat-send-result-stub.sh
@@ -328,6 +336,7 @@ jobs:
           chmod +x scripts/tests/status-chat-local-only-policy.sh
           chmod +x scripts/tests/status-chat-preferences.sh
           chmod +x scripts/tests/status-chat-session-index.sh
+          chmod +x scripts/tests/status-chat-session-title-policy.sh
           chmod +x scripts/tests/status-chat-readiness.sh
           chmod +x scripts/tests/status-chat-composer.sh
           chmod +x scripts/tests/status-chat-send-result.sh
@@ -351,6 +360,7 @@ jobs:
           shellcheck scripts/tests/status-chat-local-only-policy.sh
           shellcheck scripts/tests/status-chat-preferences.sh
           shellcheck scripts/tests/status-chat-session-index.sh
+          shellcheck scripts/tests/status-chat-session-title-policy.sh
           shellcheck scripts/tests/status-chat-readiness.sh
           shellcheck scripts/tests/status-chat-composer.sh
           shellcheck scripts/tests/status-chat-send-result.sh
@@ -379,6 +389,8 @@ jobs:
         run: bash scripts/tests/status-chat-preferences.sh scripts/status-stub.sh
       - name: run status-chat-session-index tests
         run: bash scripts/tests/status-chat-session-index.sh scripts/status-stub.sh
+      - name: run status-chat-session-title-policy tests
+        run: bash scripts/tests/status-chat-session-title-policy.sh scripts/status-stub.sh
       - name: run status-chat-readiness tests
         run: bash scripts/tests/status-chat-readiness.sh scripts/status-stub.sh
       - name: run status-chat-composer tests

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ and verify host-side prerequisites before the real engine lands.
 | [`scripts/check.sh`](./scripts/check.sh) | Probe host info, tooling availability, edge-device hints. Always exits 0. |
 | [`scripts/check-device-stub.sh`](./scripts/check-device-stub.sh) | Narrowly scoped device-tree / FPGA-node probe (KV260 / Kria detection only). Always exits 0. |
 | [`scripts/install-stub.sh`](./scripts/install-stub.sh) | Preview of the planned install flow; reports which host runtime pieces are present, lists device-side pieces as future deliverables. Always exits 0. |
-| [`scripts/status-stub.sh`](./scripts/status-stub.sh) | Launcher state summary. Default mode: local scaffold output, always exits 0. With `--include-chat-action-bar`, adds read-only disabled chat action-bar data. With `--include-chat-shortcut-map`, adds read-only disabled chat shortcut-map data. With `--include-chat-message-list`, adds read-only empty chat message-list data. With `--include-chat-response-stream`, adds read-only blocked chat response stream data. With `--include-chat-error-taxonomy`, adds read-only chat error taxonomy data. With `--include-chat-audit-event`, adds read-only blocked chat audit-event metadata. With `--include-chat-surface-layout`, adds read-only chat surface layout data. With `--include-chat-local-only-policy`, adds read-only local-only/cloud-block policy data. With `--include-chat-preferences`, adds read-only chat preferences/settings data. With `--include-chat-session-index`, adds read-only empty chat session index data. With `--include-chat-transcript-policy`, adds read-only chat transcript retention/export policy data. With `--include-chat-send-result`, adds read-only blocked chat send-result data. With `--include-chat-composer`, adds read-only chat composer/input-control data. With `--include-chat-model-status`, adds read-only blocked chat model-status display data. With `--include-chat-session`, adds read-only blocked chat/session and lifecycle summaries. With `--include-chat-readiness`, adds read-only chat readiness checks and recovery actions. With `--include-device-session`, adds a read-only device/session status panel. With `--include-runtime-readiness`, adds a read-only runtime readiness summary. With `--backend pccx-lab`, calls `pccx-lab status --format json` and forwards the run-status envelope (exits non-zero if binary is missing or output is invalid). |
+| [`scripts/status-stub.sh`](./scripts/status-stub.sh) | Launcher state summary. Default mode: local scaffold output, always exits 0. With `--include-chat-action-bar`, adds read-only disabled chat action-bar data. With `--include-chat-shortcut-map`, adds read-only disabled chat shortcut-map data. With `--include-chat-message-list`, adds read-only empty chat message-list data. With `--include-chat-response-stream`, adds read-only blocked chat response stream data. With `--include-chat-error-taxonomy`, adds read-only chat error taxonomy data. With `--include-chat-audit-event`, adds read-only blocked chat audit-event metadata. With `--include-chat-surface-layout`, adds read-only chat surface layout data. With `--include-chat-local-only-policy`, adds read-only local-only/cloud-block policy data. With `--include-chat-preferences`, adds read-only chat preferences/settings data. With `--include-chat-session-index`, adds read-only empty chat session index data. With `--include-chat-session-title-policy`, adds read-only placeholder session-title policy data. With `--include-chat-transcript-policy`, adds read-only chat transcript retention/export policy data. With `--include-chat-send-result`, adds read-only blocked chat send-result data. With `--include-chat-composer`, adds read-only chat composer/input-control data. With `--include-chat-model-status`, adds read-only blocked chat model-status display data. With `--include-chat-session`, adds read-only blocked chat/session and lifecycle summaries. With `--include-chat-readiness`, adds read-only chat readiness checks and recovery actions. With `--include-device-session`, adds a read-only device/session status panel. With `--include-runtime-readiness`, adds a read-only runtime readiness summary. With `--backend pccx-lab`, calls `pccx-lab status --format json` and forwards the run-status envelope (exits non-zero if binary is missing or output is invalid). |
 | [`scripts/device-session-status-stub.sh`](./scripts/device-session-status-stub.sh) | Data-only device/session status JSON for the Gemma 3N E4B + KV260 target. Reports connection, model load, session, diagnostics, readiness, discovery paths, flow steps, and error taxonomy as placeholder / blocked. |
 | [`scripts/runtime-readiness-stub.sh`](./scripts/runtime-readiness-stub.sh) | Data-only runtime readiness JSON for the Gemma 3N E4B + KV260 target. Reports blocked / not yet evidence-backed. |
 | [`scripts/chat-session-stub.sh`](./scripts/chat-session-stub.sh) | Data-only standalone chat/session JSON for the Gemma 3N E4B + KV260 target. Reports disabled send controls, inactive session state, no prompt/response persistence, and readiness handoff references. |
@@ -96,6 +96,7 @@ and verify host-side prerequisites before the real engine lands.
 | [`scripts/chat-local-only-policy-stub.sh`](./scripts/chat-local-only-policy-stub.sh) | Data-only chat local-only policy JSON for the Gemma 3N E4B + KV260 target. Reports cloud/provider/network dependency and fallback paths as not used, disabled, or blocked while local runtime evidence remains gated. |
 | [`scripts/chat-preferences-stub.sh`](./scripts/chat-preferences-stub.sh) | Data-only chat preferences JSON for the Gemma 3N E4B + KV260 target. Reports planned settings panels and disabled controls without reading configuration, provider settings, model paths, session stores, prompts, transcripts, or artifacts. |
 | [`scripts/chat-session-index-stub.sh`](./scripts/chat-session-index-stub.sh) | Data-only chat session index JSON for the Gemma 3N E4B + KV260 target. Reports an empty, not-configured session list/sidebar boundary without reading a store, session titles, prompts, responses, transcripts, or summaries. |
+| [`scripts/chat-session-title-policy-stub.sh`](./scripts/chat-session-title-policy-stub.sh) | Data-only chat session-title policy JSON for the Gemma 3N E4B + KV260 target. Reports static placeholder display names and disabled title read, generation, rename, and persistence controls without reading stores, transcripts, prompts, responses, summaries, titles, or paths. |
 | [`scripts/chat-model-status-stub.sh`](./scripts/chat-model-status-stub.sh) | Data-only chat model-status JSON for the Gemma 3N E4B + KV260 target. Reports descriptor, asset, load, runtime, context, and response display rows as blocked, disabled, or unavailable. |
 | [`scripts/chat-readiness-stub.sh`](./scripts/chat-readiness-stub.sh) | Data-only chat readiness JSON for the Gemma 3N E4B + KV260 target. Reports readiness checks, error categories, and recovery actions as blocked, disabled, or local data only. |
 | [`scripts/chat-composer-stub.sh`](./scripts/chat-composer-stub.sh) | Data-only chat composer JSON for the Gemma 3N E4B + KV260 target. Reports input buffer, send, attachment, validation, and privacy states without reading, echoing, storing, or persisting prompt text. |
@@ -122,6 +123,7 @@ bash scripts/status-stub.sh --include-chat-surface-layout
 bash scripts/status-stub.sh --include-chat-local-only-policy
 bash scripts/status-stub.sh --include-chat-preferences
 bash scripts/status-stub.sh --include-chat-session-index
+bash scripts/status-stub.sh --include-chat-session-title-policy
 bash scripts/status-stub.sh --include-chat-readiness
 bash scripts/status-stub.sh --include-chat-composer
 bash scripts/status-stub.sh --include-chat-send-result
@@ -143,6 +145,7 @@ bash scripts/chat-surface-layout-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-local-only-policy-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-preferences-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-session-index-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/chat-session-title-policy-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-readiness-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-composer-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-send-result-stub.sh --model gemma3n-e4b --target kv260
@@ -325,9 +328,11 @@ python3 contracts/chat_error_taxonomy_contract.py --model gemma3n-e4b --target k
 python3 contracts/chat_response_stream_contract.py --model gemma3n-e4b --target kv260
 python3 contracts/chat_action_bar_contract.py --model gemma3n-e4b --target kv260
 python3 contracts/chat_shortcut_map_contract.py --model gemma3n-e4b --target kv260
+python3 contracts/chat_session_title_policy_contract.py --model gemma3n-e4b --target kv260
 bash scripts/chat-model-status-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-session-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-session-lifecycle-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/chat-session-title-policy-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-readiness-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-audit-event-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-error-taxonomy-stub.sh --model gemma3n-e4b --target kv260
@@ -343,9 +348,11 @@ bash scripts/status-stub.sh --include-chat-error-taxonomy
 bash scripts/status-stub.sh --include-chat-response-stream
 bash scripts/status-stub.sh --include-chat-action-bar
 bash scripts/status-stub.sh --include-chat-shortcut-map
+bash scripts/status-stub.sh --include-chat-session-title-policy
 python3 scripts/tests/chat_session_contract_test.py
 python3 scripts/tests/chat_model_status_contract_test.py
 python3 scripts/tests/chat_session_lifecycle_contract_test.py
+python3 scripts/tests/chat_session_title_policy_contract_test.py
 python3 scripts/tests/chat_readiness_contract_test.py
 python3 scripts/tests/chat_audit_event_contract_test.py
 python3 scripts/tests/chat_error_taxonomy_contract_test.py
@@ -361,6 +368,7 @@ bash scripts/tests/status-chat-error-taxonomy.sh
 bash scripts/tests/status-chat-response-stream.sh
 bash scripts/tests/status-chat-action-bar.sh
 bash scripts/tests/status-chat-shortcut-map.sh
+bash scripts/tests/status-chat-session-title-policy.sh
 ```
 
 The checked chat/session fixture reports the chat surface as blocked,
@@ -379,6 +387,13 @@ disabled, blocked, inactive, or unavailable until readiness evidence, model
 load evidence, a reviewed local session store, and explicit export/redaction
 rules exist. It does not read or write manifests, transcripts, summaries,
 prompts, responses, or model paths.
+
+The chat session-title policy fixture defines placeholder display-name
+metadata for future local sessions. It renders only a static placeholder
+label and keeps stored-title reads, generated titles, rename, and
+persistence disabled or blocked. It does not read session stores,
+manifests, transcripts, summaries, prompts, responses, stored titles,
+model paths, private paths, or artifacts.
 
 The chat readiness fixture defines the readiness checklist and recovery
 action boundary for the standalone chat surface. It records local fixture

--- a/contracts/chat_session_title_policy_contract.py
+++ b/contracts/chat_session_title_policy_contract.py
@@ -1,0 +1,394 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Data-only chat session-title policy contract for the planned launcher UI.
+
+The contract describes placeholder session display names and blocked title
+generation/rename behavior for the future standalone chat surface. It does
+not read session stores, manifests, titles, summaries, prompts, transcripts,
+model assets, private paths, or logs; it does not write artifacts, load
+models, touch KV260 hardware, call providers, invoke pccx-lab, or start
+runtime code.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import sys
+
+
+SCHEMA_VERSION = "pccx.chatSessionTitlePolicy.v0"
+
+CHAT_SESSION_TITLE_POLICY_FIELDS = (
+    "schemaVersion",
+    "titlePolicyId",
+    "fixtureVersion",
+    "lastUpdatedSource",
+    "targetDevice",
+    "targetBoard",
+    "targetModel",
+    "titlePolicyState",
+    "titleSourceState",
+    "titleDisplayState",
+    "generationState",
+    "renameState",
+    "privacyState",
+    "parentChatSessionRef",
+    "chatSessionIndexRef",
+    "chatSessionLifecycleRef",
+    "chatTranscriptPolicyRef",
+    "titlePolicy",
+    "placeholderTitle",
+    "titleControls",
+    "blockedReasons",
+    "handoffRefs",
+    "safetyFlags",
+    "limitations",
+    "issueRefs",
+)
+
+TITLE_POLICY_FIELDS = (
+    "state",
+    "displayMode",
+    "placeholderSource",
+    "titleReadEnabled",
+    "titleGenerationEnabled",
+    "titleRenameEnabled",
+    "titlePersistenceEnabled",
+    "summaryReadEnabled",
+    "sideEffectPolicy",
+    "contentPolicy",
+)
+
+PLACEHOLDER_TITLE_FIELDS = (
+    "state",
+    "placeholderId",
+    "displayKind",
+    "labelTemplate",
+    "source",
+    "contentIncluded",
+    "userVisibleSummary",
+    "sideEffectPolicy",
+)
+
+TITLE_CONTROL_FIELDS = (
+    "controlId",
+    "label",
+    "state",
+    "enabled",
+    "userAction",
+    "launcherAction",
+    "sideEffectPolicy",
+    "contentPolicy",
+)
+
+BLOCKED_REASON_FIELDS = (
+    "reasonId",
+    "state",
+    "summary",
+    "requiredBefore",
+)
+
+HANDOFF_REF_FIELDS = (
+    "refId",
+    "schemaVersion",
+    "fixturePath",
+    "state",
+    "summary",
+)
+
+CHAT_SESSION_TITLE_POLICY_STATE_VALUES = (
+    "available_as_data",
+    "blocked",
+    "disabled",
+    "empty_not_captured",
+    "inactive",
+    "not_configured",
+    "placeholder",
+    "planned",
+    "redacted",
+    "requires_evidence",
+    "summary_only",
+    "unavailable",
+)
+
+_CHAT_SESSION_TITLE_POLICY = {
+    "schemaVersion": SCHEMA_VERSION,
+    "titlePolicyId": "chat_session_title_policy_gemma3n_e4b_kv260_placeholder",
+    "fixtureVersion": "chat-session-title-policy.gemma3n-e4b-kv260.2026-05-04",
+    "lastUpdatedSource": "pccx_launcher_issue_9_chat_session_title_policy_boundary_2026-05-04",
+    "targetDevice": "kv260",
+    "targetBoard": "xilinx_kria_kv260",
+    "targetModel": "gemma3n-e4b",
+    "titlePolicyState": "available_as_data",
+    "titleSourceState": "not_configured",
+    "titleDisplayState": "placeholder",
+    "generationState": "blocked",
+    "renameState": "disabled",
+    "privacyState": "summary_only",
+    "parentChatSessionRef": "chat_session_gemma3n_e4b_kv260_placeholder",
+    "chatSessionIndexRef": "chat_session_index_gemma3n_e4b_kv260_placeholder",
+    "chatSessionLifecycleRef": "chat_session_lifecycle_gemma3n_e4b_kv260_placeholder",
+    "chatTranscriptPolicyRef": "chat_transcript_policy_gemma3n_e4b_kv260_placeholder",
+    "titlePolicy": {
+        "state": "available_as_data",
+        "displayMode": "placeholder_only",
+        "placeholderSource": "deterministic_fixture_label",
+        "titleReadEnabled": False,
+        "titleGenerationEnabled": False,
+        "titleRenameEnabled": False,
+        "titlePersistenceEnabled": False,
+        "summaryReadEnabled": False,
+        "sideEffectPolicy": "local_render_only",
+        "contentPolicy": "no_stored_titles_summaries_prompts_responses_or_transcripts",
+    },
+    "placeholderTitle": {
+        "state": "placeholder",
+        "placeholderId": "untitled_local_chat_placeholder",
+        "displayKind": "static_placeholder_label",
+        "labelTemplate": "Untitled local chat",
+        "source": "fixture_static_value_not_session_store",
+        "contentIncluded": False,
+        "userVisibleSummary": "Render a deterministic placeholder label without reading a session title.",
+        "sideEffectPolicy": "local_render_only",
+    },
+    "titleControls": [
+        {
+            "controlId": "render_placeholder_title",
+            "label": "render placeholder title",
+            "state": "available_as_data",
+            "enabled": True,
+            "userAction": "Open the chat surface or session sidebar.",
+            "launcherAction": "Render the static placeholder label from checked fixture data.",
+            "sideEffectPolicy": "local_render_only",
+            "contentPolicy": "static_placeholder_only",
+        },
+        {
+            "controlId": "read_stored_title",
+            "label": "read stored title",
+            "state": "blocked",
+            "enabled": False,
+            "userAction": "Read stored titles only after a reviewed local session-store boundary exists.",
+            "launcherAction": "Refuse session-title reads because no manifest/title boundary exists.",
+            "sideEffectPolicy": "no_artifact_read_no_write",
+            "contentPolicy": "no_title_summary_or_transcript_content",
+        },
+        {
+            "controlId": "generate_title",
+            "label": "generate title",
+            "state": "blocked",
+            "enabled": False,
+            "userAction": "Generate a title only after prompt/response redaction and model boundaries are reviewed.",
+            "launcherAction": "Refuse title generation because no prompt, response, summary, or model path may be read.",
+            "sideEffectPolicy": "no_model_or_runtime_execution",
+            "contentPolicy": "no_prompt_response_summary_or_title_generation",
+        },
+        {
+            "controlId": "rename_title",
+            "label": "rename title",
+            "state": "disabled",
+            "enabled": False,
+            "userAction": "Rename only after explicit local store and write policy review.",
+            "launcherAction": "Keep rename disabled because no write boundary exists.",
+            "sideEffectPolicy": "no_write",
+            "contentPolicy": "no_title_capture_or_persistence",
+        },
+        {
+            "controlId": "persist_title",
+            "label": "persist title",
+            "state": "disabled",
+            "enabled": False,
+            "userAction": "Persist only a reviewed title value after a local session-store boundary exists.",
+            "launcherAction": "Refuse persistence because no session-store write boundary exists.",
+            "sideEffectPolicy": "no_artifact_write",
+            "contentPolicy": "no_title_storage",
+        },
+    ],
+    "blockedReasons": [
+        {
+            "reasonId": "session_store_not_configured",
+            "state": "not_configured",
+            "summary": "No reviewed local chat session store exists.",
+            "requiredBefore": "stored_session_title_available",
+        },
+        {
+            "reasonId": "session_title_read_boundary_absent",
+            "state": "planned",
+            "summary": "A checked session-title read shape is required before stored display names can be shown.",
+            "requiredBefore": "read_stored_title_enabled",
+        },
+        {
+            "reasonId": "title_generation_not_reviewed",
+            "state": "blocked",
+            "summary": "Title generation would require prompt/response redaction, model, runtime, and persistence review.",
+            "requiredBefore": "generate_title_enabled",
+        },
+        {
+            "reasonId": "rename_write_boundary_absent",
+            "state": "requires_evidence",
+            "summary": "Renaming needs an explicit local write boundary, validation, and rollback policy.",
+            "requiredBefore": "rename_title_enabled",
+        },
+        {
+            "reasonId": "summary_content_unavailable",
+            "state": "empty_not_captured",
+            "summary": "No prompt, response, transcript, or summary content is available for title derivation.",
+            "requiredBefore": "title_summary_source_available",
+        },
+    ],
+    "handoffRefs": [
+        {
+            "refId": "chat_session",
+            "schemaVersion": "pccx.chatSession.v0",
+            "fixturePath": "contracts/fixtures/chat-session.gemma3n-e4b-kv260-placeholder.json",
+            "state": "available_as_data",
+            "summary": "Base chat/session surface is referenced without message content.",
+        },
+        {
+            "refId": "chat_session_index",
+            "schemaVersion": "pccx.chatSessionIndex.v0",
+            "fixturePath": "contracts/fixtures/chat-session-index.gemma3n-e4b-kv260-placeholder.json",
+            "state": "not_configured",
+            "summary": "Session index remains empty and does not read stored titles.",
+        },
+        {
+            "refId": "chat_session_lifecycle",
+            "schemaVersion": "pccx.chatSessionLifecycle.v0",
+            "fixturePath": "contracts/fixtures/chat-session-lifecycle.gemma3n-e4b-kv260-placeholder.json",
+            "state": "blocked",
+            "summary": "Lifecycle create, restore, clear, close, and export actions remain disabled or blocked.",
+        },
+        {
+            "refId": "chat_transcript_policy",
+            "schemaVersion": "pccx.chatTranscriptPolicy.v0",
+            "fixturePath": "contracts/fixtures/chat-transcript-policy.gemma3n-e4b-kv260-placeholder.json",
+            "state": "disabled",
+            "summary": "Transcript persistence and export remain disabled.",
+        },
+        {
+            "refId": "chat_readiness",
+            "schemaVersion": "pccx.chatReadiness.v0",
+            "fixturePath": "contracts/fixtures/chat-readiness.gemma3n-e4b-kv260-placeholder.json",
+            "state": "blocked",
+            "summary": "Readiness remains separate from title display policy.",
+        },
+    ],
+    "safetyFlags": {
+        "dataOnly": True,
+        "readOnly": True,
+        "deterministic": True,
+        "sessionTitlePolicyDisplayOnly": True,
+        "writesArtifacts": False,
+        "readsArtifacts": False,
+        "readsSessionManifest": False,
+        "readsSessionTitle": False,
+        "readsTranscript": False,
+        "sessionStoreRead": False,
+        "sessionPersistence": False,
+        "titleContentIncluded": False,
+        "sessionTitleIncluded": False,
+        "sessionTitleGenerated": False,
+        "titleRenameImplemented": False,
+        "titlePersistence": False,
+        "transcriptPersistence": False,
+        "transcriptExport": False,
+        "messageBodiesIncluded": False,
+        "summaryIncluded": False,
+        "summaryGenerated": False,
+        "promptCapture": False,
+        "promptContentIncluded": False,
+        "promptEchoed": False,
+        "promptPersistence": False,
+        "responseContentIncluded": False,
+        "responseGenerated": False,
+        "attachmentReads": False,
+        "fileUpload": False,
+        "clipboardRead": False,
+        "clipboardWrite": False,
+        "modelAssetPathsIncluded": False,
+        "modelWeightPathsIncluded": False,
+        "modelLoadAttempted": False,
+        "modelLoaded": False,
+        "modelExecution": False,
+        "runtimeExecution": False,
+        "touchesHardware": False,
+        "kv260Access": False,
+        "opensSerialPort": False,
+        "networkCalls": False,
+        "networkScan": False,
+        "sshExecution": False,
+        "providerCalls": False,
+        "cloudCalls": False,
+        "privatePathsIncluded": False,
+        "secretsIncluded": False,
+        "tokensIncluded": False,
+        "generatedBlobsIncluded": False,
+        "hardwareDumpsIncluded": False,
+        "telemetry": False,
+        "automaticUpload": False,
+        "writeBack": False,
+        "executesPccxLab": False,
+        "executesSystemverilogIde": False,
+        "mcpServerImplemented": False,
+        "lspImplemented": False,
+        "stableApiAbiClaim": False,
+    },
+    "limitations": [
+        "Data-only chat session-title policy fixture; no real session store is configured or read.",
+        "Only a static placeholder label is present; no stored title, generated title, summary, prompt, response, transcript, manifest, model path, private path, secret, or token content is included.",
+        "No title is generated, renamed, persisted, imported, exported, refreshed, or written.",
+        "No artifacts are read, written, deleted, or persisted.",
+        "No KV260 hardware access, serial access, network call, provider call, telemetry, upload, or write-back is performed.",
+        "This is not a release, tag, versioned compatibility commitment, MCP, LSP, IDE, marketplace, telemetry, runtime, model, or session-store implementation.",
+    ],
+    "issueRefs": [
+        "pccxai/pccx-llm-launcher#9",
+    ],
+}
+
+
+def create_gemma3n_e4b_kv260_chat_session_title_policy() -> dict:
+    """Return the checked Gemma 3N E4B plus KV260 title-policy fixture."""
+    return copy.deepcopy(_CHAT_SESSION_TITLE_POLICY)
+
+
+def chat_session_title_policy_json(status: dict | None = None) -> str:
+    """Render a deterministic JSON representation."""
+    return json.dumps(
+        status
+        if status is not None
+        else create_gemma3n_e4b_kv260_chat_session_title_policy(),
+        indent=2,
+        sort_keys=True,
+    ) + "\n"
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Print data-only chat session-title policy JSON.",
+    )
+    parser.add_argument(
+        "--model",
+        default="gemma3n-e4b",
+        choices=("gemma3n-e4b",),
+        help="model descriptor target",
+    )
+    parser.add_argument(
+        "--target",
+        default="kv260",
+        choices=("kv260",),
+        help="target board/device",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parse_args(sys.argv[1:] if argv is None else argv)
+    sys.stdout.write(chat_session_title_policy_json())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contracts/fixtures/chat-session-title-policy.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-session-title-policy.gemma3n-e4b-kv260-placeholder.json
@@ -1,0 +1,233 @@
+{
+  "schemaVersion": "pccx.chatSessionTitlePolicy.v0",
+  "titlePolicyId": "chat_session_title_policy_gemma3n_e4b_kv260_placeholder",
+  "fixtureVersion": "chat-session-title-policy.gemma3n-e4b-kv260.2026-05-04",
+  "lastUpdatedSource": "pccx_launcher_issue_9_chat_session_title_policy_boundary_2026-05-04",
+  "targetDevice": "kv260",
+  "targetBoard": "xilinx_kria_kv260",
+  "targetModel": "gemma3n-e4b",
+  "titlePolicyState": "available_as_data",
+  "titleSourceState": "not_configured",
+  "titleDisplayState": "placeholder",
+  "generationState": "blocked",
+  "renameState": "disabled",
+  "privacyState": "summary_only",
+  "parentChatSessionRef": "chat_session_gemma3n_e4b_kv260_placeholder",
+  "chatSessionIndexRef": "chat_session_index_gemma3n_e4b_kv260_placeholder",
+  "chatSessionLifecycleRef": "chat_session_lifecycle_gemma3n_e4b_kv260_placeholder",
+  "chatTranscriptPolicyRef": "chat_transcript_policy_gemma3n_e4b_kv260_placeholder",
+  "titlePolicy": {
+    "state": "available_as_data",
+    "displayMode": "placeholder_only",
+    "placeholderSource": "deterministic_fixture_label",
+    "titleReadEnabled": false,
+    "titleGenerationEnabled": false,
+    "titleRenameEnabled": false,
+    "titlePersistenceEnabled": false,
+    "summaryReadEnabled": false,
+    "sideEffectPolicy": "local_render_only",
+    "contentPolicy": "no_stored_titles_summaries_prompts_responses_or_transcripts"
+  },
+  "placeholderTitle": {
+    "state": "placeholder",
+    "placeholderId": "untitled_local_chat_placeholder",
+    "displayKind": "static_placeholder_label",
+    "labelTemplate": "Untitled local chat",
+    "source": "fixture_static_value_not_session_store",
+    "contentIncluded": false,
+    "userVisibleSummary": "Render a deterministic placeholder label without reading a session title.",
+    "sideEffectPolicy": "local_render_only"
+  },
+  "titleControls": [
+    {
+      "controlId": "render_placeholder_title",
+      "label": "render placeholder title",
+      "state": "available_as_data",
+      "enabled": true,
+      "userAction": "Open the chat surface or session sidebar.",
+      "launcherAction": "Render the static placeholder label from checked fixture data.",
+      "sideEffectPolicy": "local_render_only",
+      "contentPolicy": "static_placeholder_only"
+    },
+    {
+      "controlId": "read_stored_title",
+      "label": "read stored title",
+      "state": "blocked",
+      "enabled": false,
+      "userAction": "Read stored titles only after a reviewed local session-store boundary exists.",
+      "launcherAction": "Refuse session-title reads because no manifest/title boundary exists.",
+      "sideEffectPolicy": "no_artifact_read_no_write",
+      "contentPolicy": "no_title_summary_or_transcript_content"
+    },
+    {
+      "controlId": "generate_title",
+      "label": "generate title",
+      "state": "blocked",
+      "enabled": false,
+      "userAction": "Generate a title only after prompt/response redaction and model boundaries are reviewed.",
+      "launcherAction": "Refuse title generation because no prompt, response, summary, or model path may be read.",
+      "sideEffectPolicy": "no_model_or_runtime_execution",
+      "contentPolicy": "no_prompt_response_summary_or_title_generation"
+    },
+    {
+      "controlId": "rename_title",
+      "label": "rename title",
+      "state": "disabled",
+      "enabled": false,
+      "userAction": "Rename only after explicit local store and write policy review.",
+      "launcherAction": "Keep rename disabled because no write boundary exists.",
+      "sideEffectPolicy": "no_write",
+      "contentPolicy": "no_title_capture_or_persistence"
+    },
+    {
+      "controlId": "persist_title",
+      "label": "persist title",
+      "state": "disabled",
+      "enabled": false,
+      "userAction": "Persist only a reviewed title value after a local session-store boundary exists.",
+      "launcherAction": "Refuse persistence because no session-store write boundary exists.",
+      "sideEffectPolicy": "no_artifact_write",
+      "contentPolicy": "no_title_storage"
+    }
+  ],
+  "blockedReasons": [
+    {
+      "reasonId": "session_store_not_configured",
+      "state": "not_configured",
+      "summary": "No reviewed local chat session store exists.",
+      "requiredBefore": "stored_session_title_available"
+    },
+    {
+      "reasonId": "session_title_read_boundary_absent",
+      "state": "planned",
+      "summary": "A checked session-title read shape is required before stored display names can be shown.",
+      "requiredBefore": "read_stored_title_enabled"
+    },
+    {
+      "reasonId": "title_generation_not_reviewed",
+      "state": "blocked",
+      "summary": "Title generation would require prompt/response redaction, model, runtime, and persistence review.",
+      "requiredBefore": "generate_title_enabled"
+    },
+    {
+      "reasonId": "rename_write_boundary_absent",
+      "state": "requires_evidence",
+      "summary": "Renaming needs an explicit local write boundary, validation, and rollback policy.",
+      "requiredBefore": "rename_title_enabled"
+    },
+    {
+      "reasonId": "summary_content_unavailable",
+      "state": "empty_not_captured",
+      "summary": "No prompt, response, transcript, or summary content is available for title derivation.",
+      "requiredBefore": "title_summary_source_available"
+    }
+  ],
+  "handoffRefs": [
+    {
+      "refId": "chat_session",
+      "schemaVersion": "pccx.chatSession.v0",
+      "fixturePath": "contracts/fixtures/chat-session.gemma3n-e4b-kv260-placeholder.json",
+      "state": "available_as_data",
+      "summary": "Base chat/session surface is referenced without message content."
+    },
+    {
+      "refId": "chat_session_index",
+      "schemaVersion": "pccx.chatSessionIndex.v0",
+      "fixturePath": "contracts/fixtures/chat-session-index.gemma3n-e4b-kv260-placeholder.json",
+      "state": "not_configured",
+      "summary": "Session index remains empty and does not read stored titles."
+    },
+    {
+      "refId": "chat_session_lifecycle",
+      "schemaVersion": "pccx.chatSessionLifecycle.v0",
+      "fixturePath": "contracts/fixtures/chat-session-lifecycle.gemma3n-e4b-kv260-placeholder.json",
+      "state": "blocked",
+      "summary": "Lifecycle create, restore, clear, close, and export actions remain disabled or blocked."
+    },
+    {
+      "refId": "chat_transcript_policy",
+      "schemaVersion": "pccx.chatTranscriptPolicy.v0",
+      "fixturePath": "contracts/fixtures/chat-transcript-policy.gemma3n-e4b-kv260-placeholder.json",
+      "state": "disabled",
+      "summary": "Transcript persistence and export remain disabled."
+    },
+    {
+      "refId": "chat_readiness",
+      "schemaVersion": "pccx.chatReadiness.v0",
+      "fixturePath": "contracts/fixtures/chat-readiness.gemma3n-e4b-kv260-placeholder.json",
+      "state": "blocked",
+      "summary": "Readiness remains separate from title display policy."
+    }
+  ],
+  "safetyFlags": {
+    "dataOnly": true,
+    "readOnly": true,
+    "deterministic": true,
+    "sessionTitlePolicyDisplayOnly": true,
+    "writesArtifacts": false,
+    "readsArtifacts": false,
+    "readsSessionManifest": false,
+    "readsSessionTitle": false,
+    "readsTranscript": false,
+    "sessionStoreRead": false,
+    "sessionPersistence": false,
+    "titleContentIncluded": false,
+    "sessionTitleIncluded": false,
+    "sessionTitleGenerated": false,
+    "titleRenameImplemented": false,
+    "titlePersistence": false,
+    "transcriptPersistence": false,
+    "transcriptExport": false,
+    "messageBodiesIncluded": false,
+    "summaryIncluded": false,
+    "summaryGenerated": false,
+    "promptCapture": false,
+    "promptContentIncluded": false,
+    "promptEchoed": false,
+    "promptPersistence": false,
+    "responseContentIncluded": false,
+    "responseGenerated": false,
+    "attachmentReads": false,
+    "fileUpload": false,
+    "clipboardRead": false,
+    "clipboardWrite": false,
+    "modelAssetPathsIncluded": false,
+    "modelWeightPathsIncluded": false,
+    "modelLoadAttempted": false,
+    "modelLoaded": false,
+    "modelExecution": false,
+    "runtimeExecution": false,
+    "touchesHardware": false,
+    "kv260Access": false,
+    "opensSerialPort": false,
+    "networkCalls": false,
+    "networkScan": false,
+    "sshExecution": false,
+    "providerCalls": false,
+    "cloudCalls": false,
+    "privatePathsIncluded": false,
+    "secretsIncluded": false,
+    "tokensIncluded": false,
+    "generatedBlobsIncluded": false,
+    "hardwareDumpsIncluded": false,
+    "telemetry": false,
+    "automaticUpload": false,
+    "writeBack": false,
+    "executesPccxLab": false,
+    "executesSystemverilogIde": false,
+    "mcpServerImplemented": false,
+    "lspImplemented": false,
+    "stableApiAbiClaim": false
+  },
+  "limitations": [
+    "Data-only chat session-title policy fixture; no real session store is configured or read.",
+    "Only a static placeholder label is present; no stored title, generated title, summary, prompt, response, transcript, manifest, model path, private path, secret, or token content is included.",
+    "No title is generated, renamed, persisted, imported, exported, refreshed, or written.",
+    "No artifacts are read, written, deleted, or persisted.",
+    "No KV260 hardware access, serial access, network call, provider call, telemetry, upload, or write-back is performed.",
+    "This is not a release, tag, versioned compatibility commitment, MCP, LSP, IDE, marketplace, telemetry, runtime, model, or session-store implementation."
+  ],
+  "issueRefs": [
+    "pccxai/pccx-llm-launcher#9"
+  ]
+}

--- a/docs/STANDALONE_CHAT_SESSION_CONTRACT.md
+++ b/docs/STANDALONE_CHAT_SESSION_CONTRACT.md
@@ -15,6 +15,7 @@ The implementation lives in:
 - `contracts/chat_local_only_policy_contract.py`
 - `contracts/chat_preferences_contract.py`
 - `contracts/chat_session_index_contract.py`
+- `contracts/chat_session_title_policy_contract.py`
 - `contracts/chat_readiness_contract.py`
 - `contracts/chat_composer_contract.py`
 - `contracts/chat_send_result_contract.py`
@@ -31,6 +32,7 @@ The implementation lives in:
 - `contracts/fixtures/chat-local-only-policy.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-preferences.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-session-index.gemma3n-e4b-kv260-placeholder.json`
+- `contracts/fixtures/chat-session-title-policy.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-readiness.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-composer.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-send-result.gemma3n-e4b-kv260-placeholder.json`
@@ -47,6 +49,7 @@ The implementation lives in:
 - `scripts/chat-local-only-policy-stub.sh`
 - `scripts/chat-preferences-stub.sh`
 - `scripts/chat-session-index-stub.sh`
+- `scripts/chat-session-title-policy-stub.sh`
 - `scripts/chat-readiness-stub.sh`
 - `scripts/chat-composer-stub.sh`
 - `scripts/chat-send-result-stub.sh`
@@ -64,6 +67,7 @@ The implementation lives in:
 - `scripts/tests/chat_local_only_policy_contract_test.py`
 - `scripts/tests/chat_preferences_contract_test.py`
 - `scripts/tests/chat_session_index_contract_test.py`
+- `scripts/tests/chat_session_title_policy_contract_test.py`
 - `scripts/tests/chat_readiness_contract_test.py`
 - `scripts/tests/chat_composer_contract_test.py`
 - `scripts/tests/chat_send_result_contract_test.py`
@@ -79,6 +83,7 @@ The implementation lives in:
 - `scripts/tests/status-chat-local-only-policy.sh`
 - `scripts/tests/status-chat-preferences.sh`
 - `scripts/tests/status-chat-session-index.sh`
+- `scripts/tests/status-chat-session-title-policy.sh`
 - `scripts/tests/status-chat-readiness.sh`
 - `scripts/tests/status-chat-composer.sh`
 - `scripts/tests/status-chat-send-result.sh`
@@ -107,6 +112,9 @@ The chat/session contract records:
   configuration reads or preference writes
 - an empty session index/list surface with disabled refresh, selection,
   restore, rename, and delete controls
+- a chat session-title policy with static placeholder display names and
+  disabled stored-title read, title generation, rename, and persistence
+  controls
 - a message envelope vocabulary without prompt or response content
 - links to the runtime readiness and device/session status fixtures
 - blocked reasons that explain what must exist before send controls can
@@ -215,6 +223,21 @@ unavailable, or blocked. The fixture does not read a session store,
 session manifest, session title, transcript, summary, prompt, response,
 model path, private path, or raw log, and it does not write, delete,
 refresh, import, export, or persist artifacts.
+
+The chat session-title policy fixture records the display-name boundary
+for future local chat sessions:
+
+```bash
+bash scripts/chat-session-title-policy-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/status-stub.sh --include-chat-session-title-policy
+```
+
+It reports a static placeholder title label and keeps stored-title reads,
+title generation, rename, and persistence disabled or blocked. The
+fixture does not read session stores, manifests, stored titles,
+transcripts, summaries, prompts, responses, model paths, private paths,
+or raw logs, and it does not generate, rename, persist, import, export,
+refresh, read, or write title artifacts.
 
 The chat readiness fixture records the checklist and recovery-action
 boundary used to decide whether the standalone chat surface can move

--- a/scripts/chat-session-title-policy-stub.sh
+++ b/scripts/chat-session-title-policy-stub.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+# Print the data-only chat session-title policy contract.
+
+set -eu
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+
+python3 "$ROOT_DIR/contracts/chat_session_title_policy_contract.py" "$@"

--- a/scripts/status-stub.sh
+++ b/scripts/status-stub.sh
@@ -25,6 +25,9 @@
 # Chat session index/sidebar plan (explicit opt-in, read-only local data):
 #   --include-chat-session-index
 #
+# Chat session-title display policy (explicit opt-in, read-only local data):
+#   --include-chat-session-title-policy
+#
 # Chat model status display plan (explicit opt-in, read-only local data):
 #   --include-chat-model-status
 #
@@ -80,6 +83,7 @@ INCLUDE_CHAT_SURFACE_LAYOUT="0"
 INCLUDE_CHAT_LOCAL_ONLY_POLICY="0"
 INCLUDE_CHAT_PREFERENCES="0"
 INCLUDE_CHAT_SESSION_INDEX="0"
+INCLUDE_CHAT_SESSION_TITLE_POLICY="0"
 INCLUDE_CHAT_MODEL_STATUS="0"
 INCLUDE_CHAT_READINESS="0"
 INCLUDE_CHAT_COMPOSER="0"
@@ -1019,6 +1023,120 @@ print(
 
     HEAD "chat session index"
     printf '%s\n' "$CHAT_SESSION_INDEX_SUMMARY"
+}
+
+print_chat_session_title_policy_summary() {
+    SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+    ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+    CHAT_SESSION_TITLE_POLICY_STUB="$ROOT_DIR/scripts/chat-session-title-policy-stub.sh"
+
+    if [ ! -f "$CHAT_SESSION_TITLE_POLICY_STUB" ]; then
+        ERROR "chat session title-policy stub not found: $CHAT_SESSION_TITLE_POLICY_STUB"
+        return 1
+    fi
+
+    if ! CHAT_SESSION_TITLE_POLICY_JSON="$(bash "$CHAT_SESSION_TITLE_POLICY_STUB" --model gemma3n-e4b --target kv260 2>&1)"; then
+        ERROR "chat session title-policy stub failed"
+        printf '%s\n' "$CHAT_SESSION_TITLE_POLICY_JSON" >&2
+        return 1
+    fi
+
+    if ! CHAT_SESSION_TITLE_POLICY_SUMMARY="$(
+        printf '%s\n' "$CHAT_SESSION_TITLE_POLICY_JSON" | python3 -c '
+import json
+import sys
+
+data = json.load(sys.stdin)
+flags = data["safetyFlags"]
+policy = data["titlePolicy"]
+placeholder = data["placeholderTitle"]
+controls = " ".join(
+    "{}={}".format(control["controlId"], control["state"])
+    for control in data["titleControls"]
+)
+blocked = " ".join(
+    "{}={}".format(reason["reasonId"], reason["state"])
+    for reason in data["blockedReasons"]
+)
+
+def b(value):
+    return "true" if value else "false"
+
+print("[INFO]  source     : scripts/chat-session-title-policy-stub.sh --model gemma3n-e4b --target kv260")
+print("[INFO]  boundary   : read-only data; no session-store/title/transcript/prompt/model/hardware/lab/IDE execution")
+print("[INFO]  target     : {}".format(data["targetDevice"]))
+print("[INFO]  model      : {}".format(data["targetModel"]))
+print("[INFO]  title      : {}".format(data["titlePolicyState"]))
+print("[INFO]  source     : {}".format(data["titleSourceState"]))
+print("[INFO]  display    : {}".format(data["titleDisplayState"]))
+print("[INFO]  generation : {}".format(data["generationState"]))
+print("[INFO]  rename     : {}".format(data["renameState"]))
+print("[INFO]  privacy    : {}".format(data["privacyState"]))
+print(
+    "[INFO]  title-policy : {} displayMode={} titleReadEnabled={} "
+    "titleGenerationEnabled={} titleRenameEnabled={} "
+    "titlePersistenceEnabled={} summaryReadEnabled={}".format(
+        policy["state"],
+        policy["displayMode"],
+        b(policy["titleReadEnabled"]),
+        b(policy["titleGenerationEnabled"]),
+        b(policy["titleRenameEnabled"]),
+        b(policy["titlePersistenceEnabled"]),
+        b(policy["summaryReadEnabled"]),
+    )
+)
+print(
+    "[INFO]  placeholder : {} displayKind={} contentIncluded={}".format(
+        placeholder["state"],
+        placeholder["displayKind"],
+        b(placeholder["contentIncluded"]),
+    )
+)
+print("[INFO]  controls   : {}".format(controls))
+print("[INFO]  blocked    : {}".format(blocked))
+print(
+    "[INFO]  flags      : readOnly={} dataOnly={} deterministic={} "
+    "sessionTitlePolicyDisplayOnly={} writesArtifacts={} readsArtifacts={} "
+    "readsSessionManifest={} readsSessionTitle={} readsTranscript={} "
+    "sessionStoreRead={} titleContentIncluded={} sessionTitleIncluded={} "
+    "sessionTitleGenerated={} titleRenameImplemented={} titlePersistence={} "
+    "summaryIncluded={} promptContentIncluded={} responseContentIncluded={} "
+    "modelExecution={} runtimeExecution={} kv260Access={} networkCalls={} "
+    "providerCalls={} executesPccxLab={}".format(
+        b(flags["readOnly"]),
+        b(flags["dataOnly"]),
+        b(flags["deterministic"]),
+        b(flags["sessionTitlePolicyDisplayOnly"]),
+        b(flags["writesArtifacts"]),
+        b(flags["readsArtifacts"]),
+        b(flags["readsSessionManifest"]),
+        b(flags["readsSessionTitle"]),
+        b(flags["readsTranscript"]),
+        b(flags["sessionStoreRead"]),
+        b(flags["titleContentIncluded"]),
+        b(flags["sessionTitleIncluded"]),
+        b(flags["sessionTitleGenerated"]),
+        b(flags["titleRenameImplemented"]),
+        b(flags["titlePersistence"]),
+        b(flags["summaryIncluded"]),
+        b(flags["promptContentIncluded"]),
+        b(flags["responseContentIncluded"]),
+        b(flags["modelExecution"]),
+        b(flags["runtimeExecution"]),
+        b(flags["kv260Access"]),
+        b(flags["networkCalls"]),
+        b(flags["providerCalls"]),
+        b(flags["executesPccxLab"]),
+    )
+)
+'
+    )"; then
+        ERROR "chat session title-policy JSON could not be summarized"
+        return 1
+    fi
+
+    HEAD "chat session title policy"
+    printf '%s\n' "$CHAT_SESSION_TITLE_POLICY_SUMMARY"
 }
 
 print_chat_audit_event_summary() {
@@ -1970,6 +2088,10 @@ while [ $# -gt 0 ]; do
             INCLUDE_CHAT_SESSION_INDEX="1"
             shift
             ;;
+        --include-chat-session-title-policy)
+            INCLUDE_CHAT_SESSION_TITLE_POLICY="1"
+            shift
+            ;;
         --include-chat-model-status)
             INCLUDE_CHAT_MODEL_STATUS="1"
             shift
@@ -2029,8 +2151,8 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-if [ -n "$BACKEND" ] && { [ "$INCLUDE_RUNTIME_READINESS" = "1" ] || [ "$INCLUDE_DEVICE_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SURFACE_LAYOUT" = "1" ] || [ "$INCLUDE_CHAT_LOCAL_ONLY_POLICY" = "1" ] || [ "$INCLUDE_CHAT_PREFERENCES" = "1" ] || [ "$INCLUDE_CHAT_SESSION_INDEX" = "1" ] || [ "$INCLUDE_CHAT_MODEL_STATUS" = "1" ] || [ "$INCLUDE_CHAT_READINESS" = "1" ] || [ "$INCLUDE_CHAT_COMPOSER" = "1" ] || [ "$INCLUDE_CHAT_SEND_RESULT" = "1" ] || [ "$INCLUDE_CHAT_TRANSCRIPT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_AUDIT_EVENT" = "1" ] || [ "$INCLUDE_CHAT_ERROR_TAXONOMY" = "1" ] || [ "$INCLUDE_CHAT_RESPONSE_STREAM" = "1" ] || [ "$INCLUDE_CHAT_MESSAGE_LIST" = "1" ] || [ "$INCLUDE_CHAT_ACTION_BAR" = "1" ] || [ "$INCLUDE_CHAT_SHORTCUT_MAP" = "1" ]; }; then
-    ERROR "--include-runtime-readiness, --include-device-session, --include-chat-session, --include-chat-surface-layout, --include-chat-local-only-policy, --include-chat-preferences, --include-chat-session-index, --include-chat-model-status, --include-chat-readiness, --include-chat-composer, --include-chat-send-result, --include-chat-transcript-policy, --include-chat-audit-event, --include-chat-error-taxonomy, --include-chat-response-stream, --include-chat-message-list, --include-chat-action-bar, and --include-chat-shortcut-map are only supported in local scaffold mode"
+if [ -n "$BACKEND" ] && { [ "$INCLUDE_RUNTIME_READINESS" = "1" ] || [ "$INCLUDE_DEVICE_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SURFACE_LAYOUT" = "1" ] || [ "$INCLUDE_CHAT_LOCAL_ONLY_POLICY" = "1" ] || [ "$INCLUDE_CHAT_PREFERENCES" = "1" ] || [ "$INCLUDE_CHAT_SESSION_INDEX" = "1" ] || [ "$INCLUDE_CHAT_SESSION_TITLE_POLICY" = "1" ] || [ "$INCLUDE_CHAT_MODEL_STATUS" = "1" ] || [ "$INCLUDE_CHAT_READINESS" = "1" ] || [ "$INCLUDE_CHAT_COMPOSER" = "1" ] || [ "$INCLUDE_CHAT_SEND_RESULT" = "1" ] || [ "$INCLUDE_CHAT_TRANSCRIPT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_AUDIT_EVENT" = "1" ] || [ "$INCLUDE_CHAT_ERROR_TAXONOMY" = "1" ] || [ "$INCLUDE_CHAT_RESPONSE_STREAM" = "1" ] || [ "$INCLUDE_CHAT_MESSAGE_LIST" = "1" ] || [ "$INCLUDE_CHAT_ACTION_BAR" = "1" ] || [ "$INCLUDE_CHAT_SHORTCUT_MAP" = "1" ]; }; then
+    ERROR "--include-runtime-readiness, --include-device-session, --include-chat-session, --include-chat-surface-layout, --include-chat-local-only-policy, --include-chat-preferences, --include-chat-session-index, --include-chat-session-title-policy, --include-chat-model-status, --include-chat-readiness, --include-chat-composer, --include-chat-send-result, --include-chat-transcript-policy, --include-chat-audit-event, --include-chat-error-taxonomy, --include-chat-response-stream, --include-chat-message-list, --include-chat-action-bar, and --include-chat-shortcut-map are only supported in local scaffold mode"
     exit 1
 fi
 
@@ -2050,6 +2172,7 @@ if [ -z "$BACKEND" ]; then
     NOTE "chat local    : opt-in via --include-chat-local-only-policy (read-only local-only policy data)"
     NOTE "chat prefs    : opt-in via --include-chat-preferences (read-only preferences data)"
     NOTE "chat index    : opt-in via --include-chat-session-index (read-only empty session index data)"
+    NOTE "chat titles   : opt-in via --include-chat-session-title-policy (read-only title policy data)"
     NOTE "chat model    : opt-in via --include-chat-model-status (read-only model status display data)"
     NOTE "chat readiness: opt-in via --include-chat-readiness (read-only readiness and recovery data)"
     NOTE "chat composer : opt-in via --include-chat-composer (read-only input control data)"
@@ -2119,6 +2242,12 @@ if [ -z "$BACKEND" ]; then
 
     if [ "$INCLUDE_CHAT_SESSION_INDEX" = "1" ]; then
         if ! print_chat_session_index_summary; then
+            exit 1
+        fi
+    fi
+
+    if [ "$INCLUDE_CHAT_SESSION_TITLE_POLICY" = "1" ]; then
+        if ! print_chat_session_title_policy_summary; then
             exit 1
         fi
     fi

--- a/scripts/tests/chat_session_title_policy_contract_test.py
+++ b/scripts/tests/chat_session_title_policy_contract_test.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Fixture tests for the standalone chat session-title policy contract."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "contracts" / "chat_session_title_policy_contract.py"
+FIXTURE_PATH = (
+    ROOT
+    / "contracts"
+    / "fixtures"
+    / "chat-session-title-policy.gemma3n-e4b-kv260-placeholder.json"
+)
+SCRIPT_PATH = ROOT / "scripts" / "chat-session-title-policy-stub.sh"
+STATUS_TEST_PATH = ROOT / "scripts" / "tests" / "status-chat-session-title-policy.sh"
+DOC_PATH = ROOT / "docs" / "STANDALONE_CHAT_SESSION_CONTRACT.md"
+README_PATH = ROOT / "README.md"
+CI_PATH = ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location(
+        "chat_session_title_policy_contract",
+        MODULE_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def iter_state_values(value):
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            if (
+                key == "state"
+                or key.endswith("State")
+                or key.endswith("Status")
+            ) and isinstance(nested, str):
+                yield nested
+            yield from iter_state_values(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            yield from iter_state_values(nested)
+
+
+def iter_keys(value):
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            yield key
+            yield from iter_keys(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            yield from iter_keys(nested)
+
+
+def flatten(value):
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            yield str(key)
+            yield from flatten(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            yield from flatten(nested)
+    else:
+        yield str(value)
+
+
+def assert_no_private_or_generated_data(text: str) -> None:
+    forbidden_patterns = [
+        r"/home/[^\s\"']+",
+        r"/Users/[^\s\"']+",
+        r"[A-Za-z]:\\Users\\",
+        r"\b(?:api[_-]?key|authorization|bearer|client[_-]?secret|password|private[_-]?key|secret|token)\b\s*[:=]",
+        r"\.(?:gguf|safetensors|ckpt|pt|pth|onnx)\b",
+        r"(?:weights|model_weights|model-cache)/(?:[^\"'\s]+)",
+        r"(?:raw[_-]?full[_-]?logs|hardware[_-]?dump|generated[_-]?blob)\s*[:=]",
+    ]
+    for pattern in forbidden_patterns:
+        assert not re.search(pattern, text, re.IGNORECASE), pattern
+
+
+def assert_no_runtime_implementation_terms(source: str) -> None:
+    forbidden = [
+        "subprocess",
+        "os.system",
+        "popen",
+        "socket",
+        "urllib",
+        "requests",
+        "http.client",
+        "openai",
+        "anthropic",
+        "gemini",
+        "modelcontextprotocol",
+        "websocket",
+        "xmutil",
+        "xrt-smi",
+        "lsusb",
+        "dmesg",
+    ]
+    lowered = source.lower()
+    for term in forbidden:
+        assert term not in lowered, term
+
+
+def assert_no_provider_configs(value) -> None:
+    forbidden_keys = {
+        "apiKey",
+        "accessToken",
+        "refreshToken",
+        "authorization",
+        "bearerToken",
+        "provider",
+        "providers",
+        "providerConfig",
+        "providerConfigs",
+    }
+    for key in iter_keys(value):
+        assert key not in forbidden_keys, key
+
+
+def assert_no_unsupported_claims(text: str) -> None:
+    literal_claims = [
+        "production-ready",
+        "marketplace-ready",
+        "stable API",
+        "stable ABI",
+        "KV260 inference works",
+        "Gemma 3N E4B runs on KV260",
+        "20 tok/s achieved",
+        "timing closed",
+        "bitstream ready",
+        "launcher executes pccx-lab",
+        "IDE controls launcher",
+        "AI provider integration is live",
+    ]
+    lowered = text.lower()
+    for claim in literal_claims:
+        assert claim.lower() not in lowered, claim
+
+
+def test_chat_session_title_policy_matches_fixture_and_is_deterministic() -> None:
+    module = load_module()
+    generated = module.create_gemma3n_e4b_kv260_chat_session_title_policy()
+    fixture = json.loads(read_text(FIXTURE_PATH))
+
+    assert generated == fixture
+    assert (
+        module.chat_session_title_policy_json(generated)
+        == module.chat_session_title_policy_json(generated)
+    )
+    assert module.chat_session_title_policy_json(generated).endswith("\n")
+    assert json.loads(module.chat_session_title_policy_json(generated)) == fixture
+
+
+def test_cli_stub_outputs_deterministic_json() -> None:
+    fixture = json.loads(read_text(FIXTURE_PATH))
+    command = [
+        "bash",
+        str(SCRIPT_PATH),
+        "--model",
+        "gemma3n-e4b",
+        "--target",
+        "kv260",
+    ]
+    first = subprocess.run(command, check=True, capture_output=True, text=True)
+    second = subprocess.run(command, check=True, capture_output=True, text=True)
+
+    assert first.stderr == ""
+    assert first.stdout == second.stdout
+    assert first.stdout.endswith("\n")
+    assert json.loads(first.stdout) == fixture
+
+
+def test_required_fields_and_allowed_states() -> None:
+    module = load_module()
+    policy = module.create_gemma3n_e4b_kv260_chat_session_title_policy()
+    allowed = set(module.CHAT_SESSION_TITLE_POLICY_STATE_VALUES)
+
+    assert tuple(policy.keys()) == module.CHAT_SESSION_TITLE_POLICY_FIELDS
+    assert policy["schemaVersion"] == "pccx.chatSessionTitlePolicy.v0"
+    assert tuple(policy["titlePolicy"].keys()) == module.TITLE_POLICY_FIELDS
+    assert (
+        tuple(policy["placeholderTitle"].keys())
+        == module.PLACEHOLDER_TITLE_FIELDS
+    )
+
+    states = list(iter_state_values(policy))
+    assert states
+    for state in states:
+        assert state in allowed, state
+
+    for control in policy["titleControls"]:
+        assert tuple(control.keys()) == module.TITLE_CONTROL_FIELDS
+    for reason in policy["blockedReasons"]:
+        assert tuple(reason.keys()) == module.BLOCKED_REASON_FIELDS
+    for ref in policy["handoffRefs"]:
+        assert tuple(ref.keys()) == module.HANDOFF_REF_FIELDS
+
+
+def test_chat_session_title_policy_covers_issue_9_title_boundary() -> None:
+    policy = load_module().create_gemma3n_e4b_kv260_chat_session_title_policy()
+    flags = policy["safetyFlags"]
+    title_policy = policy["titlePolicy"]
+    placeholder = policy["placeholderTitle"]
+    controls = {control["controlId"]: control for control in policy["titleControls"]}
+    reasons = {reason["reasonId"]: reason for reason in policy["blockedReasons"]}
+    refs = {ref["refId"]: ref for ref in policy["handoffRefs"]}
+
+    assert policy["titlePolicyState"] == "available_as_data"
+    assert policy["titleSourceState"] == "not_configured"
+    assert policy["titleDisplayState"] == "placeholder"
+    assert policy["generationState"] == "blocked"
+    assert policy["renameState"] == "disabled"
+    assert policy["privacyState"] == "summary_only"
+    assert title_policy["displayMode"] == "placeholder_only"
+    assert title_policy["titleReadEnabled"] is False
+    assert title_policy["titleGenerationEnabled"] is False
+    assert title_policy["titleRenameEnabled"] is False
+    assert title_policy["titlePersistenceEnabled"] is False
+    assert title_policy["summaryReadEnabled"] is False
+    assert placeholder["contentIncluded"] is False
+    assert placeholder["source"] == "fixture_static_value_not_session_store"
+    assert set(controls) == {
+        "render_placeholder_title",
+        "read_stored_title",
+        "generate_title",
+        "rename_title",
+        "persist_title",
+    }
+    assert controls["render_placeholder_title"]["enabled"] is True
+    assert controls["read_stored_title"]["enabled"] is False
+    assert controls["generate_title"]["state"] == "blocked"
+    assert {
+        "session_store_not_configured",
+        "session_title_read_boundary_absent",
+        "title_generation_not_reviewed",
+        "rename_write_boundary_absent",
+        "summary_content_unavailable",
+    } <= set(reasons)
+    assert set(refs) == {
+        "chat_session",
+        "chat_session_index",
+        "chat_session_lifecycle",
+        "chat_transcript_policy",
+        "chat_readiness",
+    }
+    assert flags["readOnly"] is True
+    assert flags["sessionTitlePolicyDisplayOnly"] is True
+    assert flags["readsArtifacts"] is False
+    assert flags["writesArtifacts"] is False
+    assert flags["readsSessionManifest"] is False
+    assert flags["readsSessionTitle"] is False
+    assert flags["readsTranscript"] is False
+    assert flags["sessionStoreRead"] is False
+    assert flags["sessionTitleIncluded"] is False
+    assert flags["sessionTitleGenerated"] is False
+    assert flags["titleRenameImplemented"] is False
+    assert flags["titlePersistence"] is False
+    assert flags["summaryIncluded"] is False
+    assert flags["promptContentIncluded"] is False
+    assert flags["responseContentIncluded"] is False
+    assert flags["modelExecution"] is False
+    assert flags["runtimeExecution"] is False
+    assert flags["kv260Access"] is False
+    assert flags["providerCalls"] is False
+    assert flags["executesPccxLab"] is False
+
+
+def test_contract_avoids_runtime_or_private_data() -> None:
+    module_source = read_text(MODULE_PATH)
+    fixture_text = read_text(FIXTURE_PATH)
+    fixture = json.loads(fixture_text)
+
+    assert_no_runtime_implementation_terms(module_source)
+    assert_no_private_or_generated_data(fixture_text)
+    assert_no_provider_configs(fixture)
+    assert_no_unsupported_claims(fixture_text)
+    assert "hello" not in fixture_text.lower()
+    assert "promptText" not in fixture_text
+    assert "responseText" not in fixture_text
+    assert "sessionTitleText" not in fixture_text
+    assert "titleBody" not in fixture_text
+    assert "summaryText" not in fixture_text
+    assert all(
+        "session title:" not in item.lower()
+        for item in flatten(fixture)
+    )
+
+
+def test_docs_readme_status_tests_and_ci_reference_title_policy() -> None:
+    docs = read_text(DOC_PATH)
+    readme = read_text(README_PATH)
+    status_test = read_text(STATUS_TEST_PATH)
+    ci = read_text(CI_PATH)
+
+    assert "chat_session_title_policy_contract.py" in docs
+    assert "chat-session-title-policy-stub.sh" in docs
+    assert (
+        "chat-session-title-policy.gemma3n-e4b-kv260-placeholder.json"
+        in docs
+    )
+    assert "chat session-title policy" in docs
+    assert "--include-chat-session-title-policy" in docs
+    assert "chat-session-title-policy-stub.sh" in readme
+    assert "--include-chat-session-title-policy" in readme
+    assert "status-chat-session-title-policy" in ci
+    assert "chat_session_title_policy_contract_test.py" in ci
+    assert "no session-store/title/transcript/prompt" in status_test
+
+
+if __name__ == "__main__":
+    for name, func in sorted(globals().items()):
+        if name.startswith("test_") and callable(func):
+            func()
+    print("chat session title policy contract tests ok")

--- a/scripts/tests/status-chat-session-title-policy.sh
+++ b/scripts/tests/status-chat-session-title-policy.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+# scripts/tests/status-chat-session-title-policy.sh - status title-policy tests.
+#
+# Usage: bash scripts/tests/status-chat-session-title-policy.sh [path/to/status-stub.sh]
+
+set -eu
+
+PASS() { printf '[PASS]  %s\n' "$*"; }
+FAIL() { printf '[FAIL]  %s\n' "$*" >&2; }
+HEAD() { printf '\n=== %s ===\n' "$*"; }
+
+STUB="${1:-scripts/status-stub.sh}"
+
+if [ ! -x "$STUB" ]; then
+    chmod +x "$STUB"
+fi
+
+contains() {
+    case "$1" in
+        *"$2"*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+require_contains() {
+    local output="$1"
+    local expected="$2"
+    if ! contains "$output" "$expected"; then
+        FAIL "expected output to contain: $expected"
+        printf '%s\n' "$output" >&2
+        exit 1
+    fi
+}
+
+require_not_contains() {
+    local output="$1"
+    local forbidden="$2"
+    if contains "$output" "$forbidden"; then
+        FAIL "output contained forbidden text: $forbidden"
+        printf '%s\n' "$output" >&2
+        exit 1
+    fi
+}
+
+HEAD "1: status can include chat session title policy"
+OUTPUT="$("$STUB" --include-chat-session-title-policy)"
+require_contains "$OUTPUT" "=== chat session title policy ==="
+require_contains "$OUTPUT" "source     : scripts/chat-session-title-policy-stub.sh --model gemma3n-e4b --target kv260"
+require_contains "$OUTPUT" "boundary   : read-only data; no session-store/title/transcript/prompt/model/hardware/lab/IDE execution"
+require_contains "$OUTPUT" "target     : kv260"
+require_contains "$OUTPUT" "model      : gemma3n-e4b"
+require_contains "$OUTPUT" "title      : available_as_data"
+require_contains "$OUTPUT" "source     : not_configured"
+require_contains "$OUTPUT" "display    : placeholder"
+require_contains "$OUTPUT" "generation : blocked"
+require_contains "$OUTPUT" "rename     : disabled"
+require_contains "$OUTPUT" "privacy    : summary_only"
+PASS "chat session title policy section is present and conservative"
+
+HEAD "2: policy and controls stay display-only"
+require_contains "$OUTPUT" "title-policy : available_as_data displayMode=placeholder_only titleReadEnabled=false titleGenerationEnabled=false titleRenameEnabled=false titlePersistenceEnabled=false summaryReadEnabled=false"
+require_contains "$OUTPUT" "placeholder : placeholder displayKind=static_placeholder_label contentIncluded=false"
+require_contains "$OUTPUT" "controls   : render_placeholder_title=available_as_data"
+require_contains "$OUTPUT" "read_stored_title=blocked"
+require_contains "$OUTPUT" "generate_title=blocked"
+require_contains "$OUTPUT" "rename_title=disabled"
+require_contains "$OUTPUT" "persist_title=disabled"
+require_contains "$OUTPUT" "blocked    : session_store_not_configured=not_configured"
+require_contains "$OUTPUT" "session_title_read_boundary_absent=planned"
+require_contains "$OUTPUT" "title_generation_not_reviewed=blocked"
+require_contains "$OUTPUT" "rename_write_boundary_absent=requires_evidence"
+PASS "title policy metadata is summarized without title, store, or transcript reads"
+
+HEAD "3: safety flags stay read-only and non-executing"
+require_contains "$OUTPUT" "readOnly=true"
+require_contains "$OUTPUT" "dataOnly=true"
+require_contains "$OUTPUT" "deterministic=true"
+require_contains "$OUTPUT" "sessionTitlePolicyDisplayOnly=true"
+require_contains "$OUTPUT" "writesArtifacts=false"
+require_contains "$OUTPUT" "readsArtifacts=false"
+require_contains "$OUTPUT" "readsSessionManifest=false"
+require_contains "$OUTPUT" "readsSessionTitle=false"
+require_contains "$OUTPUT" "readsTranscript=false"
+require_contains "$OUTPUT" "sessionStoreRead=false"
+require_contains "$OUTPUT" "titleContentIncluded=false"
+require_contains "$OUTPUT" "sessionTitleIncluded=false"
+require_contains "$OUTPUT" "sessionTitleGenerated=false"
+require_contains "$OUTPUT" "titleRenameImplemented=false"
+require_contains "$OUTPUT" "titlePersistence=false"
+require_contains "$OUTPUT" "summaryIncluded=false"
+require_contains "$OUTPUT" "promptContentIncluded=false"
+require_contains "$OUTPUT" "responseContentIncluded=false"
+require_contains "$OUTPUT" "modelExecution=false"
+require_contains "$OUTPUT" "runtimeExecution=false"
+require_contains "$OUTPUT" "kv260Access=false"
+require_contains "$OUTPUT" "networkCalls=false"
+require_contains "$OUTPUT" "providerCalls=false"
+require_contains "$OUTPUT" "executesPccxLab=false"
+PASS "title-policy execution, persistence, and content flags remain false"
+
+HEAD "4: output is deterministic"
+OUTPUT_AGAIN="$("$STUB" --include-chat-session-title-policy)"
+if [ "$OUTPUT" != "$OUTPUT_AGAIN" ]; then
+    FAIL "status chat session title policy output changed between runs"
+    exit 1
+fi
+PASS "status chat session title policy output is deterministic"
+
+HEAD "5: title-policy option does not combine with pccx-lab backend"
+if "$STUB" --include-chat-session-title-policy --backend pccx-lab >/dev/null 2>&1; then
+    FAIL "expected combined title-policy/backend mode to fail"
+    exit 1
+fi
+PASS "chat session title policy remains separate from backend execution"
+
+HEAD "6: output avoids known overclaims and chat content"
+FORBIDDEN_PREFIX="KV260 inference"
+FORBIDDEN_CLAIM="${FORBIDDEN_PREFIX} works"
+require_not_contains "$OUTPUT" "$FORBIDDEN_CLAIM"
+THROUGHPUT_PREFIX="20 tok/s"
+THROUGHPUT_CLAIM="${THROUGHPUT_PREFIX} achieved"
+require_not_contains "$OUTPUT" "$THROUGHPUT_CLAIM"
+require_not_contains "$OUTPUT" "hello"
+require_not_contains "$OUTPUT" "assistant response:"
+require_not_contains "$OUTPUT" "session title:"
+PASS "no title-policy overclaim or chat content in status output"
+
+printf '\n[DONE]  all status-chat-session-title-policy tests passed\n'


### PR DESCRIPTION
Refs pccxai/pccx-llm-launcher#9.

## Summary

- Add checked data-only `pccx.chatSessionTitlePolicy.v0` fixture for placeholder local chat session display names.
- Add the opt-in `--include-chat-session-title-policy` status summary, stub script, docs, README references, and CI coverage.
- Keep stored-title reads, title generation, rename, persistence, session-store reads, transcript/prompt/response/summary reads, model/runtime/provider/network calls, hardware access, pccx-lab execution, IDE execution, and artifact read/write paths out of scope.

## Validation

- `python3 -m json.tool contracts/fixtures/chat-session-title-policy.gemma3n-e4b-kv260-placeholder.json`
- `python3 -m py_compile contracts/*.py scripts/tests/*.py`
- `find scripts -type f -name '*.sh' -not -name '*.snapshot' -print0 | xargs -0 bash -n`
- `python3 scripts/tests/chat_session_title_policy_contract_test.py`
- `bash scripts/chat-session-title-policy-stub.sh --model gemma3n-e4b --target kv260`
- `bash scripts/status-stub.sh --include-chat-session-title-policy`
- `bash scripts/tests/status-chat-session-title-policy.sh scripts/status-stub.sh`
- all `scripts/tests/*_test.py` contract tests
- all `scripts/tests/status-*.sh` status tests
- `bash scripts/check.sh`
- local forbidden-claim scan equivalent
- `git diff --check`
- `git diff --cached --check`

Local note: `shellcheck` is not installed in this shell; CI installs and runs it.