### PR TITLE
Add chat session-store policy boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,7 @@ jobs:
                    scripts/chat-local-only-policy-stub.sh \
                    scripts/chat-preferences-stub.sh \
                    scripts/chat-session-index-stub.sh \
+                   scripts/chat-session-store-policy-stub.sh \
                    scripts/chat-session-title-policy-stub.sh \
                    scripts/chat-readiness-stub.sh \
                    scripts/chat-composer-stub.sh \
@@ -195,6 +196,10 @@ jobs:
         run: ./scripts/status-stub.sh --include-chat-session-index
       - name: run scripts/chat-session-index-stub.sh
         run: ./scripts/chat-session-index-stub.sh --model gemma3n-e4b --target kv260
+      - name: run scripts/status-stub.sh with chat session-store policy
+        run: ./scripts/status-stub.sh --include-chat-session-store-policy
+      - name: run scripts/chat-session-store-policy-stub.sh
+        run: ./scripts/chat-session-store-policy-stub.sh --model gemma3n-e4b --target kv260
       - name: run scripts/status-stub.sh with chat session title policy
         run: ./scripts/status-stub.sh --include-chat-session-title-policy
       - name: run scripts/chat-session-title-policy-stub.sh
@@ -279,6 +284,8 @@ jobs:
         run: python3 scripts/tests/chat_preferences_contract_test.py
       - name: run chat session-index contract tests
         run: python3 scripts/tests/chat_session_index_contract_test.py
+      - name: run chat session-store policy contract tests
+        run: python3 scripts/tests/chat_session_store_policy_contract_test.py
       - name: run chat session-title policy contract tests
         run: python3 scripts/tests/chat_session_title_policy_contract_test.py
       - name: run chat readiness contract tests
@@ -322,6 +329,7 @@ jobs:
           chmod +x scripts/chat-local-only-policy-stub.sh
           chmod +x scripts/chat-preferences-stub.sh
           chmod +x scripts/chat-session-index-stub.sh
+          chmod +x scripts/chat-session-store-policy-stub.sh
           chmod +x scripts/chat-session-title-policy-stub.sh
           chmod +x scripts/chat-readiness-stub.sh
           chmod +x scripts/chat-composer-stub.sh
@@ -344,6 +352,7 @@ jobs:
           chmod +x scripts/tests/status-chat-local-only-policy.sh
           chmod +x scripts/tests/status-chat-preferences.sh
           chmod +x scripts/tests/status-chat-session-index.sh
+          chmod +x scripts/tests/status-chat-session-store-policy.sh
           chmod +x scripts/tests/status-chat-session-title-policy.sh
           chmod +x scripts/tests/status-chat-readiness.sh
           chmod +x scripts/tests/status-chat-composer.sh
@@ -369,6 +378,7 @@ jobs:
           shellcheck scripts/tests/status-chat-local-only-policy.sh
           shellcheck scripts/tests/status-chat-preferences.sh
           shellcheck scripts/tests/status-chat-session-index.sh
+          shellcheck scripts/tests/status-chat-session-store-policy.sh
           shellcheck scripts/tests/status-chat-session-title-policy.sh
           shellcheck scripts/tests/status-chat-readiness.sh
           shellcheck scripts/tests/status-chat-composer.sh
@@ -399,6 +409,8 @@ jobs:
         run: bash scripts/tests/status-chat-preferences.sh scripts/status-stub.sh
       - name: run status-chat-session-index tests
         run: bash scripts/tests/status-chat-session-index.sh scripts/status-stub.sh
+      - name: run status-chat-session-store-policy tests
+        run: bash scripts/tests/status-chat-session-store-policy.sh scripts/status-stub.sh
       - name: run status-chat-session-title-policy tests
         run: bash scripts/tests/status-chat-session-title-policy.sh scripts/status-stub.sh
       - name: run status-chat-readiness tests

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ and verify host-side prerequisites before the real engine lands.
 | [`scripts/check.sh`](./scripts/check.sh) | Probe host info, tooling availability, edge-device hints. Always exits 0. |
 | [`scripts/check-device-stub.sh`](./scripts/check-device-stub.sh) | Narrowly scoped device-tree / FPGA-node probe (KV260 / Kria detection only). Always exits 0. |
 | [`scripts/install-stub.sh`](./scripts/install-stub.sh) | Preview of the planned install flow; reports which host runtime pieces are present, lists device-side pieces as future deliverables. Always exits 0. |
-| [`scripts/status-stub.sh`](./scripts/status-stub.sh) | Launcher state summary. Default mode: local scaffold output, always exits 0. With `--include-chat-action-bar`, adds read-only disabled chat action-bar data. With `--include-chat-attachment-policy`, adds read-only disabled chat attachment-policy data. With `--include-chat-shortcut-map`, adds read-only disabled chat shortcut-map data. With `--include-chat-message-list`, adds read-only empty chat message-list data. With `--include-chat-response-stream`, adds read-only blocked chat response stream data. With `--include-chat-error-taxonomy`, adds read-only chat error taxonomy data. With `--include-chat-audit-event`, adds read-only blocked chat audit-event metadata. With `--include-chat-surface-layout`, adds read-only chat surface layout data. With `--include-chat-local-only-policy`, adds read-only local-only/cloud-block policy data. With `--include-chat-preferences`, adds read-only chat preferences/settings data. With `--include-chat-session-index`, adds read-only empty chat session index data. With `--include-chat-session-title-policy`, adds read-only placeholder session-title policy data. With `--include-chat-transcript-policy`, adds read-only chat transcript retention/export policy data. With `--include-chat-send-result`, adds read-only blocked chat send-result data. With `--include-chat-composer`, adds read-only chat composer/input-control data. With `--include-chat-model-status`, adds read-only blocked chat model-status display data. With `--include-chat-session`, adds read-only blocked chat/session and lifecycle summaries. With `--include-chat-readiness`, adds read-only chat readiness checks and recovery actions. With `--include-device-session`, adds a read-only device/session status panel. With `--include-runtime-readiness`, adds a read-only runtime readiness summary. With `--backend pccx-lab`, calls `pccx-lab status --format json` and forwards the run-status envelope (exits non-zero if binary is missing or output is invalid). |
+| [`scripts/status-stub.sh`](./scripts/status-stub.sh) | Launcher state summary. Default mode: local scaffold output, always exits 0. With `--include-chat-action-bar`, adds read-only disabled chat action-bar data. With `--include-chat-attachment-policy`, adds read-only disabled chat attachment-policy data. With `--include-chat-shortcut-map`, adds read-only disabled chat shortcut-map data. With `--include-chat-message-list`, adds read-only empty chat message-list data. With `--include-chat-response-stream`, adds read-only blocked chat response stream data. With `--include-chat-error-taxonomy`, adds read-only chat error taxonomy data. With `--include-chat-audit-event`, adds read-only blocked chat audit-event metadata. With `--include-chat-surface-layout`, adds read-only chat surface layout data. With `--include-chat-local-only-policy`, adds read-only local-only/cloud-block policy data. With `--include-chat-preferences`, adds read-only chat preferences/settings data. With `--include-chat-session-index`, adds read-only empty chat session index data. With `--include-chat-session-store-policy`, adds read-only disabled chat session-store policy data. With `--include-chat-session-title-policy`, adds read-only placeholder session-title policy data. With `--include-chat-transcript-policy`, adds read-only chat transcript retention/export policy data. With `--include-chat-send-result`, adds read-only blocked chat send-result data. With `--include-chat-composer`, adds read-only chat composer/input-control data. With `--include-chat-model-status`, adds read-only blocked chat model-status display data. With `--include-chat-session`, adds read-only blocked chat/session and lifecycle summaries. With `--include-chat-readiness`, adds read-only chat readiness checks and recovery actions. With `--include-device-session`, adds a read-only device/session status panel. With `--include-runtime-readiness`, adds a read-only runtime readiness summary. With `--backend pccx-lab`, calls `pccx-lab status --format json` and forwards the run-status envelope (exits non-zero if binary is missing or output is invalid). |
 | [`scripts/device-session-status-stub.sh`](./scripts/device-session-status-stub.sh) | Data-only device/session status JSON for the Gemma 3N E4B + KV260 target. Reports connection, model load, session, diagnostics, readiness, discovery paths, flow steps, and error taxonomy as placeholder / blocked. |
 | [`scripts/runtime-readiness-stub.sh`](./scripts/runtime-readiness-stub.sh) | Data-only runtime readiness JSON for the Gemma 3N E4B + KV260 target. Reports blocked / not yet evidence-backed. |
 | [`scripts/chat-session-stub.sh`](./scripts/chat-session-stub.sh) | Data-only standalone chat/session JSON for the Gemma 3N E4B + KV260 target. Reports disabled send controls, inactive session state, no prompt/response persistence, and readiness handoff references. |
@@ -96,6 +96,7 @@ and verify host-side prerequisites before the real engine lands.
 | [`scripts/chat-local-only-policy-stub.sh`](./scripts/chat-local-only-policy-stub.sh) | Data-only chat local-only policy JSON for the Gemma 3N E4B + KV260 target. Reports cloud/provider/network dependency and fallback paths as not used, disabled, or blocked while local runtime evidence remains gated. |
 | [`scripts/chat-preferences-stub.sh`](./scripts/chat-preferences-stub.sh) | Data-only chat preferences JSON for the Gemma 3N E4B + KV260 target. Reports planned settings panels and disabled controls without reading configuration, provider settings, model paths, session stores, prompts, transcripts, or artifacts. |
 | [`scripts/chat-session-index-stub.sh`](./scripts/chat-session-index-stub.sh) | Data-only chat session index JSON for the Gemma 3N E4B + KV260 target. Reports an empty, not-configured session list/sidebar boundary without reading a store, session titles, prompts, responses, transcripts, or summaries. |
+| [`scripts/chat-session-store-policy-stub.sh`](./scripts/chat-session-store-policy-stub.sh) | Data-only chat session-store policy JSON for the Gemma 3N E4B + KV260 target. Reports disabled store configuration, path, manifest, read, write, delete, retention, and migration gates without reading config, paths, manifests, session records, transcripts, titles, prompts, responses, summaries, model paths, runtime logs, or artifacts. |
 | [`scripts/chat-session-title-policy-stub.sh`](./scripts/chat-session-title-policy-stub.sh) | Data-only chat session-title policy JSON for the Gemma 3N E4B + KV260 target. Reports static placeholder display names and disabled title read, generation, rename, and persistence controls without reading stores, transcripts, prompts, responses, summaries, titles, or paths. |
 | [`scripts/chat-model-status-stub.sh`](./scripts/chat-model-status-stub.sh) | Data-only chat model-status JSON for the Gemma 3N E4B + KV260 target. Reports descriptor, asset, load, runtime, context, and response display rows as blocked, disabled, or unavailable. |
 | [`scripts/chat-readiness-stub.sh`](./scripts/chat-readiness-stub.sh) | Data-only chat readiness JSON for the Gemma 3N E4B + KV260 target. Reports readiness checks, error categories, and recovery actions as blocked, disabled, or local data only. |
@@ -124,6 +125,7 @@ bash scripts/status-stub.sh --include-chat-surface-layout
 bash scripts/status-stub.sh --include-chat-local-only-policy
 bash scripts/status-stub.sh --include-chat-preferences
 bash scripts/status-stub.sh --include-chat-session-index
+bash scripts/status-stub.sh --include-chat-session-store-policy
 bash scripts/status-stub.sh --include-chat-session-title-policy
 bash scripts/status-stub.sh --include-chat-readiness
 bash scripts/status-stub.sh --include-chat-composer
@@ -147,6 +149,7 @@ bash scripts/chat-surface-layout-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-local-only-policy-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-preferences-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-session-index-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/chat-session-store-policy-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-session-title-policy-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-readiness-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-composer-stub.sh --model gemma3n-e4b --target kv260
@@ -331,11 +334,13 @@ python3 contracts/chat_error_taxonomy_contract.py --model gemma3n-e4b --target k
 python3 contracts/chat_response_stream_contract.py --model gemma3n-e4b --target kv260
 python3 contracts/chat_action_bar_contract.py --model gemma3n-e4b --target kv260
 python3 contracts/chat_attachment_policy_contract.py --model gemma3n-e4b --target kv260
+python3 contracts/chat_session_store_policy_contract.py --model gemma3n-e4b --target kv260
 python3 contracts/chat_shortcut_map_contract.py --model gemma3n-e4b --target kv260
 python3 contracts/chat_session_title_policy_contract.py --model gemma3n-e4b --target kv260
 bash scripts/chat-model-status-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-session-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-session-lifecycle-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/chat-session-store-policy-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-session-title-policy-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-readiness-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-audit-event-stub.sh --model gemma3n-e4b --target kv260
@@ -353,6 +358,7 @@ bash scripts/status-stub.sh --include-chat-error-taxonomy
 bash scripts/status-stub.sh --include-chat-response-stream
 bash scripts/status-stub.sh --include-chat-action-bar
 bash scripts/status-stub.sh --include-chat-attachment-policy
+bash scripts/status-stub.sh --include-chat-session-store-policy
 bash scripts/status-stub.sh --include-chat-shortcut-map
 bash scripts/status-stub.sh --include-chat-session-title-policy
 python3 scripts/tests/chat_session_contract_test.py
@@ -365,6 +371,7 @@ python3 scripts/tests/chat_error_taxonomy_contract_test.py
 python3 scripts/tests/chat_response_stream_contract_test.py
 python3 scripts/tests/chat_action_bar_contract_test.py
 python3 scripts/tests/chat_attachment_policy_contract_test.py
+python3 scripts/tests/chat_session_store_policy_contract_test.py
 python3 scripts/tests/chat_shortcut_map_contract_test.py
 python3 scripts/tests/chat_surface_preview_test.py
 bash scripts/tests/status-chat-model-status.sh
@@ -375,6 +382,7 @@ bash scripts/tests/status-chat-error-taxonomy.sh
 bash scripts/tests/status-chat-response-stream.sh
 bash scripts/tests/status-chat-action-bar.sh
 bash scripts/tests/status-chat-attachment-policy.sh
+bash scripts/tests/status-chat-session-store-policy.sh
 bash scripts/tests/status-chat-shortcut-map.sh
 bash scripts/tests/status-chat-session-title-policy.sh
 ```
@@ -443,6 +451,13 @@ metadata read, file content read, upload, import, preview, and persistence
 gates without reading file names, paths, metadata, contents, clipboard
 data, transcripts, generated artifacts, model paths, runtime logs, or
 artifacts.
+
+The chat session-store policy fixture defines the disabled local store
+boundary for the planned chat surface. It records store configuration,
+store path, manifest, read, write, delete, retention, and migration gates
+without reading configuration, paths, manifests, session records,
+transcripts, titles, prompts, responses, summaries, model paths, runtime
+logs, or artifacts.
 
 The preview command renders that same contract as a deterministic
 terminal chat surface sketch with disabled controls, blocked reasons, and

--- a/contracts/chat_session_store_policy_contract.py
+++ b/contracts/chat_session_store_policy_contract.py
@@ -1,0 +1,532 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Data-only chat session-store policy contract for the planned launcher UI.
+
+The contract describes disabled local session-store configuration, read,
+write, delete, retention, and migration gates for the standalone chat
+surface. It does not read configuration files, paths, manifests, session
+records, transcripts, titles, prompts, responses, summaries, model assets,
+private paths, or logs; it does not write, delete, migrate, persist, load
+models, touch KV260 hardware, call providers, invoke pccx-lab, or start
+runtime code.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import sys
+
+
+SCHEMA_VERSION = "pccx.chatSessionStorePolicy.v0"
+
+CHAT_SESSION_STORE_POLICY_FIELDS = (
+    "schemaVersion",
+    "sessionStorePolicyId",
+    "fixtureVersion",
+    "lastUpdatedSource",
+    "targetDevice",
+    "targetBoard",
+    "targetModel",
+    "sessionStorePolicyState",
+    "storeState",
+    "storePathState",
+    "manifestState",
+    "readState",
+    "writeState",
+    "deleteState",
+    "retentionState",
+    "migrationState",
+    "privacyState",
+    "chatSessionRef",
+    "chatSessionIndexRef",
+    "chatSessionLifecycleRef",
+    "chatSessionTitlePolicyRef",
+    "chatTranscriptPolicyRef",
+    "chatPreferencesRef",
+    "sessionStorePolicy",
+    "storeSurfaces",
+    "storeControls",
+    "blockedReasons",
+    "handoffRefs",
+    "safetyFlags",
+    "limitations",
+    "issueRefs",
+)
+
+SESSION_STORE_POLICY_FIELDS = (
+    "state",
+    "mode",
+    "sourcePolicy",
+    "storeConfigured",
+    "storePathConfigured",
+    "manifestSchemaConfigured",
+    "readEnabled",
+    "writeEnabled",
+    "deleteEnabled",
+    "retentionEnabled",
+    "migrationEnabled",
+    "sideEffectPolicy",
+    "contentPolicy",
+)
+
+STORE_SURFACE_FIELDS = (
+    "surfaceId",
+    "label",
+    "state",
+    "enabled",
+    "summary",
+    "sideEffectPolicy",
+    "contentPolicy",
+)
+
+STORE_CONTROL_FIELDS = (
+    "controlId",
+    "label",
+    "state",
+    "enabled",
+    "userAction",
+    "launcherAction",
+    "sideEffectPolicy",
+    "blockedReasonRef",
+)
+
+BLOCKED_REASON_FIELDS = (
+    "reasonId",
+    "state",
+    "summary",
+    "requiredBefore",
+)
+
+HANDOFF_REF_FIELDS = (
+    "refId",
+    "schemaVersion",
+    "fixturePath",
+    "state",
+    "summary",
+)
+
+CHAT_SESSION_STORE_POLICY_STATE_VALUES = (
+    "available_as_data",
+    "blocked",
+    "disabled",
+    "empty_not_captured",
+    "inactive",
+    "not_configured",
+    "not_loaded",
+    "not_started",
+    "placeholder",
+    "planned",
+    "requires_evidence",
+    "summary_only",
+    "target_selected",
+    "unavailable",
+)
+
+_CHAT_SESSION_STORE_POLICY = {
+    "schemaVersion": SCHEMA_VERSION,
+    "sessionStorePolicyId": "chat_session_store_policy_gemma3n_e4b_kv260_placeholder",
+    "fixtureVersion": "chat-session-store-policy.gemma3n-e4b-kv260.2026-05-04",
+    "lastUpdatedSource": "pccx_launcher_issue_9_chat_session_store_policy_boundary_2026-05-04",
+    "targetDevice": "kv260",
+    "targetBoard": "xilinx_kria_kv260",
+    "targetModel": "gemma3n-e4b",
+    "sessionStorePolicyState": "blocked",
+    "storeState": "not_configured",
+    "storePathState": "not_configured",
+    "manifestState": "not_configured",
+    "readState": "blocked",
+    "writeState": "disabled",
+    "deleteState": "disabled",
+    "retentionState": "not_configured",
+    "migrationState": "disabled",
+    "privacyState": "summary_only",
+    "chatSessionRef": "chat_session_gemma3n_e4b_kv260_placeholder",
+    "chatSessionIndexRef": "chat_session_index_gemma3n_e4b_kv260_placeholder",
+    "chatSessionLifecycleRef": "chat_session_lifecycle_gemma3n_e4b_kv260_placeholder",
+    "chatSessionTitlePolicyRef": "chat_session_title_policy_gemma3n_e4b_kv260_placeholder",
+    "chatTranscriptPolicyRef": "chat_transcript_policy_gemma3n_e4b_kv260_placeholder",
+    "chatPreferencesRef": "chat_preferences_gemma3n_e4b_kv260_placeholder",
+    "sessionStorePolicy": {
+        "state": "blocked",
+        "mode": "disabled_until_reviewed_local_session_store_boundary_exists",
+        "sourcePolicy": "checked fixture only; no config, environment, path, manifest, transcript, title, prompt, response, summary, artifact, model path, or runtime log is read",
+        "storeConfigured": False,
+        "storePathConfigured": False,
+        "manifestSchemaConfigured": False,
+        "readEnabled": False,
+        "writeEnabled": False,
+        "deleteEnabled": False,
+        "retentionEnabled": False,
+        "migrationEnabled": False,
+        "sideEffectPolicy": "local_render_only",
+        "contentPolicy": "session-store policy metadata only; no store path, manifest body, session record, transcript text, title text, prompt text, response text, summary text, or model path is included",
+    },
+    "storeSurfaces": [
+        {
+            "surfaceId": "local_store_path",
+            "label": "local store path",
+            "state": "not_configured",
+            "enabled": False,
+            "summary": "No local session-store path is configured, read, resolved, or emitted.",
+            "sideEffectPolicy": "no_config_or_path_read",
+            "contentPolicy": "no_store_path_or_private_path",
+        },
+        {
+            "surfaceId": "session_manifest",
+            "label": "session manifest",
+            "state": "not_configured",
+            "enabled": False,
+            "summary": "No manifest schema is configured and no manifest is read.",
+            "sideEffectPolicy": "no_manifest_read",
+            "contentPolicy": "no_manifest_body_or_session_ids",
+        },
+        {
+            "surfaceId": "session_record",
+            "label": "session record",
+            "state": "blocked",
+            "enabled": False,
+            "summary": "Session records stay unavailable until a reviewed read/write boundary exists.",
+            "sideEffectPolicy": "no_session_store_read",
+            "contentPolicy": "no_session_record_or_message_content",
+        },
+        {
+            "surfaceId": "title_record",
+            "label": "title record",
+            "state": "blocked",
+            "enabled": False,
+            "summary": "Stored titles remain unavailable because no title-read boundary exists.",
+            "sideEffectPolicy": "no_session_title_read",
+            "contentPolicy": "no_session_title_content",
+        },
+        {
+            "surfaceId": "transcript_record",
+            "label": "transcript record",
+            "state": "disabled",
+            "enabled": False,
+            "summary": "Transcript records are not retained or read.",
+            "sideEffectPolicy": "no_transcript_read_or_persistence",
+            "contentPolicy": "no_transcript_content",
+        },
+        {
+            "surfaceId": "retention_rule",
+            "label": "retention rule",
+            "state": "not_configured",
+            "enabled": False,
+            "summary": "No retention period, deletion rule, or migration rule is configured.",
+            "sideEffectPolicy": "no_retention_write",
+            "contentPolicy": "retention_metadata_only",
+        },
+    ],
+    "storeControls": [
+        {
+            "controlId": "configure_store",
+            "label": "configure store",
+            "state": "disabled",
+            "enabled": False,
+            "userAction": "Configure a local store only after explicit storage, path, and privacy review.",
+            "launcherAction": "Keep store configuration disabled and do not read or write config.",
+            "sideEffectPolicy": "no_config_read_or_write",
+            "blockedReasonRef": "store_path_boundary_absent",
+        },
+        {
+            "controlId": "read_store_path",
+            "label": "read store path",
+            "state": "blocked",
+            "enabled": False,
+            "userAction": "Read a configured store path only after explicit local path review.",
+            "launcherAction": "Refuse path reads because no config/path boundary exists.",
+            "sideEffectPolicy": "no_config_or_path_read",
+            "blockedReasonRef": "store_path_boundary_absent",
+        },
+        {
+            "controlId": "read_manifest",
+            "label": "read manifest",
+            "state": "blocked",
+            "enabled": False,
+            "userAction": "Read a manifest only after schema, redaction, and migration rules are reviewed.",
+            "launcherAction": "Refuse manifest reads because no session-store boundary exists.",
+            "sideEffectPolicy": "no_manifest_read",
+            "blockedReasonRef": "manifest_schema_absent",
+        },
+        {
+            "controlId": "read_session_record",
+            "label": "read session record",
+            "state": "blocked",
+            "enabled": False,
+            "userAction": "Read session records only after local store and content redaction review.",
+            "launcherAction": "Refuse session-record reads.",
+            "sideEffectPolicy": "no_session_store_read",
+            "blockedReasonRef": "session_store_read_boundary_absent",
+        },
+        {
+            "controlId": "write_session_record",
+            "label": "write session record",
+            "state": "disabled",
+            "enabled": False,
+            "userAction": "Persist sessions only after a reviewed write, retention, and rollback policy exists.",
+            "launcherAction": "Refuse session writes and do not create store files.",
+            "sideEffectPolicy": "no_session_store_write",
+            "blockedReasonRef": "session_store_write_boundary_absent",
+        },
+        {
+            "controlId": "delete_session_record",
+            "label": "delete session record",
+            "state": "disabled",
+            "enabled": False,
+            "userAction": "Delete records only after retention, confirmation, and rollback rules exist.",
+            "launcherAction": "Keep deletion disabled and do not mutate a store.",
+            "sideEffectPolicy": "no_delete_no_write",
+            "blockedReasonRef": "deletion_retention_policy_absent",
+        },
+        {
+            "controlId": "migrate_store",
+            "label": "migrate store",
+            "state": "disabled",
+            "enabled": False,
+            "userAction": "Migrate a store only after versioned schema and rollback review.",
+            "launcherAction": "Keep migration disabled and do not inspect or rewrite store files.",
+            "sideEffectPolicy": "no_migration_no_store_read",
+            "blockedReasonRef": "migration_policy_absent",
+        },
+        {
+            "controlId": "persist_store_policy",
+            "label": "persist store policy",
+            "state": "disabled",
+            "enabled": False,
+            "userAction": "Persist policy only after configuration storage is reviewed.",
+            "launcherAction": "Do not write policy, preference, or config files.",
+            "sideEffectPolicy": "no_policy_write",
+            "blockedReasonRef": "session_store_write_boundary_absent",
+        },
+    ],
+    "blockedReasons": [
+        {
+            "reasonId": "store_not_configured",
+            "state": "not_configured",
+            "summary": "No reviewed local chat session store is configured.",
+            "requiredBefore": "session_store_available",
+        },
+        {
+            "reasonId": "store_path_boundary_absent",
+            "state": "planned",
+            "summary": "No reviewed config/path boundary exists for locating a local store.",
+            "requiredBefore": "store_path_available",
+        },
+        {
+            "reasonId": "manifest_schema_absent",
+            "state": "not_configured",
+            "summary": "No reviewed manifest schema, version, or migration policy exists.",
+            "requiredBefore": "manifest_read_enabled",
+        },
+        {
+            "reasonId": "session_store_read_boundary_absent",
+            "state": "blocked",
+            "summary": "Session reads require reviewed manifest, redaction, and content policy.",
+            "requiredBefore": "read_session_record_enabled",
+        },
+        {
+            "reasonId": "session_store_write_boundary_absent",
+            "state": "disabled",
+            "summary": "Session writes require explicit local persistence and rollback policy.",
+            "requiredBefore": "write_session_record_enabled",
+        },
+        {
+            "reasonId": "deletion_retention_policy_absent",
+            "state": "requires_evidence",
+            "summary": "Deletion needs retention, confirmation, and recovery rules.",
+            "requiredBefore": "delete_session_record_enabled",
+        },
+        {
+            "reasonId": "migration_policy_absent",
+            "state": "not_configured",
+            "summary": "No versioned schema migration or rollback policy exists.",
+            "requiredBefore": "migrate_store_enabled",
+        },
+        {
+            "reasonId": "redaction_policy_absent",
+            "state": "planned",
+            "summary": "Stored content would require prompt, response, transcript, title, and summary redaction rules.",
+            "requiredBefore": "stored_content_allowed",
+        },
+    ],
+    "handoffRefs": [
+        {
+            "refId": "chat_session",
+            "schemaVersion": "pccx.chatSession.v0",
+            "fixturePath": "contracts/fixtures/chat-session.gemma3n-e4b-kv260-placeholder.json",
+            "state": "inactive",
+            "summary": "Base chat session remains inactive and does not persist state.",
+        },
+        {
+            "refId": "chat_session_index",
+            "schemaVersion": "pccx.chatSessionIndex.v0",
+            "fixturePath": "contracts/fixtures/chat-session-index.gemma3n-e4b-kv260-placeholder.json",
+            "state": "not_configured",
+            "summary": "Session index remains empty and does not read a store.",
+        },
+        {
+            "refId": "chat_session_lifecycle",
+            "schemaVersion": "pccx.chatSessionLifecycle.v0",
+            "fixturePath": "contracts/fixtures/chat-session-lifecycle.gemma3n-e4b-kv260-placeholder.json",
+            "state": "blocked",
+            "summary": "Lifecycle create, restore, clear, close, and export actions remain disabled or blocked.",
+        },
+        {
+            "refId": "chat_session_title_policy",
+            "schemaVersion": "pccx.chatSessionTitlePolicy.v0",
+            "fixturePath": "contracts/fixtures/chat-session-title-policy.gemma3n-e4b-kv260-placeholder.json",
+            "state": "blocked",
+            "summary": "Stored title reads, generation, rename, and persistence remain disabled or blocked.",
+        },
+        {
+            "refId": "chat_transcript_policy",
+            "schemaVersion": "pccx.chatTranscriptPolicy.v0",
+            "fixturePath": "contracts/fixtures/chat-transcript-policy.gemma3n-e4b-kv260-placeholder.json",
+            "state": "disabled",
+            "summary": "Transcript persistence and export remain disabled.",
+        },
+        {
+            "refId": "chat_preferences",
+            "schemaVersion": "pccx.chatPreferences.v0",
+            "fixturePath": "contracts/fixtures/chat-preferences.gemma3n-e4b-kv260-placeholder.json",
+            "state": "blocked",
+            "summary": "Preferences do not read or write store paths.",
+        },
+    ],
+    "safetyFlags": {
+        "dataOnly": True,
+        "readOnly": True,
+        "deterministic": True,
+        "sessionStorePolicyDisplayOnly": True,
+        "storeMetadataOnly": True,
+        "storeConfigured": False,
+        "storePathConfigured": False,
+        "storePathIncluded": False,
+        "configRead": False,
+        "configWrite": False,
+        "environmentRead": False,
+        "readsSessionStore": False,
+        "sessionStoreRead": False,
+        "sessionStoreWrite": False,
+        "readsSessionManifest": False,
+        "manifestContentIncluded": False,
+        "sessionRecordIncluded": False,
+        "sessionPersistence": False,
+        "sessionDeletion": False,
+        "retentionPolicyActive": False,
+        "migrationAttempted": False,
+        "rollbackAttempted": False,
+        "readsSessionTitle": False,
+        "sessionTitleIncluded": False,
+        "titleContentIncluded": False,
+        "titlePersistence": False,
+        "readsTranscript": False,
+        "transcriptPersistence": False,
+        "transcriptExport": False,
+        "messageBodiesIncluded": False,
+        "summaryIncluded": False,
+        "summaryGenerated": False,
+        "promptCapture": False,
+        "promptContentIncluded": False,
+        "promptEchoed": False,
+        "promptPersistence": False,
+        "responseContentIncluded": False,
+        "responseGenerated": False,
+        "attachmentReads": False,
+        "clipboardRead": False,
+        "clipboardWrite": False,
+        "writesArtifacts": False,
+        "readsArtifacts": False,
+        "artifactWrites": False,
+        "artifactReads": False,
+        "privatePathsIncluded": False,
+        "secretsIncluded": False,
+        "tokensIncluded": False,
+        "modelAssetRead": False,
+        "modelAssetPathsIncluded": False,
+        "modelWeightPathsIncluded": False,
+        "modelLoadAttempted": False,
+        "modelLoaded": False,
+        "modelExecution": False,
+        "runtimeExecution": False,
+        "touchesHardware": False,
+        "hardwareAccess": False,
+        "kv260Access": False,
+        "opensSerialPort": False,
+        "networkCalls": False,
+        "networkScan": False,
+        "sshExecution": False,
+        "providerCalls": False,
+        "cloudCalls": False,
+        "runtimeLogsIncluded": False,
+        "generatedBlobsIncluded": False,
+        "hardwareDumpsIncluded": False,
+        "telemetry": False,
+        "automaticUpload": False,
+        "writeBack": False,
+        "executesPccxLab": False,
+        "executesSystemverilogIde": False,
+        "mcpServerImplemented": False,
+        "lspImplemented": False,
+        "stableApiAbiClaim": False,
+    },
+    "limitations": [
+        "Data-only chat session-store policy fixture; no real local session store is configured or read.",
+        "No store path, private path, manifest body, session record, stored title, transcript, prompt, response, summary, model path, runtime log, secret, or token content is included.",
+        "No configuration file, environment value, session store, manifest, transcript, title, prompt, response, summary, attachment, artifact, model asset, private path, raw log, or hardware dump is read.",
+        "No session, transcript, title, policy, config, preference, artifact, or store file is written, deleted, migrated, persisted, imported, exported, compacted, or rolled back.",
+        "No model load, runtime execution, provider call, network call, pccx-lab invocation, systemverilog-ide invocation, or KV260 hardware access is performed.",
+        "This is not a release, tag, compatibility commitment, MCP, LSP, IDE, marketplace, telemetry, runtime, model, session-store, migration, or storage implementation.",
+    ],
+    "issueRefs": [
+        "pccxai/pccx-llm-launcher#9",
+    ],
+}
+
+
+def create_gemma3n_e4b_kv260_chat_session_store_policy() -> dict:
+    """Return the checked Gemma 3N E4B plus KV260 session-store policy fixture."""
+    return copy.deepcopy(_CHAT_SESSION_STORE_POLICY)
+
+
+def chat_session_store_policy_json(policy: dict | None = None) -> str:
+    """Render a deterministic JSON representation."""
+    return json.dumps(
+        policy
+        if policy is not None
+        else create_gemma3n_e4b_kv260_chat_session_store_policy(),
+        indent=2,
+        sort_keys=True,
+    ) + "\n"
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Print data-only chat session-store policy JSON.",
+    )
+    parser.add_argument(
+        "--model",
+        default="gemma3n-e4b",
+        choices=("gemma3n-e4b",),
+        help="model descriptor target",
+    )
+    parser.add_argument(
+        "--target",
+        default="kv260",
+        choices=("kv260",),
+        help="target board/device",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parse_args(sys.argv[1:] if argv is None else argv)
+    sys.stdout.write(chat_session_store_policy_json())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contracts/fixtures/chat-session-store-policy.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-session-store-policy.gemma3n-e4b-kv260-placeholder.json
@@ -1,0 +1,360 @@
+{
+  "blockedReasons": [
+    {
+      "reasonId": "store_not_configured",
+      "requiredBefore": "session_store_available",
+      "state": "not_configured",
+      "summary": "No reviewed local chat session store is configured."
+    },
+    {
+      "reasonId": "store_path_boundary_absent",
+      "requiredBefore": "store_path_available",
+      "state": "planned",
+      "summary": "No reviewed config/path boundary exists for locating a local store."
+    },
+    {
+      "reasonId": "manifest_schema_absent",
+      "requiredBefore": "manifest_read_enabled",
+      "state": "not_configured",
+      "summary": "No reviewed manifest schema, version, or migration policy exists."
+    },
+    {
+      "reasonId": "session_store_read_boundary_absent",
+      "requiredBefore": "read_session_record_enabled",
+      "state": "blocked",
+      "summary": "Session reads require reviewed manifest, redaction, and content policy."
+    },
+    {
+      "reasonId": "session_store_write_boundary_absent",
+      "requiredBefore": "write_session_record_enabled",
+      "state": "disabled",
+      "summary": "Session writes require explicit local persistence and rollback policy."
+    },
+    {
+      "reasonId": "deletion_retention_policy_absent",
+      "requiredBefore": "delete_session_record_enabled",
+      "state": "requires_evidence",
+      "summary": "Deletion needs retention, confirmation, and recovery rules."
+    },
+    {
+      "reasonId": "migration_policy_absent",
+      "requiredBefore": "migrate_store_enabled",
+      "state": "not_configured",
+      "summary": "No versioned schema migration or rollback policy exists."
+    },
+    {
+      "reasonId": "redaction_policy_absent",
+      "requiredBefore": "stored_content_allowed",
+      "state": "planned",
+      "summary": "Stored content would require prompt, response, transcript, title, and summary redaction rules."
+    }
+  ],
+  "chatPreferencesRef": "chat_preferences_gemma3n_e4b_kv260_placeholder",
+  "chatSessionIndexRef": "chat_session_index_gemma3n_e4b_kv260_placeholder",
+  "chatSessionLifecycleRef": "chat_session_lifecycle_gemma3n_e4b_kv260_placeholder",
+  "chatSessionRef": "chat_session_gemma3n_e4b_kv260_placeholder",
+  "chatSessionTitlePolicyRef": "chat_session_title_policy_gemma3n_e4b_kv260_placeholder",
+  "chatTranscriptPolicyRef": "chat_transcript_policy_gemma3n_e4b_kv260_placeholder",
+  "deleteState": "disabled",
+  "fixtureVersion": "chat-session-store-policy.gemma3n-e4b-kv260.2026-05-04",
+  "handoffRefs": [
+    {
+      "fixturePath": "contracts/fixtures/chat-session.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_session",
+      "schemaVersion": "pccx.chatSession.v0",
+      "state": "inactive",
+      "summary": "Base chat session remains inactive and does not persist state."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-session-index.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_session_index",
+      "schemaVersion": "pccx.chatSessionIndex.v0",
+      "state": "not_configured",
+      "summary": "Session index remains empty and does not read a store."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-session-lifecycle.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_session_lifecycle",
+      "schemaVersion": "pccx.chatSessionLifecycle.v0",
+      "state": "blocked",
+      "summary": "Lifecycle create, restore, clear, close, and export actions remain disabled or blocked."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-session-title-policy.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_session_title_policy",
+      "schemaVersion": "pccx.chatSessionTitlePolicy.v0",
+      "state": "blocked",
+      "summary": "Stored title reads, generation, rename, and persistence remain disabled or blocked."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-transcript-policy.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_transcript_policy",
+      "schemaVersion": "pccx.chatTranscriptPolicy.v0",
+      "state": "disabled",
+      "summary": "Transcript persistence and export remain disabled."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-preferences.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_preferences",
+      "schemaVersion": "pccx.chatPreferences.v0",
+      "state": "blocked",
+      "summary": "Preferences do not read or write store paths."
+    }
+  ],
+  "issueRefs": [
+    "pccxai/pccx-llm-launcher#9"
+  ],
+  "lastUpdatedSource": "pccx_launcher_issue_9_chat_session_store_policy_boundary_2026-05-04",
+  "limitations": [
+    "Data-only chat session-store policy fixture; no real local session store is configured or read.",
+    "No store path, private path, manifest body, session record, stored title, transcript, prompt, response, summary, model path, runtime log, secret, or token content is included.",
+    "No configuration file, environment value, session store, manifest, transcript, title, prompt, response, summary, attachment, artifact, model asset, private path, raw log, or hardware dump is read.",
+    "No session, transcript, title, policy, config, preference, artifact, or store file is written, deleted, migrated, persisted, imported, exported, compacted, or rolled back.",
+    "No model load, runtime execution, provider call, network call, pccx-lab invocation, systemverilog-ide invocation, or KV260 hardware access is performed.",
+    "This is not a release, tag, compatibility commitment, MCP, LSP, IDE, marketplace, telemetry, runtime, model, session-store, migration, or storage implementation."
+  ],
+  "manifestState": "not_configured",
+  "migrationState": "disabled",
+  "privacyState": "summary_only",
+  "readState": "blocked",
+  "retentionState": "not_configured",
+  "safetyFlags": {
+    "artifactReads": false,
+    "artifactWrites": false,
+    "attachmentReads": false,
+    "automaticUpload": false,
+    "clipboardRead": false,
+    "clipboardWrite": false,
+    "cloudCalls": false,
+    "configRead": false,
+    "configWrite": false,
+    "dataOnly": true,
+    "deterministic": true,
+    "environmentRead": false,
+    "executesPccxLab": false,
+    "executesSystemverilogIde": false,
+    "generatedBlobsIncluded": false,
+    "hardwareAccess": false,
+    "hardwareDumpsIncluded": false,
+    "kv260Access": false,
+    "lspImplemented": false,
+    "manifestContentIncluded": false,
+    "mcpServerImplemented": false,
+    "messageBodiesIncluded": false,
+    "migrationAttempted": false,
+    "modelAssetPathsIncluded": false,
+    "modelAssetRead": false,
+    "modelExecution": false,
+    "modelLoadAttempted": false,
+    "modelLoaded": false,
+    "modelWeightPathsIncluded": false,
+    "networkCalls": false,
+    "networkScan": false,
+    "opensSerialPort": false,
+    "privatePathsIncluded": false,
+    "promptCapture": false,
+    "promptContentIncluded": false,
+    "promptEchoed": false,
+    "promptPersistence": false,
+    "providerCalls": false,
+    "readOnly": true,
+    "readsArtifacts": false,
+    "readsSessionManifest": false,
+    "readsSessionStore": false,
+    "readsSessionTitle": false,
+    "readsTranscript": false,
+    "responseContentIncluded": false,
+    "responseGenerated": false,
+    "retentionPolicyActive": false,
+    "rollbackAttempted": false,
+    "runtimeExecution": false,
+    "runtimeLogsIncluded": false,
+    "secretsIncluded": false,
+    "sessionDeletion": false,
+    "sessionPersistence": false,
+    "sessionRecordIncluded": false,
+    "sessionStorePolicyDisplayOnly": true,
+    "sessionStoreRead": false,
+    "sessionStoreWrite": false,
+    "sessionTitleIncluded": false,
+    "sshExecution": false,
+    "stableApiAbiClaim": false,
+    "storeConfigured": false,
+    "storeMetadataOnly": true,
+    "storePathConfigured": false,
+    "storePathIncluded": false,
+    "summaryGenerated": false,
+    "summaryIncluded": false,
+    "telemetry": false,
+    "titleContentIncluded": false,
+    "titlePersistence": false,
+    "tokensIncluded": false,
+    "touchesHardware": false,
+    "transcriptExport": false,
+    "transcriptPersistence": false,
+    "writeBack": false,
+    "writesArtifacts": false
+  },
+  "schemaVersion": "pccx.chatSessionStorePolicy.v0",
+  "sessionStorePolicy": {
+    "contentPolicy": "session-store policy metadata only; no store path, manifest body, session record, transcript text, title text, prompt text, response text, summary text, or model path is included",
+    "deleteEnabled": false,
+    "manifestSchemaConfigured": false,
+    "migrationEnabled": false,
+    "mode": "disabled_until_reviewed_local_session_store_boundary_exists",
+    "readEnabled": false,
+    "retentionEnabled": false,
+    "sideEffectPolicy": "local_render_only",
+    "sourcePolicy": "checked fixture only; no config, environment, path, manifest, transcript, title, prompt, response, summary, artifact, model path, or runtime log is read",
+    "state": "blocked",
+    "storeConfigured": false,
+    "storePathConfigured": false,
+    "writeEnabled": false
+  },
+  "sessionStorePolicyId": "chat_session_store_policy_gemma3n_e4b_kv260_placeholder",
+  "sessionStorePolicyState": "blocked",
+  "storeControls": [
+    {
+      "blockedReasonRef": "store_path_boundary_absent",
+      "controlId": "configure_store",
+      "enabled": false,
+      "label": "configure store",
+      "launcherAction": "Keep store configuration disabled and do not read or write config.",
+      "sideEffectPolicy": "no_config_read_or_write",
+      "state": "disabled",
+      "userAction": "Configure a local store only after explicit storage, path, and privacy review."
+    },
+    {
+      "blockedReasonRef": "store_path_boundary_absent",
+      "controlId": "read_store_path",
+      "enabled": false,
+      "label": "read store path",
+      "launcherAction": "Refuse path reads because no config/path boundary exists.",
+      "sideEffectPolicy": "no_config_or_path_read",
+      "state": "blocked",
+      "userAction": "Read a configured store path only after explicit local path review."
+    },
+    {
+      "blockedReasonRef": "manifest_schema_absent",
+      "controlId": "read_manifest",
+      "enabled": false,
+      "label": "read manifest",
+      "launcherAction": "Refuse manifest reads because no session-store boundary exists.",
+      "sideEffectPolicy": "no_manifest_read",
+      "state": "blocked",
+      "userAction": "Read a manifest only after schema, redaction, and migration rules are reviewed."
+    },
+    {
+      "blockedReasonRef": "session_store_read_boundary_absent",
+      "controlId": "read_session_record",
+      "enabled": false,
+      "label": "read session record",
+      "launcherAction": "Refuse session-record reads.",
+      "sideEffectPolicy": "no_session_store_read",
+      "state": "blocked",
+      "userAction": "Read session records only after local store and content redaction review."
+    },
+    {
+      "blockedReasonRef": "session_store_write_boundary_absent",
+      "controlId": "write_session_record",
+      "enabled": false,
+      "label": "write session record",
+      "launcherAction": "Refuse session writes and do not create store files.",
+      "sideEffectPolicy": "no_session_store_write",
+      "state": "disabled",
+      "userAction": "Persist sessions only after a reviewed write, retention, and rollback policy exists."
+    },
+    {
+      "blockedReasonRef": "deletion_retention_policy_absent",
+      "controlId": "delete_session_record",
+      "enabled": false,
+      "label": "delete session record",
+      "launcherAction": "Keep deletion disabled and do not mutate a store.",
+      "sideEffectPolicy": "no_delete_no_write",
+      "state": "disabled",
+      "userAction": "Delete records only after retention, confirmation, and rollback rules exist."
+    },
+    {
+      "blockedReasonRef": "migration_policy_absent",
+      "controlId": "migrate_store",
+      "enabled": false,
+      "label": "migrate store",
+      "launcherAction": "Keep migration disabled and do not inspect or rewrite store files.",
+      "sideEffectPolicy": "no_migration_no_store_read",
+      "state": "disabled",
+      "userAction": "Migrate a store only after versioned schema and rollback review."
+    },
+    {
+      "blockedReasonRef": "session_store_write_boundary_absent",
+      "controlId": "persist_store_policy",
+      "enabled": false,
+      "label": "persist store policy",
+      "launcherAction": "Do not write policy, preference, or config files.",
+      "sideEffectPolicy": "no_policy_write",
+      "state": "disabled",
+      "userAction": "Persist policy only after configuration storage is reviewed."
+    }
+  ],
+  "storePathState": "not_configured",
+  "storeState": "not_configured",
+  "storeSurfaces": [
+    {
+      "contentPolicy": "no_store_path_or_private_path",
+      "enabled": false,
+      "label": "local store path",
+      "sideEffectPolicy": "no_config_or_path_read",
+      "state": "not_configured",
+      "summary": "No local session-store path is configured, read, resolved, or emitted.",
+      "surfaceId": "local_store_path"
+    },
+    {
+      "contentPolicy": "no_manifest_body_or_session_ids",
+      "enabled": false,
+      "label": "session manifest",
+      "sideEffectPolicy": "no_manifest_read",
+      "state": "not_configured",
+      "summary": "No manifest schema is configured and no manifest is read.",
+      "surfaceId": "session_manifest"
+    },
+    {
+      "contentPolicy": "no_session_record_or_message_content",
+      "enabled": false,
+      "label": "session record",
+      "sideEffectPolicy": "no_session_store_read",
+      "state": "blocked",
+      "summary": "Session records stay unavailable until a reviewed read/write boundary exists.",
+      "surfaceId": "session_record"
+    },
+    {
+      "contentPolicy": "no_session_title_content",
+      "enabled": false,
+      "label": "title record",
+      "sideEffectPolicy": "no_session_title_read",
+      "state": "blocked",
+      "summary": "Stored titles remain unavailable because no title-read boundary exists.",
+      "surfaceId": "title_record"
+    },
+    {
+      "contentPolicy": "no_transcript_content",
+      "enabled": false,
+      "label": "transcript record",
+      "sideEffectPolicy": "no_transcript_read_or_persistence",
+      "state": "disabled",
+      "summary": "Transcript records are not retained or read.",
+      "surfaceId": "transcript_record"
+    },
+    {
+      "contentPolicy": "retention_metadata_only",
+      "enabled": false,
+      "label": "retention rule",
+      "sideEffectPolicy": "no_retention_write",
+      "state": "not_configured",
+      "summary": "No retention period, deletion rule, or migration rule is configured.",
+      "surfaceId": "retention_rule"
+    }
+  ],
+  "targetBoard": "xilinx_kria_kv260",
+  "targetDevice": "kv260",
+  "targetModel": "gemma3n-e4b",
+  "writeState": "disabled"
+}

--- a/docs/STANDALONE_CHAT_SESSION_CONTRACT.md
+++ b/docs/STANDALONE_CHAT_SESSION_CONTRACT.md
@@ -15,6 +15,7 @@ The implementation lives in:
 - `contracts/chat_local_only_policy_contract.py`
 - `contracts/chat_preferences_contract.py`
 - `contracts/chat_session_index_contract.py`
+- `contracts/chat_session_store_policy_contract.py`
 - `contracts/chat_session_title_policy_contract.py`
 - `contracts/chat_readiness_contract.py`
 - `contracts/chat_composer_contract.py`
@@ -33,6 +34,7 @@ The implementation lives in:
 - `contracts/fixtures/chat-local-only-policy.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-preferences.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-session-index.gemma3n-e4b-kv260-placeholder.json`
+- `contracts/fixtures/chat-session-store-policy.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-session-title-policy.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-readiness.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-composer.gemma3n-e4b-kv260-placeholder.json`
@@ -51,6 +53,7 @@ The implementation lives in:
 - `scripts/chat-local-only-policy-stub.sh`
 - `scripts/chat-preferences-stub.sh`
 - `scripts/chat-session-index-stub.sh`
+- `scripts/chat-session-store-policy-stub.sh`
 - `scripts/chat-session-title-policy-stub.sh`
 - `scripts/chat-readiness-stub.sh`
 - `scripts/chat-composer-stub.sh`
@@ -70,6 +73,7 @@ The implementation lives in:
 - `scripts/tests/chat_local_only_policy_contract_test.py`
 - `scripts/tests/chat_preferences_contract_test.py`
 - `scripts/tests/chat_session_index_contract_test.py`
+- `scripts/tests/chat_session_store_policy_contract_test.py`
 - `scripts/tests/chat_session_title_policy_contract_test.py`
 - `scripts/tests/chat_readiness_contract_test.py`
 - `scripts/tests/chat_composer_contract_test.py`
@@ -87,6 +91,7 @@ The implementation lives in:
 - `scripts/tests/status-chat-local-only-policy.sh`
 - `scripts/tests/status-chat-preferences.sh`
 - `scripts/tests/status-chat-session-index.sh`
+- `scripts/tests/status-chat-session-store-policy.sh`
 - `scripts/tests/status-chat-session-title-policy.sh`
 - `scripts/tests/status-chat-readiness.sh`
 - `scripts/tests/status-chat-composer.sh`
@@ -117,6 +122,8 @@ The chat/session contract records:
   configuration reads or preference writes
 - an empty session index/list surface with disabled refresh, selection,
   restore, rename, and delete controls
+- a chat session-store policy with disabled store configuration, path,
+  manifest, read, write, delete, retention, and migration gates
 - a chat session-title policy with static placeholder display names and
   disabled stored-title read, title generation, rename, and persistence
   controls
@@ -230,6 +237,21 @@ unavailable, or blocked. The fixture does not read a session store,
 session manifest, session title, transcript, summary, prompt, response,
 model path, private path, or raw log, and it does not write, delete,
 refresh, import, export, or persist artifacts.
+
+The chat session-store policy fixture records the local storage boundary
+for future chat sessions:
+
+```bash
+bash scripts/chat-session-store-policy-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/status-stub.sh --include-chat-session-store-policy
+```
+
+It reports disabled store configuration, store path, manifest, read,
+write, delete, retention, and migration gates. The fixture does not read
+configuration files, environment values, store paths, private paths,
+manifests, session records, transcripts, titles, prompts, responses,
+summaries, model paths, runtime logs, or artifacts, and it does not write,
+delete, migrate, import, export, persist, compact, or roll back any store.
 
 The chat session-title policy fixture records the display-name boundary
 for future local chat sessions:
@@ -636,6 +658,11 @@ the composer, or enabling runtime/model/store actions.
 The session-index contract adds a reviewable empty list/sidebar boundary
 without enabling manifest reads, transcript reads, title capture,
 restore, rename, delete, refresh, persistence, or artifact writes.
+The session-store policy contract adds a reviewable disabled local store
+policy shape without configuration reads, path reads, manifest reads,
+session record reads, transcript reads, title reads, prompt/response reads,
+store writes, deletion, migration, retention activation, artifact access,
+runtime execution, model loading, provider calls, or target access.
 The composer contract adds a reviewable input-control and validation
 shape without prompt capture, prompt echo, prompt persistence, attachment
 reads, clipboard access, or send enablement.
@@ -703,6 +730,8 @@ This chat/session surface does not add:
 - session creation, restore, clear, close, or export behavior
 - readiness recovery execution
 - manifest, transcript, summary, or lifecycle artifact reads or writes
+- session-store configuration, path, manifest, record, read, write,
+  delete, retention, migration, compaction, rollback, import, or export
 - model loading or model weight paths
 - KV260 runtime execution
 - serial, SSH, or network target access

--- a/scripts/chat-session-store-policy-stub.sh
+++ b/scripts/chat-session-store-policy-stub.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+# Print the data-only chat session-store policy contract.
+
+set -eu
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+
+python3 "$ROOT_DIR/contracts/chat_session_store_policy_contract.py" "$@"

--- a/scripts/status-stub.sh
+++ b/scripts/status-stub.sh
@@ -25,6 +25,9 @@
 # Chat session index/sidebar plan (explicit opt-in, read-only local data):
 #   --include-chat-session-index
 #
+# Chat session-store policy (explicit opt-in, read-only local data):
+#   --include-chat-session-store-policy
+#
 # Chat session-title display policy (explicit opt-in, read-only local data):
 #   --include-chat-session-title-policy
 #
@@ -86,6 +89,7 @@ INCLUDE_CHAT_SURFACE_LAYOUT="0"
 INCLUDE_CHAT_LOCAL_ONLY_POLICY="0"
 INCLUDE_CHAT_PREFERENCES="0"
 INCLUDE_CHAT_SESSION_INDEX="0"
+INCLUDE_CHAT_SESSION_STORE_POLICY="0"
 INCLUDE_CHAT_SESSION_TITLE_POLICY="0"
 INCLUDE_CHAT_MODEL_STATUS="0"
 INCLUDE_CHAT_READINESS="0"
@@ -1160,6 +1164,140 @@ print(
     printf '%s\n' "$CHAT_SESSION_INDEX_SUMMARY"
 }
 
+print_chat_session_store_policy_summary() {
+    SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+    ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+    CHAT_SESSION_STORE_POLICY_STUB="$ROOT_DIR/scripts/chat-session-store-policy-stub.sh"
+
+    if [ ! -f "$CHAT_SESSION_STORE_POLICY_STUB" ]; then
+        ERROR "chat session-store policy stub not found: $CHAT_SESSION_STORE_POLICY_STUB"
+        return 1
+    fi
+
+    if ! CHAT_SESSION_STORE_POLICY_JSON="$(bash "$CHAT_SESSION_STORE_POLICY_STUB" --model gemma3n-e4b --target kv260 2>&1)"; then
+        ERROR "chat session-store policy stub failed"
+        printf '%s\n' "$CHAT_SESSION_STORE_POLICY_JSON" >&2
+        return 1
+    fi
+
+    if ! CHAT_SESSION_STORE_POLICY_SUMMARY="$(
+        printf '%s\n' "$CHAT_SESSION_STORE_POLICY_JSON" | python3 -c '
+import json
+import sys
+
+data = json.load(sys.stdin)
+flags = data["safetyFlags"]
+policy = data["sessionStorePolicy"]
+
+def b(value):
+    return "true" if value else "false"
+
+surfaces = " ".join(
+    "{}={}:{}".format(surface["surfaceId"], surface["state"], b(surface["enabled"]))
+    for surface in data["storeSurfaces"]
+)
+controls = " ".join(
+    "{}={}:{}".format(control["controlId"], control["state"], b(control["enabled"]))
+    for control in data["storeControls"]
+)
+blocked = " ".join(
+    "{}={}".format(reason["reasonId"], reason["state"])
+    for reason in data["blockedReasons"]
+)
+
+print("[INFO]  source     : scripts/chat-session-store-policy-stub.sh --model gemma3n-e4b --target kv260")
+print("[INFO]  boundary   : read-only data; no config/path/manifest/session-store/transcript/title/prompt/model/runtime/hardware/lab/IDE execution")
+print("[INFO]  target     : {}".format(data["targetDevice"]))
+print("[INFO]  model      : {}".format(data["targetModel"]))
+print("[INFO]  policy     : {}".format(data["sessionStorePolicyState"]))
+print("[INFO]  store      : {}".format(data["storeState"]))
+print("[INFO]  path       : {}".format(data["storePathState"]))
+print("[INFO]  manifest   : {}".format(data["manifestState"]))
+print("[INFO]  read       : {}".format(data["readState"]))
+print("[INFO]  write      : {}".format(data["writeState"]))
+print("[INFO]  delete     : {}".format(data["deleteState"]))
+print("[INFO]  retention  : {}".format(data["retentionState"]))
+print("[INFO]  migration  : {}".format(data["migrationState"]))
+print("[INFO]  privacy    : {}".format(data["privacyState"]))
+print(
+    "[INFO]  session-store-policy : {} mode={} storeConfigured={} "
+    "storePathConfigured={} manifestSchemaConfigured={} readEnabled={} "
+    "writeEnabled={} deleteEnabled={} retentionEnabled={} "
+    "migrationEnabled={}".format(
+        policy["state"],
+        policy["mode"],
+        b(policy["storeConfigured"]),
+        b(policy["storePathConfigured"]),
+        b(policy["manifestSchemaConfigured"]),
+        b(policy["readEnabled"]),
+        b(policy["writeEnabled"]),
+        b(policy["deleteEnabled"]),
+        b(policy["retentionEnabled"]),
+        b(policy["migrationEnabled"]),
+    )
+)
+print("[INFO]  surfaces   : {}".format(surfaces))
+print("[INFO]  controls   : {}".format(controls))
+print("[INFO]  blocked    : {}".format(blocked))
+print(
+    "[INFO]  flags      : readOnly={} dataOnly={} deterministic={} "
+    "sessionStorePolicyDisplayOnly={} storeMetadataOnly={} "
+    "storeConfigured={} storePathConfigured={} storePathIncluded={} "
+    "configRead={} configWrite={} readsSessionStore={} "
+    "sessionStoreRead={} sessionStoreWrite={} readsSessionManifest={} "
+    "manifestContentIncluded={} sessionRecordIncluded={} "
+    "sessionPersistence={} sessionDeletion={} retentionPolicyActive={} "
+    "migrationAttempted={} readsSessionTitle={} sessionTitleIncluded={} "
+    "readsTranscript={} promptContentIncluded={} responseContentIncluded={} "
+    "writesArtifacts={} readsArtifacts={} modelExecution={} "
+    "runtimeExecution={} kv260Access={} hardwareAccess={} networkCalls={} "
+    "providerCalls={} executesPccxLab={}".format(
+        b(flags["readOnly"]),
+        b(flags["dataOnly"]),
+        b(flags["deterministic"]),
+        b(flags["sessionStorePolicyDisplayOnly"]),
+        b(flags["storeMetadataOnly"]),
+        b(flags["storeConfigured"]),
+        b(flags["storePathConfigured"]),
+        b(flags["storePathIncluded"]),
+        b(flags["configRead"]),
+        b(flags["configWrite"]),
+        b(flags["readsSessionStore"]),
+        b(flags["sessionStoreRead"]),
+        b(flags["sessionStoreWrite"]),
+        b(flags["readsSessionManifest"]),
+        b(flags["manifestContentIncluded"]),
+        b(flags["sessionRecordIncluded"]),
+        b(flags["sessionPersistence"]),
+        b(flags["sessionDeletion"]),
+        b(flags["retentionPolicyActive"]),
+        b(flags["migrationAttempted"]),
+        b(flags["readsSessionTitle"]),
+        b(flags["sessionTitleIncluded"]),
+        b(flags["readsTranscript"]),
+        b(flags["promptContentIncluded"]),
+        b(flags["responseContentIncluded"]),
+        b(flags["writesArtifacts"]),
+        b(flags["readsArtifacts"]),
+        b(flags["modelExecution"]),
+        b(flags["runtimeExecution"]),
+        b(flags["kv260Access"]),
+        b(flags["hardwareAccess"]),
+        b(flags["networkCalls"]),
+        b(flags["providerCalls"]),
+        b(flags["executesPccxLab"]),
+    )
+)
+'
+    )"; then
+        ERROR "chat session-store policy JSON could not be summarized"
+        return 1
+    fi
+
+    HEAD "chat session store policy"
+    printf '%s\n' "$CHAT_SESSION_STORE_POLICY_SUMMARY"
+}
+
 print_chat_session_title_policy_summary() {
     SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
     ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
@@ -2223,6 +2361,10 @@ while [ $# -gt 0 ]; do
             INCLUDE_CHAT_SESSION_INDEX="1"
             shift
             ;;
+        --include-chat-session-store-policy)
+            INCLUDE_CHAT_SESSION_STORE_POLICY="1"
+            shift
+            ;;
         --include-chat-session-title-policy)
             INCLUDE_CHAT_SESSION_TITLE_POLICY="1"
             shift
@@ -2290,8 +2432,8 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-if [ -n "$BACKEND" ] && { [ "$INCLUDE_RUNTIME_READINESS" = "1" ] || [ "$INCLUDE_DEVICE_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SURFACE_LAYOUT" = "1" ] || [ "$INCLUDE_CHAT_LOCAL_ONLY_POLICY" = "1" ] || [ "$INCLUDE_CHAT_PREFERENCES" = "1" ] || [ "$INCLUDE_CHAT_SESSION_INDEX" = "1" ] || [ "$INCLUDE_CHAT_SESSION_TITLE_POLICY" = "1" ] || [ "$INCLUDE_CHAT_MODEL_STATUS" = "1" ] || [ "$INCLUDE_CHAT_READINESS" = "1" ] || [ "$INCLUDE_CHAT_COMPOSER" = "1" ] || [ "$INCLUDE_CHAT_SEND_RESULT" = "1" ] || [ "$INCLUDE_CHAT_TRANSCRIPT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_AUDIT_EVENT" = "1" ] || [ "$INCLUDE_CHAT_ERROR_TAXONOMY" = "1" ] || [ "$INCLUDE_CHAT_RESPONSE_STREAM" = "1" ] || [ "$INCLUDE_CHAT_MESSAGE_LIST" = "1" ] || [ "$INCLUDE_CHAT_ACTION_BAR" = "1" ] || [ "$INCLUDE_CHAT_ATTACHMENT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_SHORTCUT_MAP" = "1" ]; }; then
-    ERROR "--include-runtime-readiness, --include-device-session, --include-chat-session, --include-chat-surface-layout, --include-chat-local-only-policy, --include-chat-preferences, --include-chat-session-index, --include-chat-session-title-policy, --include-chat-model-status, --include-chat-readiness, --include-chat-composer, --include-chat-send-result, --include-chat-transcript-policy, --include-chat-audit-event, --include-chat-error-taxonomy, --include-chat-response-stream, --include-chat-message-list, --include-chat-action-bar, --include-chat-attachment-policy, and --include-chat-shortcut-map are only supported in local scaffold mode"
+if [ -n "$BACKEND" ] && { [ "$INCLUDE_RUNTIME_READINESS" = "1" ] || [ "$INCLUDE_DEVICE_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SURFACE_LAYOUT" = "1" ] || [ "$INCLUDE_CHAT_LOCAL_ONLY_POLICY" = "1" ] || [ "$INCLUDE_CHAT_PREFERENCES" = "1" ] || [ "$INCLUDE_CHAT_SESSION_INDEX" = "1" ] || [ "$INCLUDE_CHAT_SESSION_STORE_POLICY" = "1" ] || [ "$INCLUDE_CHAT_SESSION_TITLE_POLICY" = "1" ] || [ "$INCLUDE_CHAT_MODEL_STATUS" = "1" ] || [ "$INCLUDE_CHAT_READINESS" = "1" ] || [ "$INCLUDE_CHAT_COMPOSER" = "1" ] || [ "$INCLUDE_CHAT_SEND_RESULT" = "1" ] || [ "$INCLUDE_CHAT_TRANSCRIPT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_AUDIT_EVENT" = "1" ] || [ "$INCLUDE_CHAT_ERROR_TAXONOMY" = "1" ] || [ "$INCLUDE_CHAT_RESPONSE_STREAM" = "1" ] || [ "$INCLUDE_CHAT_MESSAGE_LIST" = "1" ] || [ "$INCLUDE_CHAT_ACTION_BAR" = "1" ] || [ "$INCLUDE_CHAT_ATTACHMENT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_SHORTCUT_MAP" = "1" ]; }; then
+    ERROR "--include-runtime-readiness, --include-device-session, --include-chat-session, --include-chat-surface-layout, --include-chat-local-only-policy, --include-chat-preferences, --include-chat-session-index, --include-chat-session-store-policy, --include-chat-session-title-policy, --include-chat-model-status, --include-chat-readiness, --include-chat-composer, --include-chat-send-result, --include-chat-transcript-policy, --include-chat-audit-event, --include-chat-error-taxonomy, --include-chat-response-stream, --include-chat-message-list, --include-chat-action-bar, --include-chat-attachment-policy, and --include-chat-shortcut-map are only supported in local scaffold mode"
     exit 1
 fi
 
@@ -2311,6 +2453,7 @@ if [ -z "$BACKEND" ]; then
     NOTE "chat local    : opt-in via --include-chat-local-only-policy (read-only local-only policy data)"
     NOTE "chat prefs    : opt-in via --include-chat-preferences (read-only preferences data)"
     NOTE "chat index    : opt-in via --include-chat-session-index (read-only empty session index data)"
+    NOTE "chat store    : opt-in via --include-chat-session-store-policy (read-only session-store policy data)"
     NOTE "chat titles   : opt-in via --include-chat-session-title-policy (read-only title policy data)"
     NOTE "chat model    : opt-in via --include-chat-model-status (read-only model status display data)"
     NOTE "chat readiness: opt-in via --include-chat-readiness (read-only readiness and recovery data)"
@@ -2388,6 +2531,12 @@ if [ -z "$BACKEND" ]; then
 
     if [ "$INCLUDE_CHAT_SESSION_INDEX" = "1" ]; then
         if ! print_chat_session_index_summary; then
+            exit 1
+        fi
+    fi
+
+    if [ "$INCLUDE_CHAT_SESSION_STORE_POLICY" = "1" ]; then
+        if ! print_chat_session_store_policy_summary; then
             exit 1
         fi
     fi

--- a/scripts/tests/chat_session_store_policy_contract_test.py
+++ b/scripts/tests/chat_session_store_policy_contract_test.py
@@ -1,0 +1,398 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Fixture tests for the standalone chat session-store policy contract."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "contracts" / "chat_session_store_policy_contract.py"
+FIXTURE_PATH = (
+    ROOT
+    / "contracts"
+    / "fixtures"
+    / "chat-session-store-policy.gemma3n-e4b-kv260-placeholder.json"
+)
+SCRIPT_PATH = ROOT / "scripts" / "chat-session-store-policy-stub.sh"
+STATUS_TEST_PATH = ROOT / "scripts" / "tests" / "status-chat-session-store-policy.sh"
+DOC_PATH = ROOT / "docs" / "STANDALONE_CHAT_SESSION_CONTRACT.md"
+README_PATH = ROOT / "README.md"
+TEST_PATH = Path(__file__).resolve()
+CI_PATH = ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location(
+        "chat_session_store_policy_contract",
+        MODULE_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def iter_state_values(value):
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            if (
+                key == "state"
+                or key.endswith("State")
+                or key.endswith("Status")
+            ) and isinstance(nested, str):
+                yield nested
+            yield from iter_state_values(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            yield from iter_state_values(nested)
+
+
+def iter_keys(value):
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            yield key
+            yield from iter_keys(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            yield from iter_keys(nested)
+
+
+def assert_no_private_or_generated_data(text: str) -> None:
+    forbidden_patterns = [
+        r"/home/[^\s\"']+",
+        r"/Users/[^\s\"']+",
+        r"[A-Za-z]:\\Users\\",
+        r"\b(?:api[_-]?key|authorization|bearer|client[_-]?secret|password|private[_-]?key|secret|token)\b\s*[:=]",
+        r"\.(?:gguf|safetensors|ckpt|pt|pth|onnx)\b",
+        r"(?:weights|model_weights|model-cache)/(?:[^\"'\s]+)",
+        r"(?:raw[_-]?full[_-]?logs|hardware[_-]?dump|generated[_-]?blob)\s*[:=]",
+    ]
+    for pattern in forbidden_patterns:
+        assert not re.search(pattern, text, re.IGNORECASE), pattern
+
+
+def assert_no_runtime_implementation_terms(source: str) -> None:
+    forbidden = [
+        "subprocess",
+        "os.system",
+        "popen",
+        "socket",
+        "urllib",
+        "requests",
+        "http.client",
+        "openai",
+        "anthropic",
+        "gem" + "ini",
+        "modelcontextprotocol",
+        "websocket",
+        "xmutil",
+        "xrt-smi",
+        "lsusb",
+        "dmesg",
+    ]
+    lowered = source.lower()
+    for term in forbidden:
+        assert term not in lowered, term
+
+
+def assert_no_provider_configs(value) -> None:
+    forbidden_keys = {
+        "apiKey",
+        "accessToken",
+        "refreshToken",
+        "authorization",
+        "bearerToken",
+        "provider",
+        "providers",
+        "providerConfig",
+        "providerConfigs",
+    }
+    for key in iter_keys(value):
+        assert key not in forbidden_keys, key
+
+
+def assert_no_unsupported_claims(text: str) -> None:
+    literal_claims = [
+        "production" + "-ready",
+        "marketplace" + "-ready",
+        "stable " + "API",
+        "stable " + "ABI",
+        "KV260 inference " + "works",
+        "Gemma 3N E4B " + "runs on KV260",
+        "20 tok/s " + "achieved",
+        "timing " + "closed",
+        "bitstream " + "ready",
+        "launcher executes " + "pccx-lab",
+        "IDE controls " + "launcher",
+        "AI provider integration " + "is live",
+    ]
+    lowered = text.lower()
+    for claim in literal_claims:
+        assert claim.lower() not in lowered, claim
+
+
+def test_chat_session_store_policy_matches_fixture_and_is_deterministic() -> None:
+    module = load_module()
+    generated = module.create_gemma3n_e4b_kv260_chat_session_store_policy()
+    fixture = json.loads(read_text(FIXTURE_PATH))
+
+    assert generated == fixture
+    assert module.chat_session_store_policy_json(generated) == (
+        module.chat_session_store_policy_json(generated)
+    )
+    assert module.chat_session_store_policy_json(generated).endswith("\n")
+    assert json.loads(module.chat_session_store_policy_json(generated)) == fixture
+
+
+def test_cli_stub_outputs_deterministic_json() -> None:
+    fixture = json.loads(read_text(FIXTURE_PATH))
+    command = [
+        "bash",
+        str(SCRIPT_PATH),
+        "--model",
+        "gemma3n-e4b",
+        "--target",
+        "kv260",
+    ]
+    first = subprocess.run(command, check=True, capture_output=True, text=True)
+    second = subprocess.run(command, check=True, capture_output=True, text=True)
+
+    assert first.stderr == ""
+    assert first.stdout == second.stdout
+    assert first.stdout.endswith("\n")
+    assert json.loads(first.stdout) == fixture
+
+
+def test_required_fields_and_allowed_states() -> None:
+    module = load_module()
+    policy = module.create_gemma3n_e4b_kv260_chat_session_store_policy()
+    allowed = set(module.CHAT_SESSION_STORE_POLICY_STATE_VALUES)
+
+    assert tuple(policy.keys()) == module.CHAT_SESSION_STORE_POLICY_FIELDS
+    assert policy["schemaVersion"] == "pccx.chatSessionStorePolicy.v0"
+    assert tuple(policy["sessionStorePolicy"].keys()) == (
+        module.SESSION_STORE_POLICY_FIELDS
+    )
+
+    states = list(iter_state_values(policy))
+    assert states
+    for state in states:
+        assert state in allowed, state
+
+    for surface in policy["storeSurfaces"]:
+        assert tuple(surface.keys()) == module.STORE_SURFACE_FIELDS
+    for control in policy["storeControls"]:
+        assert tuple(control.keys()) == module.STORE_CONTROL_FIELDS
+    for reason in policy["blockedReasons"]:
+        assert tuple(reason.keys()) == module.BLOCKED_REASON_FIELDS
+    for ref in policy["handoffRefs"]:
+        assert tuple(ref.keys()) == module.HANDOFF_REF_FIELDS
+
+
+def test_chat_session_store_policy_keeps_store_disabled() -> None:
+    policy = load_module().create_gemma3n_e4b_kv260_chat_session_store_policy()
+    store_policy = policy["sessionStorePolicy"]
+    surfaces = {
+        surface["surfaceId"]: surface
+        for surface in policy["storeSurfaces"]
+    }
+    controls = {
+        control["controlId"]: control
+        for control in policy["storeControls"]
+    }
+    reasons = {reason["reasonId"]: reason for reason in policy["blockedReasons"]}
+    refs = {ref["refId"]: ref for ref in policy["handoffRefs"]}
+    flags = policy["safetyFlags"]
+
+    assert policy["sessionStorePolicyState"] == "blocked"
+    assert policy["storeState"] == "not_configured"
+    assert policy["storePathState"] == "not_configured"
+    assert policy["manifestState"] == "not_configured"
+    assert policy["readState"] == "blocked"
+    assert policy["writeState"] == "disabled"
+    assert policy["deleteState"] == "disabled"
+    assert policy["retentionState"] == "not_configured"
+    assert policy["migrationState"] == "disabled"
+    assert store_policy["storeConfigured"] is False
+    assert store_policy["storePathConfigured"] is False
+    assert store_policy["manifestSchemaConfigured"] is False
+    assert store_policy["readEnabled"] is False
+    assert store_policy["writeEnabled"] is False
+    assert store_policy["deleteEnabled"] is False
+    assert store_policy["retentionEnabled"] is False
+    assert store_policy["migrationEnabled"] is False
+    assert set(surfaces) == {
+        "local_store_path",
+        "session_manifest",
+        "session_record",
+        "title_record",
+        "transcript_record",
+        "retention_rule",
+    }
+    assert all(surface["enabled"] is False for surface in surfaces.values())
+    assert set(controls) == {
+        "configure_store",
+        "read_store_path",
+        "read_manifest",
+        "read_session_record",
+        "write_session_record",
+        "delete_session_record",
+        "migrate_store",
+        "persist_store_policy",
+    }
+    assert all(control["enabled"] is False for control in controls.values())
+    assert controls["read_store_path"]["sideEffectPolicy"] == "no_config_or_path_read"
+    assert controls["read_manifest"]["sideEffectPolicy"] == "no_manifest_read"
+    assert controls["write_session_record"]["sideEffectPolicy"] == "no_session_store_write"
+    assert set(reasons) == {
+        "store_not_configured",
+        "store_path_boundary_absent",
+        "manifest_schema_absent",
+        "session_store_read_boundary_absent",
+        "session_store_write_boundary_absent",
+        "deletion_retention_policy_absent",
+        "migration_policy_absent",
+        "redaction_policy_absent",
+    }
+    assert set(refs) == {
+        "chat_session",
+        "chat_session_index",
+        "chat_session_lifecycle",
+        "chat_session_title_policy",
+        "chat_transcript_policy",
+        "chat_preferences",
+    }
+    assert flags["readOnly"] is True
+    assert flags["dataOnly"] is True
+    assert flags["sessionStorePolicyDisplayOnly"] is True
+    assert flags["storeMetadataOnly"] is True
+    assert flags["storeConfigured"] is False
+    assert flags["storePathConfigured"] is False
+    assert flags["storePathIncluded"] is False
+    assert flags["configRead"] is False
+    assert flags["configWrite"] is False
+    assert flags["readsSessionStore"] is False
+    assert flags["sessionStoreRead"] is False
+    assert flags["sessionStoreWrite"] is False
+    assert flags["readsSessionManifest"] is False
+    assert flags["manifestContentIncluded"] is False
+    assert flags["sessionRecordIncluded"] is False
+    assert flags["sessionPersistence"] is False
+    assert flags["sessionDeletion"] is False
+    assert flags["retentionPolicyActive"] is False
+    assert flags["migrationAttempted"] is False
+    assert flags["readsSessionTitle"] is False
+    assert flags["sessionTitleIncluded"] is False
+    assert flags["readsTranscript"] is False
+    assert flags["promptContentIncluded"] is False
+    assert flags["responseContentIncluded"] is False
+    assert flags["writesArtifacts"] is False
+    assert flags["readsArtifacts"] is False
+    assert flags["modelExecution"] is False
+    assert flags["runtimeExecution"] is False
+    assert flags["kv260Access"] is False
+    assert flags["networkCalls"] is False
+    assert flags["providerCalls"] is False
+    assert flags["executesPccxLab"] is False
+
+
+def test_chat_session_store_policy_docs_and_ci_are_wired() -> None:
+    doc = read_text(DOC_PATH)
+    readme = read_text(README_PATH)
+    status_test = read_text(STATUS_TEST_PATH)
+    ci = read_text(CI_PATH)
+
+    assert "contracts/chat_session_store_policy_contract.py" in doc
+    assert (
+        "contracts/fixtures/chat-session-store-policy.gemma3n-e4b-kv260-placeholder.json"
+        in doc
+    )
+    assert "scripts/chat-session-store-policy-stub.sh" in doc
+    assert "scripts/tests/chat_session_store_policy_contract_test.py" in doc
+    assert "scripts/tests/status-chat-session-store-policy.sh" in doc
+    assert "chat-session-store-policy-stub.sh" in readme
+    assert "--include-chat-session-store-policy" in readme
+    assert "chat_session_store_policy_contract_test.py" in ci
+    assert "status-chat-session-store-policy.sh" in ci
+    assert "--include-chat-session-store-policy" in status_test
+    assert "no config/path/manifest/session-store" in status_test
+
+
+def test_chat_session_store_policy_has_no_runtime_or_private_surface() -> None:
+    module = load_module()
+    policy = module.create_gemma3n_e4b_kv260_chat_session_store_policy()
+    fixture_text = read_text(FIXTURE_PATH)
+    contract_source = read_text(MODULE_PATH)
+    stub_source = read_text(SCRIPT_PATH)
+    docs = "\n".join(
+        [
+            fixture_text,
+            contract_source,
+            stub_source,
+            read_text(DOC_PATH),
+            read_text(README_PATH),
+            read_text(STATUS_TEST_PATH),
+        ]
+    )
+
+    assert_no_provider_configs(policy)
+    assert_no_private_or_generated_data(docs)
+    assert_no_unsupported_claims(docs)
+    assert_no_runtime_implementation_terms(contract_source)
+    assert_no_runtime_implementation_terms(stub_source)
+    assert "promptText" not in fixture_text
+    assert "responseText" not in fixture_text
+    assert "transcriptText" not in fixture_text
+    assert "sessionTitleText" not in fixture_text
+    assert "storePathValue" not in fixture_text
+    assert "manifestBody" not in fixture_text
+
+
+def test_source_headers_for_touched_code_files() -> None:
+    expected_headers = {
+        MODULE_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        SCRIPT_PATH: [
+            "#!/usr/bin/env bash",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        STATUS_TEST_PATH: [
+            "#!/usr/bin/env bash",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        TEST_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        CI_PATH: [
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+    }
+
+    for path, headers in expected_headers.items():
+        assert read_text(path).splitlines()[: len(headers)] == headers, path
+
+
+if __name__ == "__main__":
+    for name, func in sorted(globals().items()):
+        if name.startswith("test_") and callable(func):
+            func()
+    print("chat session-store policy contract tests ok")

--- a/scripts/tests/status-chat-session-store-policy.sh
+++ b/scripts/tests/status-chat-session-store-policy.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+# scripts/tests/status-chat-session-store-policy.sh - status session-store policy tests.
+#
+# Usage: bash scripts/tests/status-chat-session-store-policy.sh [path/to/status-stub.sh]
+
+set -eu
+
+PASS() { printf '[PASS]  %s\n' "$*"; }
+FAIL() { printf '[FAIL] %s\n' "$*" >&2; }
+HEAD() { printf '\n=== %s ===\n' "$*"; }
+
+STUB="${1:-scripts/status-stub.sh}"
+
+if [ ! -x "$STUB" ]; then
+    chmod +x "$STUB"
+fi
+
+contains() {
+    case "$1" in
+        *"$2"*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+require_contains() {
+    local output="$1"
+    local expected="$2"
+    if ! contains "$output" "$expected"; then
+        FAIL "expected output to contain: $expected"
+        printf '%s\n' "$output" >&2
+        exit 1
+    fi
+}
+
+require_not_contains() {
+    local output="$1"
+    local forbidden="$2"
+    if contains "$output" "$forbidden"; then
+        FAIL "output contained forbidden text: $forbidden"
+        printf '%s\n' "$output" >&2
+        exit 1
+    fi
+}
+
+HEAD "1: status can include chat session-store policy"
+OUTPUT="$("$STUB" --include-chat-session-store-policy)"
+require_contains "$OUTPUT" "=== chat session store policy ==="
+require_contains "$OUTPUT" "source     : scripts/chat-session-store-policy-stub.sh --model gemma3n-e4b --target kv260"
+require_contains "$OUTPUT" "boundary   : read-only data; no config/path/manifest/session-store/transcript/title/prompt/model/runtime/hardware/lab/IDE execution"
+require_contains "$OUTPUT" "target     : kv260"
+require_contains "$OUTPUT" "model      : gemma3n-e4b"
+require_contains "$OUTPUT" "policy     : blocked"
+require_contains "$OUTPUT" "store      : not_configured"
+require_contains "$OUTPUT" "path       : not_configured"
+require_contains "$OUTPUT" "manifest   : not_configured"
+require_contains "$OUTPUT" "read       : blocked"
+require_contains "$OUTPUT" "write      : disabled"
+require_contains "$OUTPUT" "delete     : disabled"
+require_contains "$OUTPUT" "retention  : not_configured"
+require_contains "$OUTPUT" "migration  : disabled"
+require_contains "$OUTPUT" "privacy    : summary_only"
+PASS "chat session-store policy section is present and conservative"
+
+HEAD "2: policy, surfaces, and controls stay disabled"
+require_contains "$OUTPUT" "session-store-policy : blocked mode=disabled_until_reviewed_local_session_store_boundary_exists"
+require_contains "$OUTPUT" "storeConfigured=false"
+require_contains "$OUTPUT" "storePathConfigured=false"
+require_contains "$OUTPUT" "manifestSchemaConfigured=false"
+require_contains "$OUTPUT" "readEnabled=false"
+require_contains "$OUTPUT" "writeEnabled=false"
+require_contains "$OUTPUT" "deleteEnabled=false"
+require_contains "$OUTPUT" "retentionEnabled=false"
+require_contains "$OUTPUT" "migrationEnabled=false"
+require_contains "$OUTPUT" "surfaces   : local_store_path=not_configured:false"
+require_contains "$OUTPUT" "session_manifest=not_configured:false"
+require_contains "$OUTPUT" "session_record=blocked:false"
+require_contains "$OUTPUT" "title_record=blocked:false"
+require_contains "$OUTPUT" "transcript_record=disabled:false"
+require_contains "$OUTPUT" "retention_rule=not_configured:false"
+require_contains "$OUTPUT" "controls   : configure_store=disabled:false"
+require_contains "$OUTPUT" "read_store_path=blocked:false"
+require_contains "$OUTPUT" "read_manifest=blocked:false"
+require_contains "$OUTPUT" "read_session_record=blocked:false"
+require_contains "$OUTPUT" "write_session_record=disabled:false"
+require_contains "$OUTPUT" "delete_session_record=disabled:false"
+require_contains "$OUTPUT" "migrate_store=disabled:false"
+require_contains "$OUTPUT" "persist_store_policy=disabled:false"
+PASS "session-store policy metadata is summarized without store reads"
+
+HEAD "3: blocked reasons stay explicit"
+require_contains "$OUTPUT" "blocked    : store_not_configured=not_configured"
+require_contains "$OUTPUT" "store_path_boundary_absent=planned"
+require_contains "$OUTPUT" "manifest_schema_absent=not_configured"
+require_contains "$OUTPUT" "session_store_read_boundary_absent=blocked"
+require_contains "$OUTPUT" "session_store_write_boundary_absent=disabled"
+require_contains "$OUTPUT" "deletion_retention_policy_absent=requires_evidence"
+require_contains "$OUTPUT" "migration_policy_absent=not_configured"
+require_contains "$OUTPUT" "redaction_policy_absent=planned"
+PASS "session-store blockers remain visible"
+
+HEAD "4: safety flags stay read-only and non-executing"
+require_contains "$OUTPUT" "readOnly=true"
+require_contains "$OUTPUT" "dataOnly=true"
+require_contains "$OUTPUT" "deterministic=true"
+require_contains "$OUTPUT" "sessionStorePolicyDisplayOnly=true"
+require_contains "$OUTPUT" "storeMetadataOnly=true"
+require_contains "$OUTPUT" "storeConfigured=false"
+require_contains "$OUTPUT" "storePathConfigured=false"
+require_contains "$OUTPUT" "storePathIncluded=false"
+require_contains "$OUTPUT" "configRead=false"
+require_contains "$OUTPUT" "configWrite=false"
+require_contains "$OUTPUT" "readsSessionStore=false"
+require_contains "$OUTPUT" "sessionStoreRead=false"
+require_contains "$OUTPUT" "sessionStoreWrite=false"
+require_contains "$OUTPUT" "readsSessionManifest=false"
+require_contains "$OUTPUT" "manifestContentIncluded=false"
+require_contains "$OUTPUT" "sessionRecordIncluded=false"
+require_contains "$OUTPUT" "sessionPersistence=false"
+require_contains "$OUTPUT" "sessionDeletion=false"
+require_contains "$OUTPUT" "retentionPolicyActive=false"
+require_contains "$OUTPUT" "migrationAttempted=false"
+require_contains "$OUTPUT" "readsSessionTitle=false"
+require_contains "$OUTPUT" "sessionTitleIncluded=false"
+require_contains "$OUTPUT" "readsTranscript=false"
+require_contains "$OUTPUT" "promptContentIncluded=false"
+require_contains "$OUTPUT" "responseContentIncluded=false"
+require_contains "$OUTPUT" "writesArtifacts=false"
+require_contains "$OUTPUT" "readsArtifacts=false"
+require_contains "$OUTPUT" "modelExecution=false"
+require_contains "$OUTPUT" "runtimeExecution=false"
+require_contains "$OUTPUT" "kv260Access=false"
+require_contains "$OUTPUT" "hardwareAccess=false"
+require_contains "$OUTPUT" "networkCalls=false"
+require_contains "$OUTPUT" "providerCalls=false"
+require_contains "$OUTPUT" "executesPccxLab=false"
+PASS "execution, store read/write, and persistence flags remain false"
+
+HEAD "5: output is deterministic"
+OUTPUT_AGAIN="$("$STUB" --include-chat-session-store-policy)"
+if [ "$OUTPUT" != "$OUTPUT_AGAIN" ]; then
+    FAIL "status chat session-store policy output changed between runs"
+    exit 1
+fi
+PASS "status chat session-store policy output is deterministic"
+
+HEAD "6: chat session-store policy option does not combine with pccx-lab backend"
+if "$STUB" --include-chat-session-store-policy --backend pccx-lab >/dev/null 2>&1; then
+    FAIL "expected combined chat-session-store-policy/backend mode to fail"
+    exit 1
+fi
+PASS "chat session-store policy remains separate from backend execution"
+
+HEAD "7: output avoids known overclaims and content"
+FORBIDDEN_PREFIX="KV260 inference"
+FORBIDDEN_CLAIM="${FORBIDDEN_PREFIX} works"
+require_not_contains "$OUTPUT" "$FORBIDDEN_CLAIM"
+THROUGHPUT_PREFIX="20 tok/s"
+THROUGHPUT_CLAIM="${THROUGHPUT_PREFIX} achieved"
+require_not_contains "$OUTPUT" "$THROUGHPUT_CLAIM"
+require_not_contains "$OUTPUT" "hello"
+require_not_contains "$OUTPUT" "assistant response:"
+require_not_contains "$OUTPUT" "session title:"
+PASS "no session-store policy overclaim or content in status output"
+
+printf '\n[DONE]  all status-chat-session-store-policy tests passed\n'


### PR DESCRIPTION
## Summary
- add a data-only `pccx.chatSessionStorePolicy.v0` fixture for the planned chat session-store boundary
- wire the disabled store policy into the status stub behind `--include-chat-session-store-policy`
- document the boundary and add contract/status tests plus CI coverage

Refs #9

## Validation
- `python3 scripts/tests/chat_session_store_policy_contract_test.py`
- `bash scripts/tests/status-chat-session-store-policy.sh scripts/status-stub.sh`
- `python3 -m json.tool contracts/fixtures/chat-session-store-policy.gemma3n-e4b-kv260-placeholder.json`
- `cmp -s contracts/fixtures/chat-session-store-policy.gemma3n-e4b-kv260-placeholder.json <(python3 contracts/chat_session_store_policy_contract.py --model gemma3n-e4b --target kv260)`
- `python3 -m py_compile contracts/chat_session_store_policy_contract.py scripts/tests/chat_session_store_policy_contract_test.py`
- `find scripts -type f -name '*.sh' -print0 | xargs -0 bash -n`
- `for t in scripts/tests/*_test.py; do python3 "$t"; done`
- `for t in scripts/tests/status-*.sh; do bash "$t" scripts/status-stub.sh; done`
- `bash scripts/status-stub.sh`
- `bash scripts/check.sh`
- `bash scripts/check-device-stub.sh`
- `bash scripts/install-stub.sh`
- `bash scripts/launch-stub.sh --dry-run`
- `bash scripts/chat-stub.sh --dry-run --prompt hello`
- local claim-scan guard from CI
- `git diff --cached --check`

Local `shellcheck` is not installed; the workflow installs and runs it in CI.
