### PR TITLE
Add chat attachment-policy boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,7 @@ jobs:
                    scripts/chat-response-stream-stub.sh \
                    scripts/chat-message-list-stub.sh \
                    scripts/chat-action-bar-stub.sh \
+                   scripts/chat-attachment-policy-stub.sh \
                    scripts/chat-shortcut-map-stub.sh \
                    scripts/chat-surface-preview.sh \
                    scripts/chat-stub.sh; do
@@ -234,6 +235,10 @@ jobs:
         run: ./scripts/status-stub.sh --include-chat-action-bar
       - name: run scripts/chat-action-bar-stub.sh
         run: ./scripts/chat-action-bar-stub.sh --model gemma3n-e4b --target kv260
+      - name: run scripts/status-stub.sh with chat attachment policy
+        run: ./scripts/status-stub.sh --include-chat-attachment-policy
+      - name: run scripts/chat-attachment-policy-stub.sh
+        run: ./scripts/chat-attachment-policy-stub.sh --model gemma3n-e4b --target kv260
       - name: run scripts/status-stub.sh with chat shortcut map
         run: ./scripts/status-stub.sh --include-chat-shortcut-map
       - name: run scripts/chat-shortcut-map-stub.sh
@@ -294,6 +299,8 @@ jobs:
         run: python3 scripts/tests/chat_message_list_contract_test.py
       - name: run chat action-bar contract tests
         run: python3 scripts/tests/chat_action_bar_contract_test.py
+      - name: run chat attachment-policy contract tests
+        run: python3 scripts/tests/chat_attachment_policy_contract_test.py
       - name: run chat shortcut-map contract tests
         run: python3 scripts/tests/chat_shortcut_map_contract_test.py
       - name: run chat surface preview tests
@@ -325,6 +332,7 @@ jobs:
           chmod +x scripts/chat-response-stream-stub.sh
           chmod +x scripts/chat-message-list-stub.sh
           chmod +x scripts/chat-action-bar-stub.sh
+          chmod +x scripts/chat-attachment-policy-stub.sh
           chmod +x scripts/chat-shortcut-map-stub.sh
           chmod +x scripts/launch-stub.sh
           chmod +x scripts/tests/status-backend.sh
@@ -346,6 +354,7 @@ jobs:
           chmod +x scripts/tests/status-chat-response-stream.sh
           chmod +x scripts/tests/status-chat-message-list.sh
           chmod +x scripts/tests/status-chat-action-bar.sh
+          chmod +x scripts/tests/status-chat-attachment-policy.sh
           chmod +x scripts/tests/status-chat-shortcut-map.sh
       - name: shellcheck status-stub and test script
         run: |
@@ -370,6 +379,7 @@ jobs:
           shellcheck scripts/tests/status-chat-response-stream.sh
           shellcheck scripts/tests/status-chat-message-list.sh
           shellcheck scripts/tests/status-chat-action-bar.sh
+          shellcheck scripts/tests/status-chat-attachment-policy.sh
           shellcheck scripts/tests/status-chat-shortcut-map.sh
       - name: run status-backend tests
         run: bash scripts/tests/status-backend.sh scripts/status-stub.sh
@@ -409,5 +419,7 @@ jobs:
         run: bash scripts/tests/status-chat-message-list.sh scripts/status-stub.sh
       - name: run status-chat-action-bar tests
         run: bash scripts/tests/status-chat-action-bar.sh scripts/status-stub.sh
+      - name: run status-chat-attachment-policy tests
+        run: bash scripts/tests/status-chat-attachment-policy.sh scripts/status-stub.sh
       - name: run status-chat-shortcut-map tests
         run: bash scripts/tests/status-chat-shortcut-map.sh scripts/status-stub.sh

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ and verify host-side prerequisites before the real engine lands.
 | [`scripts/check.sh`](./scripts/check.sh) | Probe host info, tooling availability, edge-device hints. Always exits 0. |
 | [`scripts/check-device-stub.sh`](./scripts/check-device-stub.sh) | Narrowly scoped device-tree / FPGA-node probe (KV260 / Kria detection only). Always exits 0. |
 | [`scripts/install-stub.sh`](./scripts/install-stub.sh) | Preview of the planned install flow; reports which host runtime pieces are present, lists device-side pieces as future deliverables. Always exits 0. |
-| [`scripts/status-stub.sh`](./scripts/status-stub.sh) | Launcher state summary. Default mode: local scaffold output, always exits 0. With `--include-chat-action-bar`, adds read-only disabled chat action-bar data. With `--include-chat-shortcut-map`, adds read-only disabled chat shortcut-map data. With `--include-chat-message-list`, adds read-only empty chat message-list data. With `--include-chat-response-stream`, adds read-only blocked chat response stream data. With `--include-chat-error-taxonomy`, adds read-only chat error taxonomy data. With `--include-chat-audit-event`, adds read-only blocked chat audit-event metadata. With `--include-chat-surface-layout`, adds read-only chat surface layout data. With `--include-chat-local-only-policy`, adds read-only local-only/cloud-block policy data. With `--include-chat-preferences`, adds read-only chat preferences/settings data. With `--include-chat-session-index`, adds read-only empty chat session index data. With `--include-chat-session-title-policy`, adds read-only placeholder session-title policy data. With `--include-chat-transcript-policy`, adds read-only chat transcript retention/export policy data. With `--include-chat-send-result`, adds read-only blocked chat send-result data. With `--include-chat-composer`, adds read-only chat composer/input-control data. With `--include-chat-model-status`, adds read-only blocked chat model-status display data. With `--include-chat-session`, adds read-only blocked chat/session and lifecycle summaries. With `--include-chat-readiness`, adds read-only chat readiness checks and recovery actions. With `--include-device-session`, adds a read-only device/session status panel. With `--include-runtime-readiness`, adds a read-only runtime readiness summary. With `--backend pccx-lab`, calls `pccx-lab status --format json` and forwards the run-status envelope (exits non-zero if binary is missing or output is invalid). |
+| [`scripts/status-stub.sh`](./scripts/status-stub.sh) | Launcher state summary. Default mode: local scaffold output, always exits 0. With `--include-chat-action-bar`, adds read-only disabled chat action-bar data. With `--include-chat-attachment-policy`, adds read-only disabled chat attachment-policy data. With `--include-chat-shortcut-map`, adds read-only disabled chat shortcut-map data. With `--include-chat-message-list`, adds read-only empty chat message-list data. With `--include-chat-response-stream`, adds read-only blocked chat response stream data. With `--include-chat-error-taxonomy`, adds read-only chat error taxonomy data. With `--include-chat-audit-event`, adds read-only blocked chat audit-event metadata. With `--include-chat-surface-layout`, adds read-only chat surface layout data. With `--include-chat-local-only-policy`, adds read-only local-only/cloud-block policy data. With `--include-chat-preferences`, adds read-only chat preferences/settings data. With `--include-chat-session-index`, adds read-only empty chat session index data. With `--include-chat-session-title-policy`, adds read-only placeholder session-title policy data. With `--include-chat-transcript-policy`, adds read-only chat transcript retention/export policy data. With `--include-chat-send-result`, adds read-only blocked chat send-result data. With `--include-chat-composer`, adds read-only chat composer/input-control data. With `--include-chat-model-status`, adds read-only blocked chat model-status display data. With `--include-chat-session`, adds read-only blocked chat/session and lifecycle summaries. With `--include-chat-readiness`, adds read-only chat readiness checks and recovery actions. With `--include-device-session`, adds a read-only device/session status panel. With `--include-runtime-readiness`, adds a read-only runtime readiness summary. With `--backend pccx-lab`, calls `pccx-lab status --format json` and forwards the run-status envelope (exits non-zero if binary is missing or output is invalid). |
 | [`scripts/device-session-status-stub.sh`](./scripts/device-session-status-stub.sh) | Data-only device/session status JSON for the Gemma 3N E4B + KV260 target. Reports connection, model load, session, diagnostics, readiness, discovery paths, flow steps, and error taxonomy as placeholder / blocked. |
 | [`scripts/runtime-readiness-stub.sh`](./scripts/runtime-readiness-stub.sh) | Data-only runtime readiness JSON for the Gemma 3N E4B + KV260 target. Reports blocked / not yet evidence-backed. |
 | [`scripts/chat-session-stub.sh`](./scripts/chat-session-stub.sh) | Data-only standalone chat/session JSON for the Gemma 3N E4B + KV260 target. Reports disabled send controls, inactive session state, no prompt/response persistence, and readiness handoff references. |
@@ -104,6 +104,7 @@ and verify host-side prerequisites before the real engine lands.
 | [`scripts/chat-response-stream-stub.sh`](./scripts/chat-response-stream-stub.sh) | Data-only blocked chat response stream JSON for the Gemma 3N E4B + KV260 target. Reports disabled response streaming, progress, token counter, and stop-control state without opening transport, generating chunks, counting tokens, or writing transcripts. |
 | [`scripts/chat-message-list-stub.sh`](./scripts/chat-message-list-stub.sh) | Data-only empty chat message-list JSON for the Gemma 3N E4B + KV260 target. Reports an empty conversation viewport without reading a session store, transcript, prompt, response, summary, model path, runtime log, or artifact. |
 | [`scripts/chat-action-bar-stub.sh`](./scripts/chat-action-bar-stub.sh) | Data-only disabled chat action-bar JSON for the Gemma 3N E4B + KV260 target. Reports new, clear, export, retry, copy, stop, and attach controls without reading stores, transcripts, message bodies, files, clipboard data, model paths, runtime logs, or artifacts. |
+| [`scripts/chat-attachment-policy-stub.sh`](./scripts/chat-attachment-policy-stub.sh) | Data-only disabled chat attachment-policy JSON for the Gemma 3N E4B + KV260 target. Reports disabled file picker, file read, upload, import, preview, and persistence gates without reading file names, paths, metadata, contents, clipboard data, transcripts, generated artifacts, model paths, runtime logs, or artifacts. |
 | [`scripts/chat-shortcut-map-stub.sh`](./scripts/chat-shortcut-map-stub.sh) | Data-only disabled chat shortcut-map JSON for the Gemma 3N E4B + KV260 target. Reports planned keyboard accelerator and focus metadata without installing listeners, capturing key events, dispatching commands, changing focus, reading prompts, sessions, transcripts, messages, files, or clipboard data, or starting runtime paths. |
 | [`scripts/chat-transcript-policy-stub.sh`](./scripts/chat-transcript-policy-stub.sh) | Data-only chat transcript policy JSON for the Gemma 3N E4B + KV260 target. Reports retention, export, storage, and privacy policy state without reading, generating, storing, persisting, summarizing, or exporting prompt/response/transcript content. |
 | [`scripts/chat-audit-event-stub.sh`](./scripts/chat-audit-event-stub.sh) | Data-only chat audit-event JSON for the Gemma 3N E4B + KV260 target. Reports blocked send metadata, redaction policy, absent prompt/response/transcript content, and disabled audit persistence. |
@@ -133,6 +134,7 @@ bash scripts/status-stub.sh --include-chat-error-taxonomy
 bash scripts/status-stub.sh --include-chat-response-stream
 bash scripts/status-stub.sh --include-chat-message-list
 bash scripts/status-stub.sh --include-chat-action-bar
+bash scripts/status-stub.sh --include-chat-attachment-policy
 bash scripts/status-stub.sh --include-chat-shortcut-map
 bash scripts/status-stub.sh --include-device-session
 bash scripts/status-stub.sh --include-runtime-readiness
@@ -155,6 +157,7 @@ bash scripts/chat-error-taxonomy-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-response-stream-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-message-list-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-action-bar-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/chat-attachment-policy-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-shortcut-map-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-surface-preview.sh --model gemma3n-e4b --target kv260
 bash scripts/launch-stub.sh --dry-run
@@ -327,6 +330,7 @@ python3 contracts/chat_audit_event_contract.py --model gemma3n-e4b --target kv26
 python3 contracts/chat_error_taxonomy_contract.py --model gemma3n-e4b --target kv260
 python3 contracts/chat_response_stream_contract.py --model gemma3n-e4b --target kv260
 python3 contracts/chat_action_bar_contract.py --model gemma3n-e4b --target kv260
+python3 contracts/chat_attachment_policy_contract.py --model gemma3n-e4b --target kv260
 python3 contracts/chat_shortcut_map_contract.py --model gemma3n-e4b --target kv260
 python3 contracts/chat_session_title_policy_contract.py --model gemma3n-e4b --target kv260
 bash scripts/chat-model-status-stub.sh --model gemma3n-e4b --target kv260
@@ -338,6 +342,7 @@ bash scripts/chat-audit-event-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-error-taxonomy-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-response-stream-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-action-bar-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/chat-attachment-policy-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-shortcut-map-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-surface-preview.sh --model gemma3n-e4b --target kv260
 bash scripts/status-stub.sh --include-chat-model-status
@@ -347,6 +352,7 @@ bash scripts/status-stub.sh --include-chat-audit-event
 bash scripts/status-stub.sh --include-chat-error-taxonomy
 bash scripts/status-stub.sh --include-chat-response-stream
 bash scripts/status-stub.sh --include-chat-action-bar
+bash scripts/status-stub.sh --include-chat-attachment-policy
 bash scripts/status-stub.sh --include-chat-shortcut-map
 bash scripts/status-stub.sh --include-chat-session-title-policy
 python3 scripts/tests/chat_session_contract_test.py
@@ -358,6 +364,7 @@ python3 scripts/tests/chat_audit_event_contract_test.py
 python3 scripts/tests/chat_error_taxonomy_contract_test.py
 python3 scripts/tests/chat_response_stream_contract_test.py
 python3 scripts/tests/chat_action_bar_contract_test.py
+python3 scripts/tests/chat_attachment_policy_contract_test.py
 python3 scripts/tests/chat_shortcut_map_contract_test.py
 python3 scripts/tests/chat_surface_preview_test.py
 bash scripts/tests/status-chat-model-status.sh
@@ -367,6 +374,7 @@ bash scripts/tests/status-chat-audit-event.sh
 bash scripts/tests/status-chat-error-taxonomy.sh
 bash scripts/tests/status-chat-response-stream.sh
 bash scripts/tests/status-chat-action-bar.sh
+bash scripts/tests/status-chat-attachment-policy.sh
 bash scripts/tests/status-chat-shortcut-map.sh
 bash scripts/tests/status-chat-session-title-policy.sh
 ```
@@ -428,6 +436,13 @@ controls for the planned chat surface. It records new chat, clear,
 export, retry, copy, stop, and attach controls without reading session
 stores, transcripts, message bodies, files, clipboard data, model paths,
 runtime logs, or artifacts.
+
+The chat attachment-policy fixture defines the disabled local attachment
+boundary for the planned chat surface. It records file picker, file
+metadata read, file content read, upload, import, preview, and persistence
+gates without reading file names, paths, metadata, contents, clipboard
+data, transcripts, generated artifacts, model paths, runtime logs, or
+artifacts.
 
 The preview command renders that same contract as a deterministic
 terminal chat surface sketch with disabled controls, blocked reasons, and

--- a/contracts/chat_attachment_policy_contract.py
+++ b/contracts/chat_attachment_policy_contract.py
@@ -1,0 +1,497 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Data-only chat attachment policy contract for the planned launcher UI.
+
+The contract describes the disabled local attachment boundary for the
+standalone chat surface. It does not open file pickers, read file names,
+read file metadata, read file contents, upload files, import artifacts,
+read clipboard data, persist attachment state, load models, touch KV260
+hardware, call providers, invoke pccx-lab, or start runtime code.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import sys
+
+
+SCHEMA_VERSION = "pccx.chatAttachmentPolicy.v0"
+
+CHAT_ATTACHMENT_POLICY_FIELDS = (
+    "schemaVersion",
+    "attachmentPolicyId",
+    "fixtureVersion",
+    "lastUpdatedSource",
+    "targetDevice",
+    "targetBoard",
+    "targetModel",
+    "attachmentPolicyState",
+    "attachmentState",
+    "filePickerState",
+    "fileReadState",
+    "uploadState",
+    "importState",
+    "previewState",
+    "persistenceState",
+    "privacyState",
+    "chatComposerRef",
+    "chatActionBarRef",
+    "chatShortcutMapRef",
+    "chatLocalOnlyPolicyRef",
+    "chatTranscriptPolicyRef",
+    "attachmentPolicy",
+    "attachmentInputs",
+    "attachmentControls",
+    "blockedReasons",
+    "handoffRefs",
+    "safetyFlags",
+    "limitations",
+    "issueRefs",
+)
+
+ATTACHMENT_POLICY_FIELDS = (
+    "state",
+    "mode",
+    "sourcePolicy",
+    "allowedInputKinds",
+    "maxAttachmentCount",
+    "filePickerEnabled",
+    "fileMetadataReadEnabled",
+    "fileContentReadEnabled",
+    "uploadEnabled",
+    "importEnabled",
+    "previewEnabled",
+    "persistenceEnabled",
+    "sideEffectPolicy",
+    "contentPolicy",
+)
+
+ATTACHMENT_INPUT_FIELDS = (
+    "inputKind",
+    "label",
+    "state",
+    "enabled",
+    "summary",
+    "sideEffectPolicy",
+    "contentPolicy",
+)
+
+ATTACHMENT_CONTROL_FIELDS = (
+    "controlId",
+    "label",
+    "state",
+    "enabled",
+    "userAction",
+    "launcherAction",
+    "sideEffectPolicy",
+    "blockedReasonRef",
+)
+
+BLOCKED_REASON_FIELDS = (
+    "reasonId",
+    "state",
+    "summary",
+    "requiredBefore",
+)
+
+HANDOFF_REF_FIELDS = (
+    "refId",
+    "schemaVersion",
+    "fixturePath",
+    "state",
+    "summary",
+)
+
+CHAT_ATTACHMENT_POLICY_STATE_VALUES = (
+    "available_as_data",
+    "blocked",
+    "disabled",
+    "empty_not_captured",
+    "inactive",
+    "not_configured",
+    "not_loaded",
+    "not_started",
+    "placeholder",
+    "planned",
+    "requires_evidence",
+    "summary_only",
+    "target_selected",
+    "unavailable",
+)
+
+_CHAT_ATTACHMENT_POLICY = {
+    "schemaVersion": SCHEMA_VERSION,
+    "attachmentPolicyId": "chat_attachment_policy_gemma3n_e4b_kv260_placeholder",
+    "fixtureVersion": "chat-attachment-policy.gemma3n-e4b-kv260.2026-05-04",
+    "lastUpdatedSource": "pccx_launcher_issue_9_chat_attachment_policy_boundary_2026-05-04",
+    "targetDevice": "kv260",
+    "targetBoard": "xilinx_kria_kv260",
+    "targetModel": "gemma3n-e4b",
+    "attachmentPolicyState": "blocked",
+    "attachmentState": "disabled",
+    "filePickerState": "disabled",
+    "fileReadState": "blocked",
+    "uploadState": "disabled",
+    "importState": "disabled",
+    "previewState": "disabled",
+    "persistenceState": "disabled",
+    "privacyState": "summary_only",
+    "chatComposerRef": "chat_composer_gemma3n_e4b_kv260_placeholder",
+    "chatActionBarRef": "chat_action_bar_gemma3n_e4b_kv260_placeholder",
+    "chatShortcutMapRef": "chat_shortcut_map_gemma3n_e4b_kv260_placeholder",
+    "chatLocalOnlyPolicyRef": "chat_local_only_policy_gemma3n_e4b_kv260_placeholder",
+    "chatTranscriptPolicyRef": "chat_transcript_policy_gemma3n_e4b_kv260_placeholder",
+    "attachmentPolicy": {
+        "state": "blocked",
+        "mode": "disabled_until_reviewed_local_input_boundary_exists",
+        "sourcePolicy": "checked fixture only; no file picker, path, metadata, content, clipboard, transcript, artifact, model path, or runtime log is read",
+        "allowedInputKinds": [],
+        "maxAttachmentCount": 0,
+        "filePickerEnabled": False,
+        "fileMetadataReadEnabled": False,
+        "fileContentReadEnabled": False,
+        "uploadEnabled": False,
+        "importEnabled": False,
+        "previewEnabled": False,
+        "persistenceEnabled": False,
+        "sideEffectPolicy": "local_render_only",
+        "contentPolicy": "attachment policy metadata only; no file names, paths, bytes, previews, manifests, transcript text, prompt text, or response text are included",
+    },
+    "attachmentInputs": [
+        {
+            "inputKind": "local_file",
+            "label": "local file",
+            "state": "blocked",
+            "enabled": False,
+            "summary": "Local file attachments need a reviewed picker, metadata, content, redaction, and persistence boundary.",
+            "sideEffectPolicy": "no_file_picker_no_file_read",
+            "contentPolicy": "no_file_name_path_metadata_or_content",
+        },
+        {
+            "inputKind": "local_directory",
+            "label": "local directory",
+            "state": "blocked",
+            "enabled": False,
+            "summary": "Directory attachments remain out of scope until recursive discovery and redaction rules are reviewed.",
+            "sideEffectPolicy": "no_directory_scan",
+            "contentPolicy": "no_directory_path_listing_or_content",
+        },
+        {
+            "inputKind": "clipboard_payload",
+            "label": "clipboard payload",
+            "state": "disabled",
+            "enabled": False,
+            "summary": "Clipboard-backed attachments remain disabled because no clipboard read boundary exists.",
+            "sideEffectPolicy": "no_clipboard_read",
+            "contentPolicy": "no_clipboard_content",
+        },
+        {
+            "inputKind": "generated_artifact",
+            "label": "generated artifact",
+            "state": "blocked",
+            "enabled": False,
+            "summary": "Generated artifacts are not read or attached until an artifact input boundary is reviewed.",
+            "sideEffectPolicy": "no_artifact_read",
+            "contentPolicy": "no_artifact_path_metadata_or_content",
+        },
+        {
+            "inputKind": "transcript_export",
+            "label": "transcript export",
+            "state": "disabled",
+            "enabled": False,
+            "summary": "Transcript export as an attachment remains disabled until storage and redaction policy exists.",
+            "sideEffectPolicy": "no_transcript_export",
+            "contentPolicy": "no_transcript_content",
+        },
+    ],
+    "attachmentControls": [
+        {
+            "controlId": "open_file_picker",
+            "label": "open file picker",
+            "state": "disabled",
+            "enabled": False,
+            "userAction": "Choose files only after a reviewed local file-input boundary exists.",
+            "launcherAction": "Keep the picker disabled and do not ask the host for file handles.",
+            "sideEffectPolicy": "no_file_picker",
+            "blockedReasonRef": "file_picker_boundary_absent",
+        },
+        {
+            "controlId": "read_file_metadata",
+            "label": "read file metadata",
+            "state": "blocked",
+            "enabled": False,
+            "userAction": "Read file metadata only after explicit consent, filtering, and redaction policy exists.",
+            "launcherAction": "Refuse metadata reads because file input has not been reviewed.",
+            "sideEffectPolicy": "no_file_metadata_read",
+            "blockedReasonRef": "metadata_read_boundary_absent",
+        },
+        {
+            "controlId": "read_file_content",
+            "label": "read file content",
+            "state": "blocked",
+            "enabled": False,
+            "userAction": "Read attachment content only after local parsing and redaction rules are reviewed.",
+            "launcherAction": "Refuse content reads because no attachment ingestion boundary exists.",
+            "sideEffectPolicy": "no_file_content_read",
+            "blockedReasonRef": "file_content_read_boundary_absent",
+        },
+        {
+            "controlId": "import_attachment",
+            "label": "import attachment",
+            "state": "disabled",
+            "enabled": False,
+            "userAction": "Import only after type limits, size limits, redaction, and persistence review.",
+            "launcherAction": "Keep import disabled and do not copy, parse, or index any file.",
+            "sideEffectPolicy": "no_import_no_copy_no_parse",
+            "blockedReasonRef": "import_export_boundary_absent",
+        },
+        {
+            "controlId": "upload_attachment",
+            "label": "upload attachment",
+            "state": "disabled",
+            "enabled": False,
+            "userAction": "Upload remains unavailable for the local-only chat surface.",
+            "launcherAction": "Do not upload attachment data or call cloud/provider endpoints.",
+            "sideEffectPolicy": "no_upload_no_network",
+            "blockedReasonRef": "local_only_upload_block",
+        },
+        {
+            "controlId": "preview_attachment",
+            "label": "preview attachment",
+            "state": "disabled",
+            "enabled": False,
+            "userAction": "Preview only after file read, rendering, and redaction boundaries exist.",
+            "launcherAction": "Keep preview disabled because no attachment bytes may be read.",
+            "sideEffectPolicy": "no_preview_no_file_read",
+            "blockedReasonRef": "file_content_read_boundary_absent",
+        },
+        {
+            "controlId": "persist_attachment",
+            "label": "persist attachment",
+            "state": "disabled",
+            "enabled": False,
+            "userAction": "Persist only after a reviewed local store and deletion policy exists.",
+            "launcherAction": "Refuse attachment persistence because no storage boundary exists.",
+            "sideEffectPolicy": "no_artifact_write",
+            "blockedReasonRef": "attachment_persistence_boundary_absent",
+        },
+    ],
+    "blockedReasons": [
+        {
+            "reasonId": "attachment_runtime_not_reviewed",
+            "state": "blocked",
+            "summary": "Attachment ingestion requires separate local parser, redaction, and storage review.",
+            "requiredBefore": "attachment_enabled",
+        },
+        {
+            "reasonId": "file_picker_boundary_absent",
+            "state": "planned",
+            "summary": "No reviewed file-picker or explicit user-selection boundary exists.",
+            "requiredBefore": "open_file_picker_enabled",
+        },
+        {
+            "reasonId": "metadata_read_boundary_absent",
+            "state": "planned",
+            "summary": "No reviewed file metadata read boundary exists.",
+            "requiredBefore": "read_file_metadata_enabled",
+        },
+        {
+            "reasonId": "file_content_read_boundary_absent",
+            "state": "planned",
+            "summary": "No reviewed file content read, parser, size-limit, or redaction boundary exists.",
+            "requiredBefore": "read_file_content_enabled",
+        },
+        {
+            "reasonId": "import_export_boundary_absent",
+            "state": "not_configured",
+            "summary": "No import, copy, export, or attachment manifest boundary is configured.",
+            "requiredBefore": "import_attachment_enabled",
+        },
+        {
+            "reasonId": "attachment_persistence_boundary_absent",
+            "state": "requires_evidence",
+            "summary": "Attachment persistence needs explicit local store, retention, deletion, and rollback policy.",
+            "requiredBefore": "persist_attachment_enabled",
+        },
+        {
+            "reasonId": "local_only_upload_block",
+            "state": "disabled",
+            "summary": "The standalone chat surface keeps upload and cloud/provider attachment handoff disabled.",
+            "requiredBefore": "upload_attachment_enabled",
+        },
+        {
+            "reasonId": "clipboard_boundary_absent",
+            "state": "not_configured",
+            "summary": "No clipboard-read boundary exists for attachment payloads.",
+            "requiredBefore": "clipboard_attachment_enabled",
+        },
+    ],
+    "handoffRefs": [
+        {
+            "refId": "chat_composer",
+            "schemaVersion": "pccx.chatComposer.v0",
+            "fixturePath": "contracts/fixtures/chat-composer.gemma3n-e4b-kv260-placeholder.json",
+            "state": "blocked",
+            "summary": "Composer attach controls remain disabled and do not read files.",
+        },
+        {
+            "refId": "chat_action_bar",
+            "schemaVersion": "pccx.chatActionBar.v0",
+            "fixturePath": "contracts/fixtures/chat-action-bar.gemma3n-e4b-kv260-placeholder.json",
+            "state": "disabled",
+            "summary": "Action-bar attach control remains disabled.",
+        },
+        {
+            "refId": "chat_shortcut_map",
+            "schemaVersion": "pccx.chatShortcutMap.v0",
+            "fixturePath": "contracts/fixtures/chat-shortcut-map.gemma3n-e4b-kv260-placeholder.json",
+            "state": "planned",
+            "summary": "Shortcut-map attach binding remains disabled and dispatch-free.",
+        },
+        {
+            "refId": "chat_local_only_policy",
+            "schemaVersion": "pccx.chatLocalOnlyPolicy.v0",
+            "fixturePath": "contracts/fixtures/chat-local-only-policy.gemma3n-e4b-kv260-placeholder.json",
+            "state": "available_as_data",
+            "summary": "Local-only policy keeps cloud/provider fallback disabled.",
+        },
+        {
+            "refId": "chat_transcript_policy",
+            "schemaVersion": "pccx.chatTranscriptPolicy.v0",
+            "fixturePath": "contracts/fixtures/chat-transcript-policy.gemma3n-e4b-kv260-placeholder.json",
+            "state": "disabled",
+            "summary": "Transcript export and persistence remain disabled.",
+        },
+    ],
+    "safetyFlags": {
+        "dataOnly": True,
+        "readOnly": True,
+        "deterministic": True,
+        "attachmentPolicyDisplayOnly": True,
+        "attachmentMetadataOnly": True,
+        "attachmentsEnabled": False,
+        "attachmentListIncluded": False,
+        "filePickerOpened": False,
+        "fileMetadataRead": False,
+        "fileContentRead": False,
+        "fileNameIncluded": False,
+        "filePathIncluded": False,
+        "fileBytesIncluded": False,
+        "directoryScan": False,
+        "attachmentReads": False,
+        "attachmentPersistence": False,
+        "fileUpload": False,
+        "fileImport": False,
+        "filePreview": False,
+        "clipboardRead": False,
+        "clipboardWrite": False,
+        "writesArtifacts": False,
+        "readsArtifacts": False,
+        "artifactWrites": False,
+        "artifactReads": False,
+        "readsSessionStore": False,
+        "readsTranscript": False,
+        "transcriptExport": False,
+        "transcriptPersistence": False,
+        "promptCapture": False,
+        "promptContentIncluded": False,
+        "promptEchoed": False,
+        "promptPersistence": False,
+        "inputAccepted": False,
+        "sendAttempted": False,
+        "responseContentIncluded": False,
+        "responseGenerated": False,
+        "messageBodiesIncluded": False,
+        "modelAssetRead": False,
+        "modelAssetPathsIncluded": False,
+        "modelWeightPathsIncluded": False,
+        "modelLoadAttempted": False,
+        "modelLoaded": False,
+        "modelExecution": False,
+        "runtimeExecution": False,
+        "touchesHardware": False,
+        "hardwareAccess": False,
+        "kv260Access": False,
+        "opensSerialPort": False,
+        "networkCalls": False,
+        "networkScan": False,
+        "sshExecution": False,
+        "providerCalls": False,
+        "cloudCalls": False,
+        "configRead": False,
+        "environmentRead": False,
+        "providerConfigRead": False,
+        "privatePathsIncluded": False,
+        "secretsIncluded": False,
+        "tokensIncluded": False,
+        "generatedBlobsIncluded": False,
+        "hardwareDumpsIncluded": False,
+        "runtimeLogsIncluded": False,
+        "telemetry": False,
+        "automaticUpload": False,
+        "writeBack": False,
+        "executesPccxLab": False,
+        "executesSystemverilogIde": False,
+        "mcpServerImplemented": False,
+        "lspImplemented": False,
+        "stableApiAbiClaim": False,
+    },
+    "limitations": [
+        "Data-only chat attachment-policy fixture; no real attachment input boundary is configured or read.",
+        "Attachment controls remain disabled or blocked; no file picker opens and no file name, path, metadata, bytes, preview, transcript, prompt, response, model path, runtime log, private path, secret, or token content is included.",
+        "No local file, directory, clipboard payload, generated artifact, transcript export, or attachment manifest is read, imported, uploaded, copied, parsed, indexed, persisted, deleted, or written.",
+        "No model load, runtime execution, provider call, network call, pccx-lab invocation, systemverilog-ide invocation, or KV260 hardware access is performed.",
+        "This is not a release, tag, compatibility commitment, MCP, LSP, IDE, marketplace, telemetry, runtime, model, parser, file-input, or storage implementation.",
+    ],
+    "issueRefs": [
+        "pccxai/pccx-llm-launcher#9",
+    ],
+}
+
+
+def create_gemma3n_e4b_kv260_chat_attachment_policy() -> dict:
+    """Return the checked Gemma 3N E4B plus KV260 attachment-policy fixture."""
+    return copy.deepcopy(_CHAT_ATTACHMENT_POLICY)
+
+
+def chat_attachment_policy_json(policy: dict | None = None) -> str:
+    """Render a deterministic JSON representation."""
+    return json.dumps(
+        policy
+        if policy is not None
+        else create_gemma3n_e4b_kv260_chat_attachment_policy(),
+        indent=2,
+        sort_keys=True,
+    ) + "\n"
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Print data-only chat attachment policy JSON.",
+    )
+    parser.add_argument(
+        "--model",
+        default="gemma3n-e4b",
+        choices=("gemma3n-e4b",),
+        help="model descriptor target",
+    )
+    parser.add_argument(
+        "--target",
+        default="kv260",
+        choices=("kv260",),
+        help="target board/device",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parse_args(sys.argv[1:] if argv is None else argv)
+    sys.stdout.write(chat_attachment_policy_json())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contracts/fixtures/chat-attachment-policy.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-attachment-policy.gemma3n-e4b-kv260-placeholder.json
@@ -1,0 +1,328 @@
+{
+  "attachmentControls": [
+    {
+      "blockedReasonRef": "file_picker_boundary_absent",
+      "controlId": "open_file_picker",
+      "enabled": false,
+      "label": "open file picker",
+      "launcherAction": "Keep the picker disabled and do not ask the host for file handles.",
+      "sideEffectPolicy": "no_file_picker",
+      "state": "disabled",
+      "userAction": "Choose files only after a reviewed local file-input boundary exists."
+    },
+    {
+      "blockedReasonRef": "metadata_read_boundary_absent",
+      "controlId": "read_file_metadata",
+      "enabled": false,
+      "label": "read file metadata",
+      "launcherAction": "Refuse metadata reads because file input has not been reviewed.",
+      "sideEffectPolicy": "no_file_metadata_read",
+      "state": "blocked",
+      "userAction": "Read file metadata only after explicit consent, filtering, and redaction policy exists."
+    },
+    {
+      "blockedReasonRef": "file_content_read_boundary_absent",
+      "controlId": "read_file_content",
+      "enabled": false,
+      "label": "read file content",
+      "launcherAction": "Refuse content reads because no attachment ingestion boundary exists.",
+      "sideEffectPolicy": "no_file_content_read",
+      "state": "blocked",
+      "userAction": "Read attachment content only after local parsing and redaction rules are reviewed."
+    },
+    {
+      "blockedReasonRef": "import_export_boundary_absent",
+      "controlId": "import_attachment",
+      "enabled": false,
+      "label": "import attachment",
+      "launcherAction": "Keep import disabled and do not copy, parse, or index any file.",
+      "sideEffectPolicy": "no_import_no_copy_no_parse",
+      "state": "disabled",
+      "userAction": "Import only after type limits, size limits, redaction, and persistence review."
+    },
+    {
+      "blockedReasonRef": "local_only_upload_block",
+      "controlId": "upload_attachment",
+      "enabled": false,
+      "label": "upload attachment",
+      "launcherAction": "Do not upload attachment data or call cloud/provider endpoints.",
+      "sideEffectPolicy": "no_upload_no_network",
+      "state": "disabled",
+      "userAction": "Upload remains unavailable for the local-only chat surface."
+    },
+    {
+      "blockedReasonRef": "file_content_read_boundary_absent",
+      "controlId": "preview_attachment",
+      "enabled": false,
+      "label": "preview attachment",
+      "launcherAction": "Keep preview disabled because no attachment bytes may be read.",
+      "sideEffectPolicy": "no_preview_no_file_read",
+      "state": "disabled",
+      "userAction": "Preview only after file read, rendering, and redaction boundaries exist."
+    },
+    {
+      "blockedReasonRef": "attachment_persistence_boundary_absent",
+      "controlId": "persist_attachment",
+      "enabled": false,
+      "label": "persist attachment",
+      "launcherAction": "Refuse attachment persistence because no storage boundary exists.",
+      "sideEffectPolicy": "no_artifact_write",
+      "state": "disabled",
+      "userAction": "Persist only after a reviewed local store and deletion policy exists."
+    }
+  ],
+  "attachmentInputs": [
+    {
+      "contentPolicy": "no_file_name_path_metadata_or_content",
+      "enabled": false,
+      "inputKind": "local_file",
+      "label": "local file",
+      "sideEffectPolicy": "no_file_picker_no_file_read",
+      "state": "blocked",
+      "summary": "Local file attachments need a reviewed picker, metadata, content, redaction, and persistence boundary."
+    },
+    {
+      "contentPolicy": "no_directory_path_listing_or_content",
+      "enabled": false,
+      "inputKind": "local_directory",
+      "label": "local directory",
+      "sideEffectPolicy": "no_directory_scan",
+      "state": "blocked",
+      "summary": "Directory attachments remain out of scope until recursive discovery and redaction rules are reviewed."
+    },
+    {
+      "contentPolicy": "no_clipboard_content",
+      "enabled": false,
+      "inputKind": "clipboard_payload",
+      "label": "clipboard payload",
+      "sideEffectPolicy": "no_clipboard_read",
+      "state": "disabled",
+      "summary": "Clipboard-backed attachments remain disabled because no clipboard read boundary exists."
+    },
+    {
+      "contentPolicy": "no_artifact_path_metadata_or_content",
+      "enabled": false,
+      "inputKind": "generated_artifact",
+      "label": "generated artifact",
+      "sideEffectPolicy": "no_artifact_read",
+      "state": "blocked",
+      "summary": "Generated artifacts are not read or attached until an artifact input boundary is reviewed."
+    },
+    {
+      "contentPolicy": "no_transcript_content",
+      "enabled": false,
+      "inputKind": "transcript_export",
+      "label": "transcript export",
+      "sideEffectPolicy": "no_transcript_export",
+      "state": "disabled",
+      "summary": "Transcript export as an attachment remains disabled until storage and redaction policy exists."
+    }
+  ],
+  "attachmentPolicy": {
+    "allowedInputKinds": [],
+    "contentPolicy": "attachment policy metadata only; no file names, paths, bytes, previews, manifests, transcript text, prompt text, or response text are included",
+    "fileContentReadEnabled": false,
+    "fileMetadataReadEnabled": false,
+    "filePickerEnabled": false,
+    "importEnabled": false,
+    "maxAttachmentCount": 0,
+    "mode": "disabled_until_reviewed_local_input_boundary_exists",
+    "persistenceEnabled": false,
+    "previewEnabled": false,
+    "sideEffectPolicy": "local_render_only",
+    "sourcePolicy": "checked fixture only; no file picker, path, metadata, content, clipboard, transcript, artifact, model path, or runtime log is read",
+    "state": "blocked",
+    "uploadEnabled": false
+  },
+  "attachmentPolicyId": "chat_attachment_policy_gemma3n_e4b_kv260_placeholder",
+  "attachmentPolicyState": "blocked",
+  "attachmentState": "disabled",
+  "blockedReasons": [
+    {
+      "reasonId": "attachment_runtime_not_reviewed",
+      "requiredBefore": "attachment_enabled",
+      "state": "blocked",
+      "summary": "Attachment ingestion requires separate local parser, redaction, and storage review."
+    },
+    {
+      "reasonId": "file_picker_boundary_absent",
+      "requiredBefore": "open_file_picker_enabled",
+      "state": "planned",
+      "summary": "No reviewed file-picker or explicit user-selection boundary exists."
+    },
+    {
+      "reasonId": "metadata_read_boundary_absent",
+      "requiredBefore": "read_file_metadata_enabled",
+      "state": "planned",
+      "summary": "No reviewed file metadata read boundary exists."
+    },
+    {
+      "reasonId": "file_content_read_boundary_absent",
+      "requiredBefore": "read_file_content_enabled",
+      "state": "planned",
+      "summary": "No reviewed file content read, parser, size-limit, or redaction boundary exists."
+    },
+    {
+      "reasonId": "import_export_boundary_absent",
+      "requiredBefore": "import_attachment_enabled",
+      "state": "not_configured",
+      "summary": "No import, copy, export, or attachment manifest boundary is configured."
+    },
+    {
+      "reasonId": "attachment_persistence_boundary_absent",
+      "requiredBefore": "persist_attachment_enabled",
+      "state": "requires_evidence",
+      "summary": "Attachment persistence needs explicit local store, retention, deletion, and rollback policy."
+    },
+    {
+      "reasonId": "local_only_upload_block",
+      "requiredBefore": "upload_attachment_enabled",
+      "state": "disabled",
+      "summary": "The standalone chat surface keeps upload and cloud/provider attachment handoff disabled."
+    },
+    {
+      "reasonId": "clipboard_boundary_absent",
+      "requiredBefore": "clipboard_attachment_enabled",
+      "state": "not_configured",
+      "summary": "No clipboard-read boundary exists for attachment payloads."
+    }
+  ],
+  "chatActionBarRef": "chat_action_bar_gemma3n_e4b_kv260_placeholder",
+  "chatComposerRef": "chat_composer_gemma3n_e4b_kv260_placeholder",
+  "chatLocalOnlyPolicyRef": "chat_local_only_policy_gemma3n_e4b_kv260_placeholder",
+  "chatShortcutMapRef": "chat_shortcut_map_gemma3n_e4b_kv260_placeholder",
+  "chatTranscriptPolicyRef": "chat_transcript_policy_gemma3n_e4b_kv260_placeholder",
+  "filePickerState": "disabled",
+  "fileReadState": "blocked",
+  "fixtureVersion": "chat-attachment-policy.gemma3n-e4b-kv260.2026-05-04",
+  "handoffRefs": [
+    {
+      "fixturePath": "contracts/fixtures/chat-composer.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_composer",
+      "schemaVersion": "pccx.chatComposer.v0",
+      "state": "blocked",
+      "summary": "Composer attach controls remain disabled and do not read files."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-action-bar.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_action_bar",
+      "schemaVersion": "pccx.chatActionBar.v0",
+      "state": "disabled",
+      "summary": "Action-bar attach control remains disabled."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-shortcut-map.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_shortcut_map",
+      "schemaVersion": "pccx.chatShortcutMap.v0",
+      "state": "planned",
+      "summary": "Shortcut-map attach binding remains disabled and dispatch-free."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-local-only-policy.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_local_only_policy",
+      "schemaVersion": "pccx.chatLocalOnlyPolicy.v0",
+      "state": "available_as_data",
+      "summary": "Local-only policy keeps cloud/provider fallback disabled."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-transcript-policy.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_transcript_policy",
+      "schemaVersion": "pccx.chatTranscriptPolicy.v0",
+      "state": "disabled",
+      "summary": "Transcript export and persistence remain disabled."
+    }
+  ],
+  "importState": "disabled",
+  "issueRefs": [
+    "pccxai/pccx-llm-launcher#9"
+  ],
+  "lastUpdatedSource": "pccx_launcher_issue_9_chat_attachment_policy_boundary_2026-05-04",
+  "limitations": [
+    "Data-only chat attachment-policy fixture; no real attachment input boundary is configured or read.",
+    "Attachment controls remain disabled or blocked; no file picker opens and no file name, path, metadata, bytes, preview, transcript, prompt, response, model path, runtime log, private path, secret, or token content is included.",
+    "No local file, directory, clipboard payload, generated artifact, transcript export, or attachment manifest is read, imported, uploaded, copied, parsed, indexed, persisted, deleted, or written.",
+    "No model load, runtime execution, provider call, network call, pccx-lab invocation, systemverilog-ide invocation, or KV260 hardware access is performed.",
+    "This is not a release, tag, compatibility commitment, MCP, LSP, IDE, marketplace, telemetry, runtime, model, parser, file-input, or storage implementation."
+  ],
+  "persistenceState": "disabled",
+  "previewState": "disabled",
+  "privacyState": "summary_only",
+  "safetyFlags": {
+    "artifactReads": false,
+    "artifactWrites": false,
+    "attachmentListIncluded": false,
+    "attachmentMetadataOnly": true,
+    "attachmentPersistence": false,
+    "attachmentPolicyDisplayOnly": true,
+    "attachmentReads": false,
+    "attachmentsEnabled": false,
+    "automaticUpload": false,
+    "clipboardRead": false,
+    "clipboardWrite": false,
+    "cloudCalls": false,
+    "configRead": false,
+    "dataOnly": true,
+    "deterministic": true,
+    "directoryScan": false,
+    "environmentRead": false,
+    "executesPccxLab": false,
+    "executesSystemverilogIde": false,
+    "fileBytesIncluded": false,
+    "fileContentRead": false,
+    "fileImport": false,
+    "fileMetadataRead": false,
+    "fileNameIncluded": false,
+    "filePathIncluded": false,
+    "filePickerOpened": false,
+    "filePreview": false,
+    "fileUpload": false,
+    "generatedBlobsIncluded": false,
+    "hardwareAccess": false,
+    "hardwareDumpsIncluded": false,
+    "inputAccepted": false,
+    "kv260Access": false,
+    "lspImplemented": false,
+    "mcpServerImplemented": false,
+    "messageBodiesIncluded": false,
+    "modelAssetPathsIncluded": false,
+    "modelAssetRead": false,
+    "modelExecution": false,
+    "modelLoadAttempted": false,
+    "modelLoaded": false,
+    "modelWeightPathsIncluded": false,
+    "networkCalls": false,
+    "networkScan": false,
+    "opensSerialPort": false,
+    "privatePathsIncluded": false,
+    "promptCapture": false,
+    "promptContentIncluded": false,
+    "promptEchoed": false,
+    "promptPersistence": false,
+    "providerCalls": false,
+    "providerConfigRead": false,
+    "readOnly": true,
+    "readsArtifacts": false,
+    "readsSessionStore": false,
+    "readsTranscript": false,
+    "responseContentIncluded": false,
+    "responseGenerated": false,
+    "runtimeExecution": false,
+    "runtimeLogsIncluded": false,
+    "secretsIncluded": false,
+    "sendAttempted": false,
+    "sshExecution": false,
+    "stableApiAbiClaim": false,
+    "telemetry": false,
+    "tokensIncluded": false,
+    "touchesHardware": false,
+    "transcriptExport": false,
+    "transcriptPersistence": false,
+    "writeBack": false,
+    "writesArtifacts": false
+  },
+  "schemaVersion": "pccx.chatAttachmentPolicy.v0",
+  "targetBoard": "xilinx_kria_kv260",
+  "targetDevice": "kv260",
+  "targetModel": "gemma3n-e4b",
+  "uploadState": "disabled"
+}

--- a/docs/STANDALONE_CHAT_SESSION_CONTRACT.md
+++ b/docs/STANDALONE_CHAT_SESSION_CONTRACT.md
@@ -24,6 +24,7 @@ The implementation lives in:
 - `contracts/chat_error_taxonomy_contract.py`
 - `contracts/chat_message_list_contract.py`
 - `contracts/chat_action_bar_contract.py`
+- `contracts/chat_attachment_policy_contract.py`
 - `contracts/chat_shortcut_map_contract.py`
 - `contracts/fixtures/chat-session.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-model-status.gemma3n-e4b-kv260-placeholder.json`
@@ -41,6 +42,7 @@ The implementation lives in:
 - `contracts/fixtures/chat-error-taxonomy.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-message-list.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-action-bar.gemma3n-e4b-kv260-placeholder.json`
+- `contracts/fixtures/chat-attachment-policy.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-shortcut-map.gemma3n-e4b-kv260-placeholder.json`
 - `scripts/chat-session-stub.sh`
 - `scripts/chat-model-status-stub.sh`
@@ -58,6 +60,7 @@ The implementation lives in:
 - `scripts/chat-error-taxonomy-stub.sh`
 - `scripts/chat-message-list-stub.sh`
 - `scripts/chat-action-bar-stub.sh`
+- `scripts/chat-attachment-policy-stub.sh`
 - `scripts/chat-shortcut-map-stub.sh`
 - `scripts/chat-surface-preview.sh`
 - `scripts/tests/chat_session_contract_test.py`
@@ -76,6 +79,7 @@ The implementation lives in:
 - `scripts/tests/chat_error_taxonomy_contract_test.py`
 - `scripts/tests/chat_message_list_contract_test.py`
 - `scripts/tests/chat_action_bar_contract_test.py`
+- `scripts/tests/chat_attachment_policy_contract_test.py`
 - `scripts/tests/chat_shortcut_map_contract_test.py`
 - `scripts/tests/chat_surface_preview_test.py`
 - `scripts/tests/status-chat-model-status.sh`
@@ -93,6 +97,7 @@ The implementation lives in:
 - `scripts/tests/status-chat-response-stream.sh`
 - `scripts/tests/status-chat-message-list.sh`
 - `scripts/tests/status-chat-action-bar.sh`
+- `scripts/tests/status-chat-attachment-policy.sh`
 - `scripts/tests/status-chat-shortcut-map.sh`
 
 ## What Is Implemented
@@ -127,6 +132,8 @@ The chat/session contract records:
   message bodies or transcript reads
 - disabled action-bar metadata for new, clear, export, retry, copy, stop,
   and attach controls without side effects
+- disabled attachment-policy metadata for file picker, file read, upload,
+  import, preview, and persistence gates without side effects
 - disabled shortcut-map metadata for planned keyboard accelerators,
   focus, and navigation without listeners, capture, dispatch, or side
   effects
@@ -322,6 +329,22 @@ unavailable, or planned. No session store or transcript is read, no
 message body is included, no transcript is exported, no clipboard or file
 operation is performed, no stop signal is sent, no model or runtime path
 is started, and no artifact is written.
+
+The chat attachment-policy fixture records the disabled local attachment
+boundary used by the planned standalone chat surface:
+
+```bash
+bash scripts/chat-attachment-policy-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/status-stub.sh --include-chat-attachment-policy
+```
+
+It keeps attachment handling as local metadata: file picker, file
+metadata read, file content read, upload, import, preview, and persistence
+gates remain disabled, blocked, or not configured. No file picker opens,
+no file name, path, metadata, bytes, directory listing, clipboard data,
+transcript, generated artifact, model path, runtime log, or artifact is
+read or written, no upload is attempted, no import/export runs, no model
+or runtime path is started, and no target access occurs.
 
 The chat shortcut-map fixture records the disabled keyboard shortcut map
 for the planned standalone chat surface:
@@ -642,6 +665,12 @@ session creation, conversation clearing, transcript export, clipboard
 writes, attachment reads, retry attempts, stop signals, runtime
 execution, model loading, provider calls, artifact writes, or target
 access.
+The attachment-policy contract adds a reviewable disabled file-input
+policy shape without opening pickers, reading file names, paths, metadata,
+contents, directory listings, clipboard payloads, transcripts, generated
+artifacts, model paths, runtime logs, artifact reads, uploads, imports,
+persistence, runtime execution, model loading, provider calls, or target
+access.
 
 pccx-lab remains a separate CLI/core diagnostics and verification
 backend. systemverilog-ide may consume launcher data later as read-only
@@ -662,6 +691,9 @@ This chat/session surface does not add:
 - action-bar execution, session creation, conversation clearing,
   transcript export, clipboard writes, retry attempts, stop signals, file
   attachment reads, or action persistence
+- attachment-policy execution, file picker opening, file-name/path reads,
+  file metadata reads, file content reads, directory scans, clipboard
+  attachment reads, uploads, imports, previews, or persistence
 - transcript retention, transcript export, local transcript storage,
   transcript summaries, or transcript message content
 - audit logging, audit persistence, actor identifiers, event timestamps,

--- a/scripts/chat-attachment-policy-stub.sh
+++ b/scripts/chat-attachment-policy-stub.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+# Print the data-only chat attachment-policy contract.
+
+set -eu
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+
+python3 "$ROOT_DIR/contracts/chat_attachment_policy_contract.py" "$@"

--- a/scripts/status-stub.sh
+++ b/scripts/status-stub.sh
@@ -58,6 +58,9 @@
 # Chat action-bar controls boundary (explicit opt-in, read-only local data):
 #   --include-chat-action-bar
 #
+# Chat attachment-policy boundary (explicit opt-in, read-only local data):
+#   --include-chat-attachment-policy
+#
 # Chat shortcut-map boundary (explicit opt-in, read-only local data):
 #   --include-chat-shortcut-map
 #
@@ -94,6 +97,7 @@ INCLUDE_CHAT_ERROR_TAXONOMY="0"
 INCLUDE_CHAT_RESPONSE_STREAM="0"
 INCLUDE_CHAT_MESSAGE_LIST="0"
 INCLUDE_CHAT_ACTION_BAR="0"
+INCLUDE_CHAT_ATTACHMENT_POLICY="0"
 INCLUDE_CHAT_SHORTCUT_MAP="0"
 
 print_chat_error_taxonomy_summary() {
@@ -510,6 +514,137 @@ print(
 
     HEAD "chat action bar"
     printf '%s\n' "$CHAT_ACTION_BAR_SUMMARY"
+}
+
+print_chat_attachment_policy_summary() {
+    SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+    ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+    CHAT_ATTACHMENT_POLICY_STUB="$ROOT_DIR/scripts/chat-attachment-policy-stub.sh"
+
+    if [ ! -f "$CHAT_ATTACHMENT_POLICY_STUB" ]; then
+        ERROR "chat attachment-policy stub not found: $CHAT_ATTACHMENT_POLICY_STUB"
+        return 1
+    fi
+
+    if ! CHAT_ATTACHMENT_POLICY_JSON="$(bash "$CHAT_ATTACHMENT_POLICY_STUB" --model gemma3n-e4b --target kv260 2>&1)"; then
+        ERROR "chat attachment-policy stub failed"
+        printf '%s\n' "$CHAT_ATTACHMENT_POLICY_JSON" >&2
+        return 1
+    fi
+
+    if ! CHAT_ATTACHMENT_POLICY_SUMMARY="$(
+        printf '%s\n' "$CHAT_ATTACHMENT_POLICY_JSON" | python3 -c '
+import json
+import sys
+
+data = json.load(sys.stdin)
+flags = data["safetyFlags"]
+policy = data["attachmentPolicy"]
+
+def b(value):
+    return "true" if value else "false"
+
+inputs = " ".join(
+    "{}={}:{}".format(input_item["inputKind"], input_item["state"], b(input_item["enabled"]))
+    for input_item in data["attachmentInputs"]
+)
+controls = " ".join(
+    "{}={}:{}".format(control["controlId"], control["state"], b(control["enabled"]))
+    for control in data["attachmentControls"]
+)
+blocked = " ".join(
+    "{}={}".format(reason["reasonId"], reason["state"])
+    for reason in data["blockedReasons"]
+)
+
+print("[INFO]  source     : scripts/chat-attachment-policy-stub.sh --model gemma3n-e4b --target kv260")
+print("[INFO]  boundary   : read-only data; no file picker/file metadata/file content/upload/import/clipboard/model/runtime/hardware/lab/IDE execution")
+print("[INFO]  target     : {}".format(data["targetDevice"]))
+print("[INFO]  model      : {}".format(data["targetModel"]))
+print("[INFO]  policy     : {}".format(data["attachmentPolicyState"]))
+print("[INFO]  attachment : {}".format(data["attachmentState"]))
+print("[INFO]  file picker: {}".format(data["filePickerState"]))
+print("[INFO]  file read  : {}".format(data["fileReadState"]))
+print("[INFO]  upload     : {}".format(data["uploadState"]))
+print("[INFO]  import     : {}".format(data["importState"]))
+print("[INFO]  preview    : {}".format(data["previewState"]))
+print("[INFO]  persistence: {}".format(data["persistenceState"]))
+print("[INFO]  privacy    : {}".format(data["privacyState"]))
+print(
+    "[INFO]  attachment-policy : {} mode={} maxAttachmentCount={} "
+    "filePickerEnabled={} fileMetadataReadEnabled={} "
+    "fileContentReadEnabled={} uploadEnabled={} importEnabled={} "
+    "previewEnabled={} persistenceEnabled={}".format(
+        policy["state"],
+        policy["mode"],
+        policy["maxAttachmentCount"],
+        b(policy["filePickerEnabled"]),
+        b(policy["fileMetadataReadEnabled"]),
+        b(policy["fileContentReadEnabled"]),
+        b(policy["uploadEnabled"]),
+        b(policy["importEnabled"]),
+        b(policy["previewEnabled"]),
+        b(policy["persistenceEnabled"]),
+    )
+)
+print("[INFO]  inputs     : {}".format(inputs))
+print("[INFO]  controls   : {}".format(controls))
+print("[INFO]  blocked    : {}".format(blocked))
+print(
+    "[INFO]  flags      : readOnly={} dataOnly={} deterministic={} "
+    "attachmentPolicyDisplayOnly={} attachmentMetadataOnly={} "
+    "attachmentsEnabled={} filePickerOpened={} fileMetadataRead={} "
+    "fileContentRead={} fileNameIncluded={} filePathIncluded={} "
+    "fileBytesIncluded={} directoryScan={} attachmentReads={} "
+    "attachmentPersistence={} fileUpload={} fileImport={} "
+    "filePreview={} clipboardRead={} writesArtifacts={} "
+    "readsArtifacts={} readsTranscript={} transcriptExport={} "
+    "promptContentIncluded={} responseContentIncluded={} "
+    "modelExecution={} runtimeExecution={} kv260Access={} "
+    "hardwareAccess={} networkCalls={} providerCalls={} "
+    "executesPccxLab={}".format(
+        b(flags["readOnly"]),
+        b(flags["dataOnly"]),
+        b(flags["deterministic"]),
+        b(flags["attachmentPolicyDisplayOnly"]),
+        b(flags["attachmentMetadataOnly"]),
+        b(flags["attachmentsEnabled"]),
+        b(flags["filePickerOpened"]),
+        b(flags["fileMetadataRead"]),
+        b(flags["fileContentRead"]),
+        b(flags["fileNameIncluded"]),
+        b(flags["filePathIncluded"]),
+        b(flags["fileBytesIncluded"]),
+        b(flags["directoryScan"]),
+        b(flags["attachmentReads"]),
+        b(flags["attachmentPersistence"]),
+        b(flags["fileUpload"]),
+        b(flags["fileImport"]),
+        b(flags["filePreview"]),
+        b(flags["clipboardRead"]),
+        b(flags["writesArtifacts"]),
+        b(flags["readsArtifacts"]),
+        b(flags["readsTranscript"]),
+        b(flags["transcriptExport"]),
+        b(flags["promptContentIncluded"]),
+        b(flags["responseContentIncluded"]),
+        b(flags["modelExecution"]),
+        b(flags["runtimeExecution"]),
+        b(flags["kv260Access"]),
+        b(flags["hardwareAccess"]),
+        b(flags["networkCalls"]),
+        b(flags["providerCalls"]),
+        b(flags["executesPccxLab"]),
+    )
+)
+'
+    )"; then
+        ERROR "chat attachment-policy JSON could not be summarized"
+        return 1
+    fi
+
+    HEAD "chat attachment policy"
+    printf '%s\n' "$CHAT_ATTACHMENT_POLICY_SUMMARY"
 }
 
 print_chat_shortcut_map_summary() {
@@ -2132,6 +2267,10 @@ while [ $# -gt 0 ]; do
             INCLUDE_CHAT_ACTION_BAR="1"
             shift
             ;;
+        --include-chat-attachment-policy)
+            INCLUDE_CHAT_ATTACHMENT_POLICY="1"
+            shift
+            ;;
         --include-chat-shortcut-map)
             INCLUDE_CHAT_SHORTCUT_MAP="1"
             shift
@@ -2151,8 +2290,8 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-if [ -n "$BACKEND" ] && { [ "$INCLUDE_RUNTIME_READINESS" = "1" ] || [ "$INCLUDE_DEVICE_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SURFACE_LAYOUT" = "1" ] || [ "$INCLUDE_CHAT_LOCAL_ONLY_POLICY" = "1" ] || [ "$INCLUDE_CHAT_PREFERENCES" = "1" ] || [ "$INCLUDE_CHAT_SESSION_INDEX" = "1" ] || [ "$INCLUDE_CHAT_SESSION_TITLE_POLICY" = "1" ] || [ "$INCLUDE_CHAT_MODEL_STATUS" = "1" ] || [ "$INCLUDE_CHAT_READINESS" = "1" ] || [ "$INCLUDE_CHAT_COMPOSER" = "1" ] || [ "$INCLUDE_CHAT_SEND_RESULT" = "1" ] || [ "$INCLUDE_CHAT_TRANSCRIPT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_AUDIT_EVENT" = "1" ] || [ "$INCLUDE_CHAT_ERROR_TAXONOMY" = "1" ] || [ "$INCLUDE_CHAT_RESPONSE_STREAM" = "1" ] || [ "$INCLUDE_CHAT_MESSAGE_LIST" = "1" ] || [ "$INCLUDE_CHAT_ACTION_BAR" = "1" ] || [ "$INCLUDE_CHAT_SHORTCUT_MAP" = "1" ]; }; then
-    ERROR "--include-runtime-readiness, --include-device-session, --include-chat-session, --include-chat-surface-layout, --include-chat-local-only-policy, --include-chat-preferences, --include-chat-session-index, --include-chat-session-title-policy, --include-chat-model-status, --include-chat-readiness, --include-chat-composer, --include-chat-send-result, --include-chat-transcript-policy, --include-chat-audit-event, --include-chat-error-taxonomy, --include-chat-response-stream, --include-chat-message-list, --include-chat-action-bar, and --include-chat-shortcut-map are only supported in local scaffold mode"
+if [ -n "$BACKEND" ] && { [ "$INCLUDE_RUNTIME_READINESS" = "1" ] || [ "$INCLUDE_DEVICE_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SURFACE_LAYOUT" = "1" ] || [ "$INCLUDE_CHAT_LOCAL_ONLY_POLICY" = "1" ] || [ "$INCLUDE_CHAT_PREFERENCES" = "1" ] || [ "$INCLUDE_CHAT_SESSION_INDEX" = "1" ] || [ "$INCLUDE_CHAT_SESSION_TITLE_POLICY" = "1" ] || [ "$INCLUDE_CHAT_MODEL_STATUS" = "1" ] || [ "$INCLUDE_CHAT_READINESS" = "1" ] || [ "$INCLUDE_CHAT_COMPOSER" = "1" ] || [ "$INCLUDE_CHAT_SEND_RESULT" = "1" ] || [ "$INCLUDE_CHAT_TRANSCRIPT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_AUDIT_EVENT" = "1" ] || [ "$INCLUDE_CHAT_ERROR_TAXONOMY" = "1" ] || [ "$INCLUDE_CHAT_RESPONSE_STREAM" = "1" ] || [ "$INCLUDE_CHAT_MESSAGE_LIST" = "1" ] || [ "$INCLUDE_CHAT_ACTION_BAR" = "1" ] || [ "$INCLUDE_CHAT_ATTACHMENT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_SHORTCUT_MAP" = "1" ]; }; then
+    ERROR "--include-runtime-readiness, --include-device-session, --include-chat-session, --include-chat-surface-layout, --include-chat-local-only-policy, --include-chat-preferences, --include-chat-session-index, --include-chat-session-title-policy, --include-chat-model-status, --include-chat-readiness, --include-chat-composer, --include-chat-send-result, --include-chat-transcript-policy, --include-chat-audit-event, --include-chat-error-taxonomy, --include-chat-response-stream, --include-chat-message-list, --include-chat-action-bar, --include-chat-attachment-policy, and --include-chat-shortcut-map are only supported in local scaffold mode"
     exit 1
 fi
 
@@ -2183,6 +2322,7 @@ if [ -z "$BACKEND" ]; then
     NOTE "chat stream   : opt-in via --include-chat-response-stream (read-only response stream data)"
     NOTE "chat messages : opt-in via --include-chat-message-list (read-only empty message-list data)"
     NOTE "chat actions  : opt-in via --include-chat-action-bar (read-only disabled action-bar data)"
+    NOTE "chat attach   : opt-in via --include-chat-attachment-policy (read-only disabled attachment-policy data)"
     NOTE "chat shortcuts: opt-in via --include-chat-shortcut-map (read-only disabled shortcut-map data)"
     NOTE "editor bridge  : planned (VS Code / other IDEs)"
 
@@ -2206,6 +2346,12 @@ if [ -z "$BACKEND" ]; then
 
     if [ "$INCLUDE_CHAT_ACTION_BAR" = "1" ]; then
         if ! print_chat_action_bar_summary; then
+            exit 1
+        fi
+    fi
+
+    if [ "$INCLUDE_CHAT_ATTACHMENT_POLICY" = "1" ]; then
+        if ! print_chat_attachment_policy_summary; then
             exit 1
         fi
     fi

--- a/scripts/tests/chat_attachment_policy_contract_test.py
+++ b/scripts/tests/chat_attachment_policy_contract_test.py
@@ -1,0 +1,414 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Fixture tests for the standalone chat attachment-policy contract."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "contracts" / "chat_attachment_policy_contract.py"
+FIXTURE_PATH = (
+    ROOT
+    / "contracts"
+    / "fixtures"
+    / "chat-attachment-policy.gemma3n-e4b-kv260-placeholder.json"
+)
+SCRIPT_PATH = ROOT / "scripts" / "chat-attachment-policy-stub.sh"
+STATUS_TEST_PATH = ROOT / "scripts" / "tests" / "status-chat-attachment-policy.sh"
+DOC_PATH = ROOT / "docs" / "STANDALONE_CHAT_SESSION_CONTRACT.md"
+README_PATH = ROOT / "README.md"
+TEST_PATH = Path(__file__).resolve()
+CI_PATH = ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location(
+        "chat_attachment_policy_contract",
+        MODULE_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def iter_state_values(value):
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            if (
+                key == "state"
+                or key.endswith("State")
+                or key.endswith("Status")
+            ) and isinstance(nested, str):
+                yield nested
+            yield from iter_state_values(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            yield from iter_state_values(nested)
+
+
+def iter_keys(value):
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            yield key
+            yield from iter_keys(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            yield from iter_keys(nested)
+
+
+def flatten(value):
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            yield str(key)
+            yield from flatten(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            yield from flatten(nested)
+    else:
+        yield str(value)
+
+
+def assert_no_private_or_generated_data(text: str) -> None:
+    forbidden_patterns = [
+        r"/home/[^\s\"']+",
+        r"/Users/[^\s\"']+",
+        r"[A-Za-z]:\\Users\\",
+        r"\b(?:api[_-]?key|authorization|bearer|client[_-]?secret|password|private[_-]?key|secret|token)\b\s*[:=]",
+        r"\.(?:gguf|safetensors|ckpt|pt|pth|onnx)\b",
+        r"(?:weights|model_weights|model-cache)/(?:[^\"'\s]+)",
+        r"(?:raw[_-]?full[_-]?logs|hardware[_-]?dump|generated[_-]?blob)\s*[:=]",
+    ]
+    for pattern in forbidden_patterns:
+        assert not re.search(pattern, text, re.IGNORECASE), pattern
+
+
+def assert_no_runtime_implementation_terms(source: str) -> None:
+    forbidden = [
+        "subprocess",
+        "os.system",
+        "popen",
+        "socket",
+        "urllib",
+        "requests",
+        "http.client",
+        "openai",
+        "anthropic",
+        "gem" + "ini",
+        "modelcontextprotocol",
+        "websocket",
+        "xmutil",
+        "xrt-smi",
+        "lsusb",
+        "dmesg",
+    ]
+    lowered = source.lower()
+    for term in forbidden:
+        assert term not in lowered, term
+
+
+def assert_no_provider_configs(value) -> None:
+    forbidden_keys = {
+        "apiKey",
+        "accessToken",
+        "refreshToken",
+        "authorization",
+        "bearerToken",
+        "provider",
+        "providers",
+        "providerConfig",
+        "providerConfigs",
+    }
+    for key in iter_keys(value):
+        assert key not in forbidden_keys, key
+
+
+def assert_no_unsupported_claims(text: str) -> None:
+    literal_claims = [
+        "production" + "-ready",
+        "marketplace" + "-ready",
+        "stable " + "API",
+        "stable " + "ABI",
+        "KV260 inference " + "works",
+        "Gemma 3N E4B " + "runs on KV260",
+        "20 tok/s " + "achieved",
+        "timing " + "closed",
+        "bitstream " + "ready",
+        "launcher executes " + "pccx-lab",
+        "IDE controls " + "launcher",
+        "AI provider integration " + "is live",
+    ]
+    lowered = text.lower()
+    for claim in literal_claims:
+        assert claim.lower() not in lowered, claim
+
+
+def test_chat_attachment_policy_matches_fixture_and_is_deterministic() -> None:
+    module = load_module()
+    generated = module.create_gemma3n_e4b_kv260_chat_attachment_policy()
+    fixture = json.loads(read_text(FIXTURE_PATH))
+
+    assert generated == fixture
+    assert module.chat_attachment_policy_json(generated) == (
+        module.chat_attachment_policy_json(generated)
+    )
+    assert module.chat_attachment_policy_json(generated).endswith("\n")
+    assert json.loads(module.chat_attachment_policy_json(generated)) == fixture
+
+
+def test_cli_stub_outputs_deterministic_json() -> None:
+    fixture = json.loads(read_text(FIXTURE_PATH))
+    command = [
+        "bash",
+        str(SCRIPT_PATH),
+        "--model",
+        "gemma3n-e4b",
+        "--target",
+        "kv260",
+    ]
+    first = subprocess.run(command, check=True, capture_output=True, text=True)
+    second = subprocess.run(command, check=True, capture_output=True, text=True)
+
+    assert first.stderr == ""
+    assert first.stdout == second.stdout
+    assert first.stdout.endswith("\n")
+    assert json.loads(first.stdout) == fixture
+
+
+def test_required_fields_and_allowed_states() -> None:
+    module = load_module()
+    policy = module.create_gemma3n_e4b_kv260_chat_attachment_policy()
+    allowed = set(module.CHAT_ATTACHMENT_POLICY_STATE_VALUES)
+
+    assert tuple(policy.keys()) == module.CHAT_ATTACHMENT_POLICY_FIELDS
+    assert policy["schemaVersion"] == "pccx.chatAttachmentPolicy.v0"
+    assert tuple(policy["attachmentPolicy"].keys()) == (
+        module.ATTACHMENT_POLICY_FIELDS
+    )
+
+    states = list(iter_state_values(policy))
+    assert states
+    for state in states:
+        assert state in allowed, state
+
+    for input_item in policy["attachmentInputs"]:
+        assert tuple(input_item.keys()) == module.ATTACHMENT_INPUT_FIELDS
+    for control in policy["attachmentControls"]:
+        assert tuple(control.keys()) == module.ATTACHMENT_CONTROL_FIELDS
+    for reason in policy["blockedReasons"]:
+        assert tuple(reason.keys()) == module.BLOCKED_REASON_FIELDS
+    for ref in policy["handoffRefs"]:
+        assert tuple(ref.keys()) == module.HANDOFF_REF_FIELDS
+
+
+def test_chat_attachment_policy_keeps_file_inputs_disabled() -> None:
+    policy = load_module().create_gemma3n_e4b_kv260_chat_attachment_policy()
+    attachment_policy = policy["attachmentPolicy"]
+    inputs = {
+        input_item["inputKind"]: input_item
+        for input_item in policy["attachmentInputs"]
+    }
+    controls = {
+        control["controlId"]: control
+        for control in policy["attachmentControls"]
+    }
+    reasons = {reason["reasonId"]: reason for reason in policy["blockedReasons"]}
+    refs = {ref["refId"]: ref for ref in policy["handoffRefs"]}
+    flags = policy["safetyFlags"]
+
+    assert policy["attachmentPolicyState"] == "blocked"
+    assert policy["attachmentState"] == "disabled"
+    assert policy["filePickerState"] == "disabled"
+    assert policy["fileReadState"] == "blocked"
+    assert policy["uploadState"] == "disabled"
+    assert policy["importState"] == "disabled"
+    assert policy["previewState"] == "disabled"
+    assert policy["persistenceState"] == "disabled"
+    assert policy["privacyState"] == "summary_only"
+    assert attachment_policy["allowedInputKinds"] == []
+    assert attachment_policy["maxAttachmentCount"] == 0
+    assert attachment_policy["filePickerEnabled"] is False
+    assert attachment_policy["fileMetadataReadEnabled"] is False
+    assert attachment_policy["fileContentReadEnabled"] is False
+    assert attachment_policy["uploadEnabled"] is False
+    assert attachment_policy["importEnabled"] is False
+    assert attachment_policy["previewEnabled"] is False
+    assert attachment_policy["persistenceEnabled"] is False
+    assert set(inputs) == {
+        "local_file",
+        "local_directory",
+        "clipboard_payload",
+        "generated_artifact",
+        "transcript_export",
+    }
+    assert all(input_item["enabled"] is False for input_item in inputs.values())
+    assert inputs["local_file"]["sideEffectPolicy"] == "no_file_picker_no_file_read"
+    assert inputs["local_directory"]["sideEffectPolicy"] == "no_directory_scan"
+    assert inputs["clipboard_payload"]["sideEffectPolicy"] == "no_clipboard_read"
+    assert set(controls) == {
+        "open_file_picker",
+        "read_file_metadata",
+        "read_file_content",
+        "import_attachment",
+        "upload_attachment",
+        "preview_attachment",
+        "persist_attachment",
+    }
+    assert all(control["enabled"] is False for control in controls.values())
+    assert controls["open_file_picker"]["sideEffectPolicy"] == "no_file_picker"
+    assert controls["read_file_metadata"]["sideEffectPolicy"] == "no_file_metadata_read"
+    assert controls["read_file_content"]["sideEffectPolicy"] == "no_file_content_read"
+    assert controls["upload_attachment"]["sideEffectPolicy"] == "no_upload_no_network"
+    assert set(reasons) == {
+        "attachment_runtime_not_reviewed",
+        "file_picker_boundary_absent",
+        "metadata_read_boundary_absent",
+        "file_content_read_boundary_absent",
+        "import_export_boundary_absent",
+        "attachment_persistence_boundary_absent",
+        "local_only_upload_block",
+        "clipboard_boundary_absent",
+    }
+    assert set(refs) == {
+        "chat_composer",
+        "chat_action_bar",
+        "chat_shortcut_map",
+        "chat_local_only_policy",
+        "chat_transcript_policy",
+    }
+    assert flags["readOnly"] is True
+    assert flags["dataOnly"] is True
+    assert flags["attachmentPolicyDisplayOnly"] is True
+    assert flags["attachmentMetadataOnly"] is True
+    assert flags["attachmentsEnabled"] is False
+    assert flags["filePickerOpened"] is False
+    assert flags["fileMetadataRead"] is False
+    assert flags["fileContentRead"] is False
+    assert flags["fileNameIncluded"] is False
+    assert flags["filePathIncluded"] is False
+    assert flags["fileBytesIncluded"] is False
+    assert flags["directoryScan"] is False
+    assert flags["attachmentReads"] is False
+    assert flags["attachmentPersistence"] is False
+    assert flags["fileUpload"] is False
+    assert flags["fileImport"] is False
+    assert flags["filePreview"] is False
+    assert flags["clipboardRead"] is False
+    assert flags["writesArtifacts"] is False
+    assert flags["readsArtifacts"] is False
+    assert flags["readsTranscript"] is False
+    assert flags["transcriptExport"] is False
+    assert flags["promptContentIncluded"] is False
+    assert flags["responseContentIncluded"] is False
+    assert flags["modelExecution"] is False
+    assert flags["runtimeExecution"] is False
+    assert flags["kv260Access"] is False
+    assert flags["networkCalls"] is False
+    assert flags["providerCalls"] is False
+    assert flags["executesPccxLab"] is False
+
+
+def test_chat_attachment_policy_docs_and_ci_are_wired() -> None:
+    doc = read_text(DOC_PATH)
+    readme = read_text(README_PATH)
+    status_test = read_text(STATUS_TEST_PATH)
+    ci = read_text(CI_PATH)
+
+    assert "contracts/chat_attachment_policy_contract.py" in doc
+    assert (
+        "contracts/fixtures/chat-attachment-policy.gemma3n-e4b-kv260-placeholder.json"
+        in doc
+    )
+    assert "scripts/chat-attachment-policy-stub.sh" in doc
+    assert "scripts/tests/chat_attachment_policy_contract_test.py" in doc
+    assert "scripts/tests/status-chat-attachment-policy.sh" in doc
+    assert "chat-attachment-policy-stub.sh" in readme
+    assert "--include-chat-attachment-policy" in readme
+    assert "chat_attachment_policy_contract_test.py" in ci
+    assert "status-chat-attachment-policy.sh" in ci
+    assert "--include-chat-attachment-policy" in status_test
+    assert "no file picker/file metadata/file content/upload" in status_test
+
+
+def test_chat_attachment_policy_has_no_runtime_or_private_surface() -> None:
+    module = load_module()
+    policy = module.create_gemma3n_e4b_kv260_chat_attachment_policy()
+    fixture_text = read_text(FIXTURE_PATH)
+    contract_source = read_text(MODULE_PATH)
+    stub_source = read_text(SCRIPT_PATH)
+    docs = "\n".join(
+        [
+            fixture_text,
+            contract_source,
+            stub_source,
+            read_text(DOC_PATH),
+            read_text(README_PATH),
+            read_text(STATUS_TEST_PATH),
+        ]
+    )
+
+    assert_no_provider_configs(policy)
+    assert_no_private_or_generated_data(docs)
+    assert_no_unsupported_claims(docs)
+    assert_no_runtime_implementation_terms(contract_source)
+    assert_no_runtime_implementation_terms(stub_source)
+    assert "promptText" not in fixture_text
+    assert "responseText" not in fixture_text
+    assert "fileNameValue" not in fixture_text
+    assert "filePathValue" not in fixture_text
+    assert "fileContentText" not in fixture_text
+    assert "previewBody" not in fixture_text
+    assert all(
+        "attachment:" not in item.lower()
+        for item in flatten(policy)
+    )
+
+
+def test_source_headers_for_touched_code_files() -> None:
+    expected_headers = {
+        MODULE_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        SCRIPT_PATH: [
+            "#!/usr/bin/env bash",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        STATUS_TEST_PATH: [
+            "#!/usr/bin/env bash",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        TEST_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        CI_PATH: [
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+    }
+
+    for path, headers in expected_headers.items():
+        assert read_text(path).splitlines()[: len(headers)] == headers, path
+
+
+if __name__ == "__main__":
+    for name, func in sorted(globals().items()):
+        if name.startswith("test_") and callable(func):
+            func()
+    print("chat attachment policy contract tests ok")

--- a/scripts/tests/status-chat-attachment-policy.sh
+++ b/scripts/tests/status-chat-attachment-policy.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+# scripts/tests/status-chat-attachment-policy.sh - status attachment-policy tests.
+#
+# Usage: bash scripts/tests/status-chat-attachment-policy.sh [path/to/status-stub.sh]
+
+set -eu
+
+PASS() { printf '[PASS]  %s\n' "$*"; }
+FAIL() { printf '[FAIL] %s\n' "$*" >&2; }
+HEAD() { printf '\n=== %s ===\n' "$*"; }
+
+STUB="${1:-scripts/status-stub.sh}"
+
+if [ ! -x "$STUB" ]; then
+    chmod +x "$STUB"
+fi
+
+contains() {
+    case "$1" in
+        *"$2"*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+require_contains() {
+    local output="$1"
+    local expected="$2"
+    if ! contains "$output" "$expected"; then
+        FAIL "expected output to contain: $expected"
+        printf '%s\n' "$output" >&2
+        exit 1
+    fi
+}
+
+require_not_contains() {
+    local output="$1"
+    local forbidden="$2"
+    if contains "$output" "$forbidden"; then
+        FAIL "output contained forbidden text: $forbidden"
+        printf '%s\n' "$output" >&2
+        exit 1
+    fi
+}
+
+HEAD "1: status can include chat attachment policy"
+OUTPUT="$("$STUB" --include-chat-attachment-policy)"
+require_contains "$OUTPUT" "=== chat attachment policy ==="
+require_contains "$OUTPUT" "source     : scripts/chat-attachment-policy-stub.sh --model gemma3n-e4b --target kv260"
+require_contains "$OUTPUT" "boundary   : read-only data; no file picker/file metadata/file content/upload/import/clipboard/model/runtime/hardware/lab/IDE execution"
+require_contains "$OUTPUT" "target     : kv260"
+require_contains "$OUTPUT" "model      : gemma3n-e4b"
+require_contains "$OUTPUT" "policy     : blocked"
+require_contains "$OUTPUT" "attachment : disabled"
+require_contains "$OUTPUT" "file picker: disabled"
+require_contains "$OUTPUT" "file read  : blocked"
+require_contains "$OUTPUT" "upload     : disabled"
+require_contains "$OUTPUT" "import     : disabled"
+require_contains "$OUTPUT" "preview    : disabled"
+require_contains "$OUTPUT" "persistence: disabled"
+require_contains "$OUTPUT" "privacy    : summary_only"
+PASS "chat attachment-policy section is present and conservative"
+
+HEAD "2: policy, inputs, and controls stay disabled"
+require_contains "$OUTPUT" "attachment-policy : blocked mode=disabled_until_reviewed_local_input_boundary_exists"
+require_contains "$OUTPUT" "maxAttachmentCount=0"
+require_contains "$OUTPUT" "filePickerEnabled=false"
+require_contains "$OUTPUT" "fileMetadataReadEnabled=false"
+require_contains "$OUTPUT" "fileContentReadEnabled=false"
+require_contains "$OUTPUT" "uploadEnabled=false"
+require_contains "$OUTPUT" "importEnabled=false"
+require_contains "$OUTPUT" "previewEnabled=false"
+require_contains "$OUTPUT" "persistenceEnabled=false"
+require_contains "$OUTPUT" "inputs     : local_file=blocked:false"
+require_contains "$OUTPUT" "local_directory=blocked:false"
+require_contains "$OUTPUT" "clipboard_payload=disabled:false"
+require_contains "$OUTPUT" "generated_artifact=blocked:false"
+require_contains "$OUTPUT" "transcript_export=disabled:false"
+require_contains "$OUTPUT" "controls   : open_file_picker=disabled:false"
+require_contains "$OUTPUT" "read_file_metadata=blocked:false"
+require_contains "$OUTPUT" "read_file_content=blocked:false"
+require_contains "$OUTPUT" "import_attachment=disabled:false"
+require_contains "$OUTPUT" "upload_attachment=disabled:false"
+require_contains "$OUTPUT" "preview_attachment=disabled:false"
+require_contains "$OUTPUT" "persist_attachment=disabled:false"
+PASS "attachment policy metadata is summarized without file reads"
+
+HEAD "3: blocked reasons stay explicit"
+require_contains "$OUTPUT" "blocked    : attachment_runtime_not_reviewed=blocked"
+require_contains "$OUTPUT" "file_picker_boundary_absent=planned"
+require_contains "$OUTPUT" "metadata_read_boundary_absent=planned"
+require_contains "$OUTPUT" "file_content_read_boundary_absent=planned"
+require_contains "$OUTPUT" "import_export_boundary_absent=not_configured"
+require_contains "$OUTPUT" "attachment_persistence_boundary_absent=requires_evidence"
+require_contains "$OUTPUT" "local_only_upload_block=disabled"
+require_contains "$OUTPUT" "clipboard_boundary_absent=not_configured"
+PASS "attachment blockers remain visible"
+
+HEAD "4: safety flags stay read-only and non-executing"
+require_contains "$OUTPUT" "readOnly=true"
+require_contains "$OUTPUT" "dataOnly=true"
+require_contains "$OUTPUT" "deterministic=true"
+require_contains "$OUTPUT" "attachmentPolicyDisplayOnly=true"
+require_contains "$OUTPUT" "attachmentMetadataOnly=true"
+require_contains "$OUTPUT" "attachmentsEnabled=false"
+require_contains "$OUTPUT" "filePickerOpened=false"
+require_contains "$OUTPUT" "fileMetadataRead=false"
+require_contains "$OUTPUT" "fileContentRead=false"
+require_contains "$OUTPUT" "fileNameIncluded=false"
+require_contains "$OUTPUT" "filePathIncluded=false"
+require_contains "$OUTPUT" "fileBytesIncluded=false"
+require_contains "$OUTPUT" "directoryScan=false"
+require_contains "$OUTPUT" "attachmentReads=false"
+require_contains "$OUTPUT" "attachmentPersistence=false"
+require_contains "$OUTPUT" "fileUpload=false"
+require_contains "$OUTPUT" "fileImport=false"
+require_contains "$OUTPUT" "filePreview=false"
+require_contains "$OUTPUT" "clipboardRead=false"
+require_contains "$OUTPUT" "writesArtifacts=false"
+require_contains "$OUTPUT" "readsArtifacts=false"
+require_contains "$OUTPUT" "readsTranscript=false"
+require_contains "$OUTPUT" "transcriptExport=false"
+require_contains "$OUTPUT" "promptContentIncluded=false"
+require_contains "$OUTPUT" "responseContentIncluded=false"
+require_contains "$OUTPUT" "modelExecution=false"
+require_contains "$OUTPUT" "runtimeExecution=false"
+require_contains "$OUTPUT" "kv260Access=false"
+require_contains "$OUTPUT" "hardwareAccess=false"
+require_contains "$OUTPUT" "networkCalls=false"
+require_contains "$OUTPUT" "providerCalls=false"
+require_contains "$OUTPUT" "executesPccxLab=false"
+PASS "execution, read, upload, and persistence flags remain false"
+
+HEAD "5: output is deterministic"
+OUTPUT_AGAIN="$("$STUB" --include-chat-attachment-policy)"
+if [ "$OUTPUT" != "$OUTPUT_AGAIN" ]; then
+    FAIL "status chat attachment-policy output changed between runs"
+    exit 1
+fi
+PASS "status chat attachment-policy output is deterministic"
+
+HEAD "6: chat attachment-policy option does not combine with pccx-lab backend"
+if "$STUB" --include-chat-attachment-policy --backend pccx-lab >/dev/null 2>&1; then
+    FAIL "expected combined chat-attachment-policy/backend mode to fail"
+    exit 1
+fi
+PASS "chat attachment policy remains separate from backend execution"
+
+HEAD "7: output avoids known overclaims and content"
+FORBIDDEN_PREFIX="KV260 inference"
+FORBIDDEN_CLAIM="${FORBIDDEN_PREFIX} works"
+require_not_contains "$OUTPUT" "$FORBIDDEN_CLAIM"
+THROUGHPUT_PREFIX="20 tok/s"
+THROUGHPUT_CLAIM="${THROUGHPUT_PREFIX} achieved"
+require_not_contains "$OUTPUT" "$THROUGHPUT_CLAIM"
+require_not_contains "$OUTPUT" "hello"
+require_not_contains "$OUTPUT" "assistant response:"
+require_not_contains "$OUTPUT" "attachment:"
+PASS "no attachment-policy overclaim or content in status output"
+
+printf '\n[DONE]  all status-chat-attachment-policy tests passed\n'


### PR DESCRIPTION
## Summary
- add a data-only `pccx.chatAttachmentPolicy.v0` fixture and stub for the standalone chat surface
- wire `--include-chat-attachment-policy` into the status stub, README, contract docs, tests, and CI
- keep file picker, file metadata/content reads, uploads, imports, previews, persistence, clipboard reads, model/runtime execution, target access, and cross-repo execution disabled

Refs #9.

## Validation
- `python3 scripts/tests/chat_attachment_policy_contract_test.py`
- `bash scripts/tests/status-chat-attachment-policy.sh scripts/status-stub.sh`
- `python3 scripts/tests/chat_action_bar_contract_test.py`
- `python3 scripts/tests/chat_shortcut_map_contract_test.py`
- `python3 scripts/tests/chat_composer_contract_test.py`
- `python3 scripts/tests/chat_surface_preview_test.py`
- `python3 -m py_compile contracts/chat_attachment_policy_contract.py scripts/tests/chat_attachment_policy_contract_test.py`
- `python3 -m json.tool contracts/fixtures/chat-attachment-policy.gemma3n-e4b-kv260-placeholder.json`
- `cmp -s contracts/fixtures/chat-attachment-policy.gemma3n-e4b-kv260-placeholder.json <(python3 contracts/chat_attachment_policy_contract.py --model gemma3n-e4b --target kv260)`
- `find scripts -type f -name '*.sh' -print0 | xargs -0 bash -n`
- `for t in scripts/tests/*_test.py; do python3 "$t"; done`
- `for t in scripts/tests/status-*.sh; do bash "$t" scripts/status-stub.sh; done`
- `bash scripts/status-stub.sh`
- `bash scripts/check.sh`
- `bash scripts/check-device-stub.sh`
- `bash scripts/install-stub.sh`
- `bash scripts/launch-stub.sh --dry-run`
- `bash scripts/chat-stub.sh --dry-run --prompt hello`
- local claim-scan matching CI guard
- `git diff --check`
- `git diff --cached --check`
