### PR TITLE
Add chat model-load request boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,7 @@ jobs:
                    scripts/device-session-status-stub.sh \
                    scripts/runtime-readiness-stub.sh \
                    scripts/chat-model-status-stub.sh \
+                   scripts/chat-model-load-request-stub.sh \
                    scripts/chat-session-stub.sh \
                    scripts/chat-session-lifecycle-stub.sh \
                    scripts/chat-surface-layout-stub.sh \
@@ -176,6 +177,10 @@ jobs:
         run: ./scripts/status-stub.sh --include-chat-model-status
       - name: run scripts/chat-model-status-stub.sh
         run: ./scripts/chat-model-status-stub.sh --model gemma3n-e4b --target kv260
+      - name: run scripts/status-stub.sh with chat model-load request
+        run: ./scripts/status-stub.sh --include-chat-model-load-request
+      - name: run scripts/chat-model-load-request-stub.sh
+        run: ./scripts/chat-model-load-request-stub.sh --model gemma3n-e4b --target kv260
       - name: run scripts/chat-session-stub.sh
         run: ./scripts/chat-session-stub.sh --model gemma3n-e4b --target kv260
       - name: run scripts/chat-session-lifecycle-stub.sh
@@ -274,6 +279,8 @@ jobs:
         run: python3 scripts/tests/chat_session_contract_test.py
       - name: run chat model status contract tests
         run: python3 scripts/tests/chat_model_status_contract_test.py
+      - name: run chat model-load request contract tests
+        run: python3 scripts/tests/chat_model_load_request_contract_test.py
       - name: run chat/session lifecycle contract tests
         run: python3 scripts/tests/chat_session_lifecycle_contract_test.py
       - name: run chat surface-layout contract tests
@@ -323,6 +330,7 @@ jobs:
           chmod +x scripts/status-stub.sh
           chmod +x scripts/chat-stub.sh
           chmod +x scripts/chat-model-status-stub.sh
+          chmod +x scripts/chat-model-load-request-stub.sh
           chmod +x scripts/chat-session-stub.sh
           chmod +x scripts/chat-session-lifecycle-stub.sh
           chmod +x scripts/chat-surface-layout-stub.sh
@@ -347,6 +355,7 @@ jobs:
           chmod +x scripts/tests/status-device-session.sh
           chmod +x scripts/tests/status-readiness.sh
           chmod +x scripts/tests/status-chat-model-status.sh
+          chmod +x scripts/tests/status-chat-model-load-request.sh
           chmod +x scripts/tests/status-chat-session.sh
           chmod +x scripts/tests/status-chat-surface-layout.sh
           chmod +x scripts/tests/status-chat-local-only-policy.sh
@@ -373,6 +382,7 @@ jobs:
           shellcheck scripts/tests/status-device-session.sh
           shellcheck scripts/tests/status-readiness.sh
           shellcheck scripts/tests/status-chat-model-status.sh
+          shellcheck scripts/tests/status-chat-model-load-request.sh
           shellcheck scripts/tests/status-chat-session.sh
           shellcheck scripts/tests/status-chat-surface-layout.sh
           shellcheck scripts/tests/status-chat-local-only-policy.sh
@@ -399,6 +409,8 @@ jobs:
         run: bash scripts/tests/status-readiness.sh scripts/status-stub.sh
       - name: run status-chat-model-status tests
         run: bash scripts/tests/status-chat-model-status.sh scripts/status-stub.sh
+      - name: run status-chat-model-load-request tests
+        run: bash scripts/tests/status-chat-model-load-request.sh scripts/status-stub.sh
       - name: run status-chat-session tests
         run: bash scripts/tests/status-chat-session.sh scripts/status-stub.sh
       - name: run status-chat-surface-layout tests

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ and verify host-side prerequisites before the real engine lands.
 | [`scripts/check.sh`](./scripts/check.sh) | Probe host info, tooling availability, edge-device hints. Always exits 0. |
 | [`scripts/check-device-stub.sh`](./scripts/check-device-stub.sh) | Narrowly scoped device-tree / FPGA-node probe (KV260 / Kria detection only). Always exits 0. |
 | [`scripts/install-stub.sh`](./scripts/install-stub.sh) | Preview of the planned install flow; reports which host runtime pieces are present, lists device-side pieces as future deliverables. Always exits 0. |
-| [`scripts/status-stub.sh`](./scripts/status-stub.sh) | Launcher state summary. Default mode: local scaffold output, always exits 0. With `--include-chat-action-bar`, adds read-only disabled chat action-bar data. With `--include-chat-attachment-policy`, adds read-only disabled chat attachment-policy data. With `--include-chat-shortcut-map`, adds read-only disabled chat shortcut-map data. With `--include-chat-message-list`, adds read-only empty chat message-list data. With `--include-chat-response-stream`, adds read-only blocked chat response stream data. With `--include-chat-error-taxonomy`, adds read-only chat error taxonomy data. With `--include-chat-audit-event`, adds read-only blocked chat audit-event metadata. With `--include-chat-surface-layout`, adds read-only chat surface layout data. With `--include-chat-local-only-policy`, adds read-only local-only/cloud-block policy data. With `--include-chat-preferences`, adds read-only chat preferences/settings data. With `--include-chat-session-index`, adds read-only empty chat session index data. With `--include-chat-session-store-policy`, adds read-only disabled chat session-store policy data. With `--include-chat-session-title-policy`, adds read-only placeholder session-title policy data. With `--include-chat-transcript-policy`, adds read-only chat transcript retention/export policy data. With `--include-chat-send-result`, adds read-only blocked chat send-result data. With `--include-chat-composer`, adds read-only chat composer/input-control data. With `--include-chat-model-status`, adds read-only blocked chat model-status display data. With `--include-chat-session`, adds read-only blocked chat/session and lifecycle summaries. With `--include-chat-readiness`, adds read-only chat readiness checks and recovery actions. With `--include-device-session`, adds a read-only device/session status panel. With `--include-runtime-readiness`, adds a read-only runtime readiness summary. With `--backend pccx-lab`, calls `pccx-lab status --format json` and forwards the run-status envelope (exits non-zero if binary is missing or output is invalid). |
+| [`scripts/status-stub.sh`](./scripts/status-stub.sh) | Launcher state summary. Default mode: local scaffold output, always exits 0. With `--include-chat-action-bar`, adds read-only disabled chat action-bar data. With `--include-chat-attachment-policy`, adds read-only disabled chat attachment-policy data. With `--include-chat-shortcut-map`, adds read-only disabled chat shortcut-map data. With `--include-chat-message-list`, adds read-only empty chat message-list data. With `--include-chat-response-stream`, adds read-only blocked chat response stream data. With `--include-chat-error-taxonomy`, adds read-only chat error taxonomy data. With `--include-chat-audit-event`, adds read-only blocked chat audit-event metadata. With `--include-chat-surface-layout`, adds read-only chat surface layout data. With `--include-chat-local-only-policy`, adds read-only local-only/cloud-block policy data. With `--include-chat-preferences`, adds read-only chat preferences/settings data. With `--include-chat-session-index`, adds read-only empty chat session index data. With `--include-chat-session-store-policy`, adds read-only disabled chat session-store policy data. With `--include-chat-session-title-policy`, adds read-only placeholder session-title policy data. With `--include-chat-transcript-policy`, adds read-only chat transcript retention/export policy data. With `--include-chat-send-result`, adds read-only blocked chat send-result data. With `--include-chat-composer`, adds read-only chat composer/input-control data. With `--include-chat-model-status`, adds read-only blocked chat model-status display data. With `--include-chat-model-load-request`, adds read-only disabled chat model-load request data. With `--include-chat-session`, adds read-only blocked chat/session and lifecycle summaries. With `--include-chat-readiness`, adds read-only chat readiness checks and recovery actions. With `--include-device-session`, adds a read-only device/session status panel. With `--include-runtime-readiness`, adds a read-only runtime readiness summary. With `--backend pccx-lab`, calls `pccx-lab status --format json` and forwards the run-status envelope (exits non-zero if binary is missing or output is invalid). |
 | [`scripts/device-session-status-stub.sh`](./scripts/device-session-status-stub.sh) | Data-only device/session status JSON for the Gemma 3N E4B + KV260 target. Reports connection, model load, session, diagnostics, readiness, discovery paths, flow steps, and error taxonomy as placeholder / blocked. |
 | [`scripts/runtime-readiness-stub.sh`](./scripts/runtime-readiness-stub.sh) | Data-only runtime readiness JSON for the Gemma 3N E4B + KV260 target. Reports blocked / not yet evidence-backed. |
 | [`scripts/chat-session-stub.sh`](./scripts/chat-session-stub.sh) | Data-only standalone chat/session JSON for the Gemma 3N E4B + KV260 target. Reports disabled send controls, inactive session state, no prompt/response persistence, and readiness handoff references. |
@@ -99,6 +99,7 @@ and verify host-side prerequisites before the real engine lands.
 | [`scripts/chat-session-store-policy-stub.sh`](./scripts/chat-session-store-policy-stub.sh) | Data-only chat session-store policy JSON for the Gemma 3N E4B + KV260 target. Reports disabled store configuration, path, manifest, read, write, delete, retention, and migration gates without reading config, paths, manifests, session records, transcripts, titles, prompts, responses, summaries, model paths, runtime logs, or artifacts. |
 | [`scripts/chat-session-title-policy-stub.sh`](./scripts/chat-session-title-policy-stub.sh) | Data-only chat session-title policy JSON for the Gemma 3N E4B + KV260 target. Reports static placeholder display names and disabled title read, generation, rename, and persistence controls without reading stores, transcripts, prompts, responses, summaries, titles, or paths. |
 | [`scripts/chat-model-status-stub.sh`](./scripts/chat-model-status-stub.sh) | Data-only chat model-status JSON for the Gemma 3N E4B + KV260 target. Reports descriptor, asset, load, runtime, context, and response display rows as blocked, disabled, or unavailable. |
+| [`scripts/chat-model-load-request-stub.sh`](./scripts/chat-model-load-request-stub.sh) | Data-only chat model-load request JSON for the Gemma 3N E4B + KV260 target. Reports disabled model asset path, validation, runtime preflight, load, warmup, unload, and persistence gates without reading config, environment values, model paths, asset paths, weights, tokenizers, checksum manifests, prompts, responses, transcripts, runtime logs, or artifacts. |
 | [`scripts/chat-readiness-stub.sh`](./scripts/chat-readiness-stub.sh) | Data-only chat readiness JSON for the Gemma 3N E4B + KV260 target. Reports readiness checks, error categories, and recovery actions as blocked, disabled, or local data only. |
 | [`scripts/chat-composer-stub.sh`](./scripts/chat-composer-stub.sh) | Data-only chat composer JSON for the Gemma 3N E4B + KV260 target. Reports input buffer, send, attachment, validation, and privacy states without reading, echoing, storing, or persisting prompt text. |
 | [`scripts/chat-send-result-stub.sh`](./scripts/chat-send-result-stub.sh) | Data-only blocked chat send-result JSON for the Gemma 3N E4B + KV260 target. Reports disabled send state, no accepted input, no prompt echo, no generated response, and no runtime/model handoff. |
@@ -120,6 +121,7 @@ bash scripts/check-device-stub.sh
 bash scripts/install-stub.sh
 bash scripts/status-stub.sh
 bash scripts/status-stub.sh --include-chat-model-status
+bash scripts/status-stub.sh --include-chat-model-load-request
 bash scripts/status-stub.sh --include-chat-session
 bash scripts/status-stub.sh --include-chat-surface-layout
 bash scripts/status-stub.sh --include-chat-local-only-policy
@@ -143,6 +145,7 @@ bash scripts/status-stub.sh --include-runtime-readiness
 bash scripts/device-session-status-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/runtime-readiness-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-model-status-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/chat-model-load-request-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-session-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-session-lifecycle-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-surface-layout-stub.sh --model gemma3n-e4b --target kv260
@@ -328,6 +331,7 @@ the planned local chat entry point:
 ```bash
 python3 contracts/chat_session_contract.py --model gemma3n-e4b --target kv260
 python3 contracts/chat_model_status_contract.py --model gemma3n-e4b --target kv260
+python3 contracts/chat_model_load_request_contract.py --model gemma3n-e4b --target kv260
 python3 contracts/chat_readiness_contract.py --model gemma3n-e4b --target kv260
 python3 contracts/chat_audit_event_contract.py --model gemma3n-e4b --target kv260
 python3 contracts/chat_error_taxonomy_contract.py --model gemma3n-e4b --target kv260
@@ -338,6 +342,7 @@ python3 contracts/chat_session_store_policy_contract.py --model gemma3n-e4b --ta
 python3 contracts/chat_shortcut_map_contract.py --model gemma3n-e4b --target kv260
 python3 contracts/chat_session_title_policy_contract.py --model gemma3n-e4b --target kv260
 bash scripts/chat-model-status-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/chat-model-load-request-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-session-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-session-lifecycle-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-session-store-policy-stub.sh --model gemma3n-e4b --target kv260
@@ -351,6 +356,7 @@ bash scripts/chat-attachment-policy-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-shortcut-map-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-surface-preview.sh --model gemma3n-e4b --target kv260
 bash scripts/status-stub.sh --include-chat-model-status
+bash scripts/status-stub.sh --include-chat-model-load-request
 bash scripts/status-stub.sh --include-chat-session
 bash scripts/status-stub.sh --include-chat-readiness
 bash scripts/status-stub.sh --include-chat-audit-event
@@ -363,6 +369,7 @@ bash scripts/status-stub.sh --include-chat-shortcut-map
 bash scripts/status-stub.sh --include-chat-session-title-policy
 python3 scripts/tests/chat_session_contract_test.py
 python3 scripts/tests/chat_model_status_contract_test.py
+python3 scripts/tests/chat_model_load_request_contract_test.py
 python3 scripts/tests/chat_session_lifecycle_contract_test.py
 python3 scripts/tests/chat_session_title_policy_contract_test.py
 python3 scripts/tests/chat_readiness_contract_test.py
@@ -375,6 +382,7 @@ python3 scripts/tests/chat_session_store_policy_contract_test.py
 python3 scripts/tests/chat_shortcut_map_contract_test.py
 python3 scripts/tests/chat_surface_preview_test.py
 bash scripts/tests/status-chat-model-status.sh
+bash scripts/tests/status-chat-model-load-request.sh
 bash scripts/tests/status-chat-session.sh
 bash scripts/tests/status-chat-readiness.sh
 bash scripts/tests/status-chat-audit-event.sh
@@ -458,6 +466,13 @@ store path, manifest, read, write, delete, retention, and migration gates
 without reading configuration, paths, manifests, session records,
 transcripts, titles, prompts, responses, summaries, model paths, runtime
 logs, or artifacts.
+
+The chat model-load request fixture defines the disabled local model-load
+boundary for the planned chat surface. It records descriptor selection,
+asset path, checksum, runtime preflight, load, warmup, unload, and
+persistence gates without reading configuration, environment values,
+model paths, asset paths, weights, tokenizers, checksum manifests,
+prompts, responses, transcripts, runtime logs, or artifacts.
 
 The preview command renders that same contract as a deterministic
 terminal chat surface sketch with disabled controls, blocked reasons, and

--- a/contracts/chat_model_load_request_contract.py
+++ b/contracts/chat_model_load_request_contract.py
@@ -1,0 +1,531 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Data-only chat model-load request contract for the planned launcher UI.
+
+The contract describes the disabled local model-load request boundary for the
+standalone chat surface. It does not read configuration, environment values,
+model asset paths, model weights, tokenizer files, checksum manifests, prompts,
+responses, transcripts, private paths, or runtime logs; it does not validate,
+load, unload, warm up, execute, touch KV260 hardware, call providers, invoke
+pccx-lab, or write artifacts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import sys
+
+
+SCHEMA_VERSION = "pccx.chatModelLoadRequest.v0"
+
+CHAT_MODEL_LOAD_REQUEST_FIELDS = (
+    "schemaVersion",
+    "loadRequestId",
+    "fixtureVersion",
+    "lastUpdatedSource",
+    "targetDevice",
+    "targetBoard",
+    "targetModel",
+    "loadRequestState",
+    "selectedModelState",
+    "descriptorState",
+    "assetInputState",
+    "assetPathState",
+    "checksumState",
+    "loadPlanState",
+    "runtimePreflightState",
+    "deviceSessionState",
+    "warmupState",
+    "unloadState",
+    "privacyState",
+    "chatModelStatusRef",
+    "runtimeReadinessRef",
+    "deviceSessionStatusRef",
+    "chatReadinessRef",
+    "chatLocalOnlyPolicyRef",
+    "loadRequestPolicy",
+    "loadInputs",
+    "loadControls",
+    "blockedReasons",
+    "handoffRefs",
+    "safetyFlags",
+    "limitations",
+    "issueRefs",
+)
+
+LOAD_REQUEST_POLICY_FIELDS = (
+    "state",
+    "mode",
+    "sourcePolicy",
+    "descriptorSelected",
+    "modelAssetsConfigured",
+    "assetPathsConfigured",
+    "checksumsAvailable",
+    "runtimeReady",
+    "deviceSessionReady",
+    "loadEnabled",
+    "warmupEnabled",
+    "unloadEnabled",
+    "sideEffectPolicy",
+    "contentPolicy",
+)
+
+LOAD_INPUT_FIELDS = (
+    "inputId",
+    "label",
+    "state",
+    "enabled",
+    "summary",
+    "sideEffectPolicy",
+    "contentPolicy",
+)
+
+LOAD_CONTROL_FIELDS = (
+    "controlId",
+    "label",
+    "state",
+    "enabled",
+    "userAction",
+    "launcherAction",
+    "sideEffectPolicy",
+    "blockedReasonRef",
+)
+
+BLOCKED_REASON_FIELDS = (
+    "reasonId",
+    "state",
+    "summary",
+    "requiredBefore",
+)
+
+HANDOFF_REF_FIELDS = (
+    "refId",
+    "schemaVersion",
+    "fixturePath",
+    "state",
+    "summary",
+)
+
+CHAT_MODEL_LOAD_REQUEST_STATE_VALUES = (
+    "available_as_data",
+    "blocked",
+    "disabled",
+    "external_not_configured",
+    "inactive",
+    "not_configured",
+    "not_loaded",
+    "not_started",
+    "not_used",
+    "placeholder",
+    "planned",
+    "requires_evidence",
+    "summary_only",
+    "target_selected",
+    "unavailable",
+)
+
+_CHAT_MODEL_LOAD_REQUEST = {
+    "schemaVersion": SCHEMA_VERSION,
+    "loadRequestId": "chat_model_load_request_gemma3n_e4b_kv260_placeholder",
+    "fixtureVersion": "chat-model-load-request.gemma3n-e4b-kv260.2026-05-04",
+    "lastUpdatedSource": "pccx_launcher_issue_9_chat_model_load_request_boundary_2026-05-04",
+    "targetDevice": "kv260",
+    "targetBoard": "xilinx_kria_kv260",
+    "targetModel": "gemma3n-e4b",
+    "loadRequestState": "blocked",
+    "selectedModelState": "target_selected",
+    "descriptorState": "available_as_data",
+    "assetInputState": "blocked",
+    "assetPathState": "not_configured",
+    "checksumState": "not_configured",
+    "loadPlanState": "blocked",
+    "runtimePreflightState": "blocked",
+    "deviceSessionState": "inactive",
+    "warmupState": "disabled",
+    "unloadState": "disabled",
+    "privacyState": "summary_only",
+    "chatModelStatusRef": "chat_model_status_gemma3n_e4b_kv260_placeholder",
+    "runtimeReadinessRef": "runtime_readiness_gemma3n_e4b_kv260",
+    "deviceSessionStatusRef": "device_session_status_gemma3n_e4b_kv260",
+    "chatReadinessRef": "chat_readiness_gemma3n_e4b_kv260_placeholder",
+    "chatLocalOnlyPolicyRef": "chat_local_only_policy_gemma3n_e4b_kv260_placeholder",
+    "loadRequestPolicy": {
+        "state": "blocked",
+        "mode": "disabled_until_reviewed_model_load_boundary_exists",
+        "sourcePolicy": "checked fixture only; no config, environment, model path, asset path, weight file, tokenizer file, checksum manifest, prompt, response, transcript, artifact, or runtime log is read",
+        "descriptorSelected": True,
+        "modelAssetsConfigured": False,
+        "assetPathsConfigured": False,
+        "checksumsAvailable": False,
+        "runtimeReady": False,
+        "deviceSessionReady": False,
+        "loadEnabled": False,
+        "warmupEnabled": False,
+        "unloadEnabled": False,
+        "sideEffectPolicy": "local_render_only",
+        "contentPolicy": "model-load request metadata only; no model path, asset path, file name, checksum value, manifest body, prompt text, response text, transcript text, runtime log, or private path is included",
+    },
+    "loadInputs": [
+        {
+            "inputId": "model_descriptor",
+            "label": "model descriptor",
+            "state": "available_as_data",
+            "enabled": False,
+            "summary": "Gemma 3N E4B is represented by the checked descriptor fixture only.",
+            "sideEffectPolicy": "fixture_metadata_only",
+            "contentPolicy": "descriptor_id_and_target_label_only",
+        },
+        {
+            "inputId": "local_asset_path",
+            "label": "local asset path",
+            "state": "not_configured",
+            "enabled": False,
+            "summary": "No reviewed local model asset path is configured, resolved, read, or emitted.",
+            "sideEffectPolicy": "no_config_or_path_read",
+            "contentPolicy": "no_model_asset_path_or_private_path",
+        },
+        {
+            "inputId": "model_weight_file",
+            "label": "model weight file",
+            "state": "blocked",
+            "enabled": False,
+            "summary": "Model weight files are not discovered, opened, validated, or loaded.",
+            "sideEffectPolicy": "no_model_asset_read",
+            "contentPolicy": "no_weight_filename_path_or_bytes",
+        },
+        {
+            "inputId": "tokenizer_asset",
+            "label": "tokenizer asset",
+            "state": "blocked",
+            "enabled": False,
+            "summary": "Tokenizer assets are not discovered, opened, validated, or loaded.",
+            "sideEffectPolicy": "no_tokenizer_read",
+            "contentPolicy": "no_tokenizer_filename_path_or_bytes",
+        },
+        {
+            "inputId": "checksum_manifest",
+            "label": "checksum manifest",
+            "state": "not_configured",
+            "enabled": False,
+            "summary": "No checksum manifest schema or local integrity evidence is configured.",
+            "sideEffectPolicy": "no_manifest_read",
+            "contentPolicy": "no_checksum_values_or_manifest_body",
+        },
+        {
+            "inputId": "runtime_profile",
+            "label": "runtime profile",
+            "state": "blocked",
+            "enabled": False,
+            "summary": "Runtime profile selection is blocked until runtime readiness is evidence-backed.",
+            "sideEffectPolicy": "no_runtime_preflight",
+            "contentPolicy": "profile_metadata_only",
+        },
+        {
+            "inputId": "device_session",
+            "label": "device session",
+            "state": "inactive",
+            "enabled": False,
+            "summary": "No target device session exists and no board runtime state is measured.",
+            "sideEffectPolicy": "no_hardware_probe",
+            "contentPolicy": "inactive_status_only",
+        },
+    ],
+    "loadControls": [
+        {
+            "controlId": "select_model_descriptor",
+            "label": "select model descriptor",
+            "state": "target_selected",
+            "enabled": False,
+            "userAction": "Review the target model descriptor in the future chat UI.",
+            "launcherAction": "Render descriptor metadata from checked fixtures only.",
+            "sideEffectPolicy": "local_render_only",
+            "blockedReasonRef": "model_load_executor_absent",
+        },
+        {
+            "controlId": "configure_asset_path",
+            "label": "configure asset path",
+            "state": "blocked",
+            "enabled": False,
+            "userAction": "Configure local assets only after a reviewed model-asset input boundary exists.",
+            "launcherAction": "Keep asset path configuration disabled and do not read config or paths.",
+            "sideEffectPolicy": "no_config_or_path_read",
+            "blockedReasonRef": "model_asset_input_boundary_absent",
+        },
+        {
+            "controlId": "validate_assets",
+            "label": "validate assets",
+            "state": "blocked",
+            "enabled": False,
+            "userAction": "Validate assets only after integrity and redaction rules are reviewed.",
+            "launcherAction": "Refuse asset validation and do not open model files or manifests.",
+            "sideEffectPolicy": "no_model_asset_read",
+            "blockedReasonRef": "model_integrity_evidence_absent",
+        },
+        {
+            "controlId": "build_load_plan",
+            "label": "build load plan",
+            "state": "blocked",
+            "enabled": False,
+            "userAction": "Build a load plan only after asset, runtime, and target-session evidence exists.",
+            "launcherAction": "Render blocked load-plan metadata only.",
+            "sideEffectPolicy": "no_runtime_preflight",
+            "blockedReasonRef": "runtime_readiness_blocked",
+        },
+        {
+            "controlId": "start_runtime",
+            "label": "start runtime",
+            "state": "disabled",
+            "enabled": False,
+            "userAction": "Start runtime only after evidence-backed runtime and target-session readiness.",
+            "launcherAction": "Keep runtime start disabled.",
+            "sideEffectPolicy": "no_runtime_execution",
+            "blockedReasonRef": "runtime_readiness_blocked",
+        },
+        {
+            "controlId": "load_model",
+            "label": "load model",
+            "state": "disabled",
+            "enabled": False,
+            "userAction": "Load model only after assets, integrity, runtime, and device evidence are reviewed.",
+            "launcherAction": "Refuse model load and do not touch model assets or hardware.",
+            "sideEffectPolicy": "no_model_load",
+            "blockedReasonRef": "model_load_executor_absent",
+        },
+        {
+            "controlId": "warmup_model",
+            "label": "warm up model",
+            "state": "disabled",
+            "enabled": False,
+            "userAction": "Warm up only after a model is loaded by a reviewed runtime path.",
+            "launcherAction": "Keep warmup disabled and do not execute inference.",
+            "sideEffectPolicy": "no_model_execution",
+            "blockedReasonRef": "model_load_executor_absent",
+        },
+        {
+            "controlId": "unload_model",
+            "label": "unload model",
+            "state": "disabled",
+            "enabled": False,
+            "userAction": "Unload only after a reviewed runtime lifecycle exists.",
+            "launcherAction": "Keep unload disabled because no model is loaded.",
+            "sideEffectPolicy": "no_runtime_execution",
+            "blockedReasonRef": "unload_policy_absent",
+        },
+        {
+            "controlId": "persist_load_request",
+            "label": "persist load request",
+            "state": "disabled",
+            "enabled": False,
+            "userAction": "Persist load requests only after local configuration storage is reviewed.",
+            "launcherAction": "Do not write policy, request, preference, or config files.",
+            "sideEffectPolicy": "no_policy_write",
+            "blockedReasonRef": "model_asset_path_boundary_absent",
+        },
+    ],
+    "blockedReasons": [
+        {
+            "reasonId": "model_asset_input_boundary_absent",
+            "state": "blocked",
+            "summary": "No reviewed local model asset input boundary exists.",
+            "requiredBefore": "configure_asset_path_enabled",
+        },
+        {
+            "reasonId": "model_asset_path_boundary_absent",
+            "state": "not_configured",
+            "summary": "No reviewed config/path boundary exists for model asset locations.",
+            "requiredBefore": "asset_paths_available",
+        },
+        {
+            "reasonId": "model_integrity_evidence_absent",
+            "state": "requires_evidence",
+            "summary": "Checksum, size, format, and provenance evidence are absent.",
+            "requiredBefore": "validate_assets_enabled",
+        },
+        {
+            "reasonId": "runtime_readiness_blocked",
+            "state": "blocked",
+            "summary": "Runtime readiness remains blocked and not evidence-backed.",
+            "requiredBefore": "runtime_preflight_enabled",
+        },
+        {
+            "reasonId": "device_session_inactive",
+            "state": "inactive",
+            "summary": "No KV260 target session exists for model load handoff.",
+            "requiredBefore": "load_model_enabled",
+        },
+        {
+            "reasonId": "model_load_executor_absent",
+            "state": "disabled",
+            "summary": "No reviewed model-load executor or runtime lifecycle exists.",
+            "requiredBefore": "load_model_enabled",
+        },
+        {
+            "reasonId": "unload_policy_absent",
+            "state": "planned",
+            "summary": "Unload, cleanup, and rollback policy needs a reviewed runtime lifecycle.",
+            "requiredBefore": "unload_model_enabled",
+        },
+        {
+            "reasonId": "local_only_policy_required",
+            "state": "planned",
+            "summary": "Local-only policy must continue blocking provider and cloud fallback paths.",
+            "requiredBefore": "load_request_review_complete",
+        },
+    ],
+    "handoffRefs": [
+        {
+            "refId": "chat_model_status",
+            "schemaVersion": "pccx.chatModelStatus.v0",
+            "fixturePath": "contracts/fixtures/chat-model-status.gemma3n-e4b-kv260-placeholder.json",
+            "state": "blocked",
+            "summary": "Model status display keeps model loading blocked and disabled.",
+        },
+        {
+            "refId": "runtime_readiness",
+            "schemaVersion": "pccx.runtimeReadiness.v0",
+            "fixturePath": "contracts/fixtures/runtime-readiness.gemma3n-e4b-kv260.json",
+            "state": "blocked",
+            "summary": "Runtime readiness remains blocked and local-data only.",
+        },
+        {
+            "refId": "device_session_status",
+            "schemaVersion": "pccx.deviceSessionStatus.v0",
+            "fixturePath": "contracts/fixtures/device-session-status.gemma3n-e4b-kv260.json",
+            "state": "inactive",
+            "summary": "Device/session status reports no active target session.",
+        },
+        {
+            "refId": "chat_readiness",
+            "schemaVersion": "pccx.chatReadiness.v0",
+            "fixturePath": "contracts/fixtures/chat-readiness.gemma3n-e4b-kv260-placeholder.json",
+            "state": "blocked",
+            "summary": "Chat readiness keeps send and recovery actions blocked.",
+        },
+        {
+            "refId": "chat_local_only_policy",
+            "schemaVersion": "pccx.chatLocalOnlyPolicy.v0",
+            "fixturePath": "contracts/fixtures/chat-local-only-policy.gemma3n-e4b-kv260-placeholder.json",
+            "state": "blocked",
+            "summary": "Local-only policy keeps provider, cloud, and fallback paths blocked.",
+        },
+    ],
+    "safetyFlags": {
+        "dataOnly": True,
+        "readOnly": True,
+        "deterministic": True,
+        "loadRequestDisplayOnly": True,
+        "modelDescriptorMetadataOnly": True,
+        "modelAssetsConfigured": False,
+        "modelAssetPathsConfigured": False,
+        "modelAssetPathsIncluded": False,
+        "modelWeightPathsIncluded": False,
+        "modelAssetRead": False,
+        "modelWeightRead": False,
+        "tokenizerRead": False,
+        "checksumManifestRead": False,
+        "checksumValuesIncluded": False,
+        "modelIntegrityChecked": False,
+        "configRead": False,
+        "configWrite": False,
+        "environmentRead": False,
+        "promptContentIncluded": False,
+        "promptCapture": False,
+        "responseContentIncluded": False,
+        "responseGenerated": False,
+        "transcriptPersistence": False,
+        "sessionPersistence": False,
+        "writesArtifacts": False,
+        "readsArtifacts": False,
+        "artifactWrites": False,
+        "artifactReads": False,
+        "privatePathsIncluded": False,
+        "secretsIncluded": False,
+        "tokensIncluded": False,
+        "runtimePreflightExecuted": False,
+        "runtimeStarted": False,
+        "runtimeExecution": False,
+        "modelLoadAttempted": False,
+        "modelLoaded": False,
+        "modelUnloadAttempted": False,
+        "modelExecution": False,
+        "warmupAttempted": False,
+        "touchesHardware": False,
+        "hardwareAccess": False,
+        "kv260Access": False,
+        "opensSerialPort": False,
+        "networkCalls": False,
+        "networkScan": False,
+        "sshExecution": False,
+        "providerCalls": False,
+        "cloudCalls": False,
+        "runtimeLogsIncluded": False,
+        "generatedBlobsIncluded": False,
+        "hardwareDumpsIncluded": False,
+        "telemetry": False,
+        "automaticUpload": False,
+        "writeBack": False,
+        "executesPccxLab": False,
+        "executesSystemverilogIde": False,
+        "mcpServerImplemented": False,
+        "lspImplemented": False,
+        "stableApiAbiClaim": False,
+    },
+    "limitations": [
+        "Data-only chat model-load request fixture; no model asset path is configured, read, resolved, or emitted.",
+        "No model weights, tokenizer files, checksum manifests, configuration files, environment values, prompts, responses, transcripts, runtime logs, private paths, secrets, or tokens are read.",
+        "No model asset validation, checksum computation, runtime preflight, model load, model unload, model warmup, response generation, persistence, import, export, upload, telemetry, or artifact write is performed.",
+        "No KV260 hardware access, serial access, network call, provider call, pccx-lab invocation, or systemverilog-ide invocation is performed.",
+        "This is not a release, tag, compatibility commitment, MCP, LSP, IDE, marketplace, telemetry, runtime, model-loader, provider, storage, or hardware implementation.",
+    ],
+    "issueRefs": [
+        "pccxai/pccx-llm-launcher#9",
+    ],
+}
+
+
+def create_gemma3n_e4b_kv260_chat_model_load_request() -> dict:
+    """Return the checked Gemma 3N E4B plus KV260 model-load request fixture."""
+    return copy.deepcopy(_CHAT_MODEL_LOAD_REQUEST)
+
+
+def chat_model_load_request_json(request: dict | None = None) -> str:
+    """Render a deterministic JSON representation."""
+    return json.dumps(
+        request
+        if request is not None
+        else create_gemma3n_e4b_kv260_chat_model_load_request(),
+        indent=2,
+        sort_keys=True,
+    ) + "\n"
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Print data-only chat model-load request JSON.",
+    )
+    parser.add_argument(
+        "--model",
+        default="gemma3n-e4b",
+        choices=("gemma3n-e4b",),
+        help="model descriptor target",
+    )
+    parser.add_argument(
+        "--target",
+        default="kv260",
+        choices=("kv260",),
+        help="target board/device",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parse_args(sys.argv[1:] if argv is None else argv)
+    sys.stdout.write(chat_model_load_request_json())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contracts/fixtures/chat-model-load-request.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-model-load-request.gemma3n-e4b-kv260-placeholder.json
@@ -1,0 +1,357 @@
+{
+  "assetInputState": "blocked",
+  "assetPathState": "not_configured",
+  "blockedReasons": [
+    {
+      "reasonId": "model_asset_input_boundary_absent",
+      "requiredBefore": "configure_asset_path_enabled",
+      "state": "blocked",
+      "summary": "No reviewed local model asset input boundary exists."
+    },
+    {
+      "reasonId": "model_asset_path_boundary_absent",
+      "requiredBefore": "asset_paths_available",
+      "state": "not_configured",
+      "summary": "No reviewed config/path boundary exists for model asset locations."
+    },
+    {
+      "reasonId": "model_integrity_evidence_absent",
+      "requiredBefore": "validate_assets_enabled",
+      "state": "requires_evidence",
+      "summary": "Checksum, size, format, and provenance evidence are absent."
+    },
+    {
+      "reasonId": "runtime_readiness_blocked",
+      "requiredBefore": "runtime_preflight_enabled",
+      "state": "blocked",
+      "summary": "Runtime readiness remains blocked and not evidence-backed."
+    },
+    {
+      "reasonId": "device_session_inactive",
+      "requiredBefore": "load_model_enabled",
+      "state": "inactive",
+      "summary": "No KV260 target session exists for model load handoff."
+    },
+    {
+      "reasonId": "model_load_executor_absent",
+      "requiredBefore": "load_model_enabled",
+      "state": "disabled",
+      "summary": "No reviewed model-load executor or runtime lifecycle exists."
+    },
+    {
+      "reasonId": "unload_policy_absent",
+      "requiredBefore": "unload_model_enabled",
+      "state": "planned",
+      "summary": "Unload, cleanup, and rollback policy needs a reviewed runtime lifecycle."
+    },
+    {
+      "reasonId": "local_only_policy_required",
+      "requiredBefore": "load_request_review_complete",
+      "state": "planned",
+      "summary": "Local-only policy must continue blocking provider and cloud fallback paths."
+    }
+  ],
+  "chatLocalOnlyPolicyRef": "chat_local_only_policy_gemma3n_e4b_kv260_placeholder",
+  "chatModelStatusRef": "chat_model_status_gemma3n_e4b_kv260_placeholder",
+  "chatReadinessRef": "chat_readiness_gemma3n_e4b_kv260_placeholder",
+  "checksumState": "not_configured",
+  "descriptorState": "available_as_data",
+  "deviceSessionState": "inactive",
+  "deviceSessionStatusRef": "device_session_status_gemma3n_e4b_kv260",
+  "fixtureVersion": "chat-model-load-request.gemma3n-e4b-kv260.2026-05-04",
+  "handoffRefs": [
+    {
+      "fixturePath": "contracts/fixtures/chat-model-status.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_model_status",
+      "schemaVersion": "pccx.chatModelStatus.v0",
+      "state": "blocked",
+      "summary": "Model status display keeps model loading blocked and disabled."
+    },
+    {
+      "fixturePath": "contracts/fixtures/runtime-readiness.gemma3n-e4b-kv260.json",
+      "refId": "runtime_readiness",
+      "schemaVersion": "pccx.runtimeReadiness.v0",
+      "state": "blocked",
+      "summary": "Runtime readiness remains blocked and local-data only."
+    },
+    {
+      "fixturePath": "contracts/fixtures/device-session-status.gemma3n-e4b-kv260.json",
+      "refId": "device_session_status",
+      "schemaVersion": "pccx.deviceSessionStatus.v0",
+      "state": "inactive",
+      "summary": "Device/session status reports no active target session."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-readiness.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_readiness",
+      "schemaVersion": "pccx.chatReadiness.v0",
+      "state": "blocked",
+      "summary": "Chat readiness keeps send and recovery actions blocked."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-local-only-policy.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_local_only_policy",
+      "schemaVersion": "pccx.chatLocalOnlyPolicy.v0",
+      "state": "blocked",
+      "summary": "Local-only policy keeps provider, cloud, and fallback paths blocked."
+    }
+  ],
+  "issueRefs": [
+    "pccxai/pccx-llm-launcher#9"
+  ],
+  "lastUpdatedSource": "pccx_launcher_issue_9_chat_model_load_request_boundary_2026-05-04",
+  "limitations": [
+    "Data-only chat model-load request fixture; no model asset path is configured, read, resolved, or emitted.",
+    "No model weights, tokenizer files, checksum manifests, configuration files, environment values, prompts, responses, transcripts, runtime logs, private paths, secrets, or tokens are read.",
+    "No model asset validation, checksum computation, runtime preflight, model load, model unload, model warmup, response generation, persistence, import, export, upload, telemetry, or artifact write is performed.",
+    "No KV260 hardware access, serial access, network call, provider call, pccx-lab invocation, or systemverilog-ide invocation is performed.",
+    "This is not a release, tag, compatibility commitment, MCP, LSP, IDE, marketplace, telemetry, runtime, model-loader, provider, storage, or hardware implementation."
+  ],
+  "loadControls": [
+    {
+      "blockedReasonRef": "model_load_executor_absent",
+      "controlId": "select_model_descriptor",
+      "enabled": false,
+      "label": "select model descriptor",
+      "launcherAction": "Render descriptor metadata from checked fixtures only.",
+      "sideEffectPolicy": "local_render_only",
+      "state": "target_selected",
+      "userAction": "Review the target model descriptor in the future chat UI."
+    },
+    {
+      "blockedReasonRef": "model_asset_input_boundary_absent",
+      "controlId": "configure_asset_path",
+      "enabled": false,
+      "label": "configure asset path",
+      "launcherAction": "Keep asset path configuration disabled and do not read config or paths.",
+      "sideEffectPolicy": "no_config_or_path_read",
+      "state": "blocked",
+      "userAction": "Configure local assets only after a reviewed model-asset input boundary exists."
+    },
+    {
+      "blockedReasonRef": "model_integrity_evidence_absent",
+      "controlId": "validate_assets",
+      "enabled": false,
+      "label": "validate assets",
+      "launcherAction": "Refuse asset validation and do not open model files or manifests.",
+      "sideEffectPolicy": "no_model_asset_read",
+      "state": "blocked",
+      "userAction": "Validate assets only after integrity and redaction rules are reviewed."
+    },
+    {
+      "blockedReasonRef": "runtime_readiness_blocked",
+      "controlId": "build_load_plan",
+      "enabled": false,
+      "label": "build load plan",
+      "launcherAction": "Render blocked load-plan metadata only.",
+      "sideEffectPolicy": "no_runtime_preflight",
+      "state": "blocked",
+      "userAction": "Build a load plan only after asset, runtime, and target-session evidence exists."
+    },
+    {
+      "blockedReasonRef": "runtime_readiness_blocked",
+      "controlId": "start_runtime",
+      "enabled": false,
+      "label": "start runtime",
+      "launcherAction": "Keep runtime start disabled.",
+      "sideEffectPolicy": "no_runtime_execution",
+      "state": "disabled",
+      "userAction": "Start runtime only after evidence-backed runtime and target-session readiness."
+    },
+    {
+      "blockedReasonRef": "model_load_executor_absent",
+      "controlId": "load_model",
+      "enabled": false,
+      "label": "load model",
+      "launcherAction": "Refuse model load and do not touch model assets or hardware.",
+      "sideEffectPolicy": "no_model_load",
+      "state": "disabled",
+      "userAction": "Load model only after assets, integrity, runtime, and device evidence are reviewed."
+    },
+    {
+      "blockedReasonRef": "model_load_executor_absent",
+      "controlId": "warmup_model",
+      "enabled": false,
+      "label": "warm up model",
+      "launcherAction": "Keep warmup disabled and do not execute inference.",
+      "sideEffectPolicy": "no_model_execution",
+      "state": "disabled",
+      "userAction": "Warm up only after a model is loaded by a reviewed runtime path."
+    },
+    {
+      "blockedReasonRef": "unload_policy_absent",
+      "controlId": "unload_model",
+      "enabled": false,
+      "label": "unload model",
+      "launcherAction": "Keep unload disabled because no model is loaded.",
+      "sideEffectPolicy": "no_runtime_execution",
+      "state": "disabled",
+      "userAction": "Unload only after a reviewed runtime lifecycle exists."
+    },
+    {
+      "blockedReasonRef": "model_asset_path_boundary_absent",
+      "controlId": "persist_load_request",
+      "enabled": false,
+      "label": "persist load request",
+      "launcherAction": "Do not write policy, request, preference, or config files.",
+      "sideEffectPolicy": "no_policy_write",
+      "state": "disabled",
+      "userAction": "Persist load requests only after local configuration storage is reviewed."
+    }
+  ],
+  "loadInputs": [
+    {
+      "contentPolicy": "descriptor_id_and_target_label_only",
+      "enabled": false,
+      "inputId": "model_descriptor",
+      "label": "model descriptor",
+      "sideEffectPolicy": "fixture_metadata_only",
+      "state": "available_as_data",
+      "summary": "Gemma 3N E4B is represented by the checked descriptor fixture only."
+    },
+    {
+      "contentPolicy": "no_model_asset_path_or_private_path",
+      "enabled": false,
+      "inputId": "local_asset_path",
+      "label": "local asset path",
+      "sideEffectPolicy": "no_config_or_path_read",
+      "state": "not_configured",
+      "summary": "No reviewed local model asset path is configured, resolved, read, or emitted."
+    },
+    {
+      "contentPolicy": "no_weight_filename_path_or_bytes",
+      "enabled": false,
+      "inputId": "model_weight_file",
+      "label": "model weight file",
+      "sideEffectPolicy": "no_model_asset_read",
+      "state": "blocked",
+      "summary": "Model weight files are not discovered, opened, validated, or loaded."
+    },
+    {
+      "contentPolicy": "no_tokenizer_filename_path_or_bytes",
+      "enabled": false,
+      "inputId": "tokenizer_asset",
+      "label": "tokenizer asset",
+      "sideEffectPolicy": "no_tokenizer_read",
+      "state": "blocked",
+      "summary": "Tokenizer assets are not discovered, opened, validated, or loaded."
+    },
+    {
+      "contentPolicy": "no_checksum_values_or_manifest_body",
+      "enabled": false,
+      "inputId": "checksum_manifest",
+      "label": "checksum manifest",
+      "sideEffectPolicy": "no_manifest_read",
+      "state": "not_configured",
+      "summary": "No checksum manifest schema or local integrity evidence is configured."
+    },
+    {
+      "contentPolicy": "profile_metadata_only",
+      "enabled": false,
+      "inputId": "runtime_profile",
+      "label": "runtime profile",
+      "sideEffectPolicy": "no_runtime_preflight",
+      "state": "blocked",
+      "summary": "Runtime profile selection is blocked until runtime readiness is evidence-backed."
+    },
+    {
+      "contentPolicy": "inactive_status_only",
+      "enabled": false,
+      "inputId": "device_session",
+      "label": "device session",
+      "sideEffectPolicy": "no_hardware_probe",
+      "state": "inactive",
+      "summary": "No target device session exists and no board runtime state is measured."
+    }
+  ],
+  "loadPlanState": "blocked",
+  "loadRequestId": "chat_model_load_request_gemma3n_e4b_kv260_placeholder",
+  "loadRequestPolicy": {
+    "assetPathsConfigured": false,
+    "checksumsAvailable": false,
+    "contentPolicy": "model-load request metadata only; no model path, asset path, file name, checksum value, manifest body, prompt text, response text, transcript text, runtime log, or private path is included",
+    "descriptorSelected": true,
+    "deviceSessionReady": false,
+    "loadEnabled": false,
+    "mode": "disabled_until_reviewed_model_load_boundary_exists",
+    "modelAssetsConfigured": false,
+    "runtimeReady": false,
+    "sideEffectPolicy": "local_render_only",
+    "sourcePolicy": "checked fixture only; no config, environment, model path, asset path, weight file, tokenizer file, checksum manifest, prompt, response, transcript, artifact, or runtime log is read",
+    "state": "blocked",
+    "unloadEnabled": false,
+    "warmupEnabled": false
+  },
+  "loadRequestState": "blocked",
+  "privacyState": "summary_only",
+  "runtimePreflightState": "blocked",
+  "runtimeReadinessRef": "runtime_readiness_gemma3n_e4b_kv260",
+  "safetyFlags": {
+    "artifactReads": false,
+    "artifactWrites": false,
+    "automaticUpload": false,
+    "checksumManifestRead": false,
+    "checksumValuesIncluded": false,
+    "cloudCalls": false,
+    "configRead": false,
+    "configWrite": false,
+    "dataOnly": true,
+    "deterministic": true,
+    "environmentRead": false,
+    "executesPccxLab": false,
+    "executesSystemverilogIde": false,
+    "generatedBlobsIncluded": false,
+    "hardwareAccess": false,
+    "hardwareDumpsIncluded": false,
+    "kv260Access": false,
+    "loadRequestDisplayOnly": true,
+    "lspImplemented": false,
+    "mcpServerImplemented": false,
+    "modelAssetPathsConfigured": false,
+    "modelAssetPathsIncluded": false,
+    "modelAssetRead": false,
+    "modelAssetsConfigured": false,
+    "modelDescriptorMetadataOnly": true,
+    "modelExecution": false,
+    "modelIntegrityChecked": false,
+    "modelLoadAttempted": false,
+    "modelLoaded": false,
+    "modelUnloadAttempted": false,
+    "modelWeightPathsIncluded": false,
+    "modelWeightRead": false,
+    "networkCalls": false,
+    "networkScan": false,
+    "opensSerialPort": false,
+    "privatePathsIncluded": false,
+    "promptCapture": false,
+    "promptContentIncluded": false,
+    "providerCalls": false,
+    "readOnly": true,
+    "readsArtifacts": false,
+    "responseContentIncluded": false,
+    "responseGenerated": false,
+    "runtimeExecution": false,
+    "runtimeLogsIncluded": false,
+    "runtimePreflightExecuted": false,
+    "runtimeStarted": false,
+    "secretsIncluded": false,
+    "sessionPersistence": false,
+    "sshExecution": false,
+    "stableApiAbiClaim": false,
+    "telemetry": false,
+    "tokenizerRead": false,
+    "tokensIncluded": false,
+    "touchesHardware": false,
+    "transcriptPersistence": false,
+    "warmupAttempted": false,
+    "writeBack": false,
+    "writesArtifacts": false
+  },
+  "schemaVersion": "pccx.chatModelLoadRequest.v0",
+  "selectedModelState": "target_selected",
+  "targetBoard": "xilinx_kria_kv260",
+  "targetDevice": "kv260",
+  "targetModel": "gemma3n-e4b",
+  "unloadState": "disabled",
+  "warmupState": "disabled"
+}

--- a/docs/STANDALONE_CHAT_SESSION_CONTRACT.md
+++ b/docs/STANDALONE_CHAT_SESSION_CONTRACT.md
@@ -10,6 +10,7 @@ The implementation lives in:
 
 - `contracts/chat_session_contract.py`
 - `contracts/chat_model_status_contract.py`
+- `contracts/chat_model_load_request_contract.py`
 - `contracts/chat_session_lifecycle_contract.py`
 - `contracts/chat_surface_layout_contract.py`
 - `contracts/chat_local_only_policy_contract.py`
@@ -29,6 +30,7 @@ The implementation lives in:
 - `contracts/chat_shortcut_map_contract.py`
 - `contracts/fixtures/chat-session.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-model-status.gemma3n-e4b-kv260-placeholder.json`
+- `contracts/fixtures/chat-model-load-request.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-session-lifecycle.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-surface-layout.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-local-only-policy.gemma3n-e4b-kv260-placeholder.json`
@@ -48,6 +50,7 @@ The implementation lives in:
 - `contracts/fixtures/chat-shortcut-map.gemma3n-e4b-kv260-placeholder.json`
 - `scripts/chat-session-stub.sh`
 - `scripts/chat-model-status-stub.sh`
+- `scripts/chat-model-load-request-stub.sh`
 - `scripts/chat-session-lifecycle-stub.sh`
 - `scripts/chat-surface-layout-stub.sh`
 - `scripts/chat-local-only-policy-stub.sh`
@@ -68,6 +71,7 @@ The implementation lives in:
 - `scripts/chat-surface-preview.sh`
 - `scripts/tests/chat_session_contract_test.py`
 - `scripts/tests/chat_model_status_contract_test.py`
+- `scripts/tests/chat_model_load_request_contract_test.py`
 - `scripts/tests/chat_session_lifecycle_contract_test.py`
 - `scripts/tests/chat_surface_layout_contract_test.py`
 - `scripts/tests/chat_local_only_policy_contract_test.py`
@@ -87,6 +91,7 @@ The implementation lives in:
 - `scripts/tests/chat_shortcut_map_contract_test.py`
 - `scripts/tests/chat_surface_preview_test.py`
 - `scripts/tests/status-chat-model-status.sh`
+- `scripts/tests/status-chat-model-load-request.sh`
 - `scripts/tests/status-chat-surface-layout.sh`
 - `scripts/tests/status-chat-local-only-policy.sh`
 - `scripts/tests/status-chat-preferences.sh`
@@ -111,6 +116,8 @@ The chat/session contract records:
 
 - target model and KV260-class target identity
 - chat surface, model-load, input, send, and session states
+- a disabled model-load request boundary for descriptor selection, asset
+  paths, checksums, runtime preflight, load, warmup, and unload gates
 - disabled session controls for new session, model status, send,
   clear, and export actions
 - planned shell regions and navigation items for the blocked chat
@@ -163,6 +170,22 @@ bash scripts/status-stub.sh --include-chat-model-status
 Model loading stays blocked and disabled. The model-status fixture does
 not read model paths, load weights, start runtimes, generate responses,
 touch hardware, call providers, invoke pccx-lab, or write artifacts.
+
+The chat model-load request fixture records the disabled local load
+boundary for future chat model loading:
+
+```bash
+bash scripts/chat-model-load-request-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/status-stub.sh --include-chat-model-load-request
+```
+
+It reports descriptor selection, asset path, checksum, runtime preflight,
+load, warmup, unload, and persistence gates. The fixture does not read
+configuration files, environment values, model paths, asset paths, model
+weights, tokenizer files, checksum manifests, private paths, prompts,
+responses, transcripts, runtime logs, or artifacts, and it does not
+validate, load, unload, warm up, execute, import, export, persist, upload,
+or write model-load request data.
 
 The lifecycle fixture records the session-management boundary for create,
 restore, clear, close, and export-summary operations:
@@ -649,6 +672,12 @@ model-status contract adds reviewable display rows for model-load state.
 The lifecycle contract adds a reviewable session-management shape, but
 these contracts do not add runtime execution, model loading, provider
 calls, persistence, target access, artifact reads, or artifact writes.
+The model-load request contract adds a reviewable disabled load-request
+shape without configuration reads, environment reads, model path reads,
+asset path reads, weight reads, tokenizer reads, checksum manifest reads,
+runtime preflight, model loading, model unloading, model warmup, model
+execution, provider calls, hardware access, persistence, or artifact
+access.
 The readiness contract ties those display and lifecycle states into a
 single checklist and recovery-action view without enabling any send,
 load, restore, or export action.
@@ -727,6 +756,10 @@ This chat/session surface does not add:
   runtime traces, raw logs, or audit export behavior
 - error recovery execution, provider/config reads, model asset reads, or
   taxonomy persistence
+- model-load request execution, configuration reads, environment reads,
+  model path reads, asset path reads, weight reads, tokenizer reads,
+  checksum manifest reads, runtime preflight, model loading, model
+  unloading, model warmup, model execution, or load-request persistence
 - session creation, restore, clear, close, or export behavior
 - readiness recovery execution
 - manifest, transcript, summary, or lifecycle artifact reads or writes

--- a/scripts/chat-model-load-request-stub.sh
+++ b/scripts/chat-model-load-request-stub.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+# Print the data-only chat model-load request contract.
+
+set -eu
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+
+python3 "$ROOT_DIR/contracts/chat_model_load_request_contract.py" "$@"

--- a/scripts/status-stub.sh
+++ b/scripts/status-stub.sh
@@ -34,6 +34,9 @@
 # Chat model status display plan (explicit opt-in, read-only local data):
 #   --include-chat-model-status
 #
+# Chat model-load request boundary (explicit opt-in, read-only local data):
+#   --include-chat-model-load-request
+#
 # Chat readiness checks and recovery actions (explicit opt-in, read-only local data):
 #   --include-chat-readiness
 #
@@ -92,6 +95,7 @@ INCLUDE_CHAT_SESSION_INDEX="0"
 INCLUDE_CHAT_SESSION_STORE_POLICY="0"
 INCLUDE_CHAT_SESSION_TITLE_POLICY="0"
 INCLUDE_CHAT_MODEL_STATUS="0"
+INCLUDE_CHAT_MODEL_LOAD_REQUEST="0"
 INCLUDE_CHAT_READINESS="0"
 INCLUDE_CHAT_COMPOSER="0"
 INCLUDE_CHAT_SEND_RESULT="0"
@@ -2071,6 +2075,146 @@ print(
     printf '%s\n' "$CHAT_MODEL_STATUS_SUMMARY"
 }
 
+print_chat_model_load_request_summary() {
+    SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+    ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+    CHAT_MODEL_LOAD_REQUEST_STUB="$ROOT_DIR/scripts/chat-model-load-request-stub.sh"
+
+    if [ ! -f "$CHAT_MODEL_LOAD_REQUEST_STUB" ]; then
+        ERROR "chat model-load request stub not found: $CHAT_MODEL_LOAD_REQUEST_STUB"
+        return 1
+    fi
+
+    if ! CHAT_MODEL_LOAD_REQUEST_JSON="$(bash "$CHAT_MODEL_LOAD_REQUEST_STUB" --model gemma3n-e4b --target kv260 2>&1)"; then
+        ERROR "chat model-load request stub failed"
+        printf '%s\n' "$CHAT_MODEL_LOAD_REQUEST_JSON" >&2
+        return 1
+    fi
+
+    if ! CHAT_MODEL_LOAD_REQUEST_SUMMARY="$(
+        printf '%s\n' "$CHAT_MODEL_LOAD_REQUEST_JSON" | python3 -c '
+import json
+import sys
+
+data = json.load(sys.stdin)
+flags = data["safetyFlags"]
+policy = data["loadRequestPolicy"]
+
+def b(value):
+    return "true" if value else "false"
+
+inputs = " ".join(
+    "{}={}:{}".format(item["inputId"], item["state"], b(item["enabled"]))
+    for item in data["loadInputs"]
+)
+controls = " ".join(
+    "{}={}:{}".format(control["controlId"], control["state"], b(control["enabled"]))
+    for control in data["loadControls"]
+)
+blocked = " ".join(
+    "{}={}".format(reason["reasonId"], reason["state"])
+    for reason in data["blockedReasons"]
+)
+
+print("[INFO]  source     : scripts/chat-model-load-request-stub.sh --model gemma3n-e4b --target kv260")
+print("[INFO]  boundary   : read-only data; no model asset path/read/load/runtime/provider/hardware/lab/IDE execution")
+print("[INFO]  target     : {}".format(data["targetDevice"]))
+print("[INFO]  model      : {}".format(data["targetModel"]))
+print("[INFO]  request    : {}".format(data["loadRequestState"]))
+print("[INFO]  selected   : {}".format(data["selectedModelState"]))
+print("[INFO]  descriptor : {}".format(data["descriptorState"]))
+print("[INFO]  assets     : {}".format(data["assetInputState"]))
+print("[INFO]  paths      : {}".format(data["assetPathState"]))
+print("[INFO]  checksums  : {}".format(data["checksumState"]))
+print("[INFO]  plan       : {}".format(data["loadPlanState"]))
+print("[INFO]  preflight  : {}".format(data["runtimePreflightState"]))
+print("[INFO]  device     : {}".format(data["deviceSessionState"]))
+print("[INFO]  warmup     : {}".format(data["warmupState"]))
+print("[INFO]  unload     : {}".format(data["unloadState"]))
+print("[INFO]  privacy    : {}".format(data["privacyState"]))
+print(
+    "[INFO]  model-load-request : {} mode={} descriptorSelected={} "
+    "modelAssetsConfigured={} assetPathsConfigured={} checksumsAvailable={} "
+    "runtimeReady={} deviceSessionReady={} loadEnabled={} warmupEnabled={} "
+    "unloadEnabled={}".format(
+        policy["state"],
+        policy["mode"],
+        b(policy["descriptorSelected"]),
+        b(policy["modelAssetsConfigured"]),
+        b(policy["assetPathsConfigured"]),
+        b(policy["checksumsAvailable"]),
+        b(policy["runtimeReady"]),
+        b(policy["deviceSessionReady"]),
+        b(policy["loadEnabled"]),
+        b(policy["warmupEnabled"]),
+        b(policy["unloadEnabled"]),
+    )
+)
+print("[INFO]  inputs     : {}".format(inputs))
+print("[INFO]  controls   : {}".format(controls))
+print("[INFO]  blocked    : {}".format(blocked))
+print(
+    "[INFO]  flags      : readOnly={} dataOnly={} deterministic={} "
+    "loadRequestDisplayOnly={} modelDescriptorMetadataOnly={} "
+    "modelAssetsConfigured={} modelAssetPathsConfigured={} "
+    "modelAssetPathsIncluded={} modelWeightPathsIncluded={} "
+    "modelAssetRead={} modelWeightRead={} tokenizerRead={} "
+    "checksumManifestRead={} checksumValuesIncluded={} "
+    "modelIntegrityChecked={} configRead={} configWrite={} "
+    "environmentRead={} promptContentIncluded={} responseContentIncluded={} "
+    "runtimePreflightExecuted={} runtimeStarted={} runtimeExecution={} "
+    "modelLoadAttempted={} modelLoaded={} modelUnloadAttempted={} "
+    "modelExecution={} warmupAttempted={} kv260Access={} hardwareAccess={} "
+    "networkCalls={} providerCalls={} cloudCalls={} writesArtifacts={} "
+    "readsArtifacts={} executesPccxLab={}".format(
+        b(flags["readOnly"]),
+        b(flags["dataOnly"]),
+        b(flags["deterministic"]),
+        b(flags["loadRequestDisplayOnly"]),
+        b(flags["modelDescriptorMetadataOnly"]),
+        b(flags["modelAssetsConfigured"]),
+        b(flags["modelAssetPathsConfigured"]),
+        b(flags["modelAssetPathsIncluded"]),
+        b(flags["modelWeightPathsIncluded"]),
+        b(flags["modelAssetRead"]),
+        b(flags["modelWeightRead"]),
+        b(flags["tokenizerRead"]),
+        b(flags["checksumManifestRead"]),
+        b(flags["checksumValuesIncluded"]),
+        b(flags["modelIntegrityChecked"]),
+        b(flags["configRead"]),
+        b(flags["configWrite"]),
+        b(flags["environmentRead"]),
+        b(flags["promptContentIncluded"]),
+        b(flags["responseContentIncluded"]),
+        b(flags["runtimePreflightExecuted"]),
+        b(flags["runtimeStarted"]),
+        b(flags["runtimeExecution"]),
+        b(flags["modelLoadAttempted"]),
+        b(flags["modelLoaded"]),
+        b(flags["modelUnloadAttempted"]),
+        b(flags["modelExecution"]),
+        b(flags["warmupAttempted"]),
+        b(flags["kv260Access"]),
+        b(flags["hardwareAccess"]),
+        b(flags["networkCalls"]),
+        b(flags["providerCalls"]),
+        b(flags["cloudCalls"]),
+        b(flags["writesArtifacts"]),
+        b(flags["readsArtifacts"]),
+        b(flags["executesPccxLab"]),
+    )
+)
+'
+    )"; then
+        ERROR "chat model-load request JSON could not be summarized"
+        return 1
+    fi
+
+    HEAD "chat model load request"
+    printf '%s\n' "$CHAT_MODEL_LOAD_REQUEST_SUMMARY"
+}
+
 print_chat_session_summary() {
     SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
     ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
@@ -2373,6 +2517,10 @@ while [ $# -gt 0 ]; do
             INCLUDE_CHAT_MODEL_STATUS="1"
             shift
             ;;
+        --include-chat-model-load-request)
+            INCLUDE_CHAT_MODEL_LOAD_REQUEST="1"
+            shift
+            ;;
         --include-chat-readiness)
             INCLUDE_CHAT_READINESS="1"
             shift
@@ -2432,8 +2580,8 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-if [ -n "$BACKEND" ] && { [ "$INCLUDE_RUNTIME_READINESS" = "1" ] || [ "$INCLUDE_DEVICE_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SURFACE_LAYOUT" = "1" ] || [ "$INCLUDE_CHAT_LOCAL_ONLY_POLICY" = "1" ] || [ "$INCLUDE_CHAT_PREFERENCES" = "1" ] || [ "$INCLUDE_CHAT_SESSION_INDEX" = "1" ] || [ "$INCLUDE_CHAT_SESSION_STORE_POLICY" = "1" ] || [ "$INCLUDE_CHAT_SESSION_TITLE_POLICY" = "1" ] || [ "$INCLUDE_CHAT_MODEL_STATUS" = "1" ] || [ "$INCLUDE_CHAT_READINESS" = "1" ] || [ "$INCLUDE_CHAT_COMPOSER" = "1" ] || [ "$INCLUDE_CHAT_SEND_RESULT" = "1" ] || [ "$INCLUDE_CHAT_TRANSCRIPT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_AUDIT_EVENT" = "1" ] || [ "$INCLUDE_CHAT_ERROR_TAXONOMY" = "1" ] || [ "$INCLUDE_CHAT_RESPONSE_STREAM" = "1" ] || [ "$INCLUDE_CHAT_MESSAGE_LIST" = "1" ] || [ "$INCLUDE_CHAT_ACTION_BAR" = "1" ] || [ "$INCLUDE_CHAT_ATTACHMENT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_SHORTCUT_MAP" = "1" ]; }; then
-    ERROR "--include-runtime-readiness, --include-device-session, --include-chat-session, --include-chat-surface-layout, --include-chat-local-only-policy, --include-chat-preferences, --include-chat-session-index, --include-chat-session-store-policy, --include-chat-session-title-policy, --include-chat-model-status, --include-chat-readiness, --include-chat-composer, --include-chat-send-result, --include-chat-transcript-policy, --include-chat-audit-event, --include-chat-error-taxonomy, --include-chat-response-stream, --include-chat-message-list, --include-chat-action-bar, --include-chat-attachment-policy, and --include-chat-shortcut-map are only supported in local scaffold mode"
+if [ -n "$BACKEND" ] && { [ "$INCLUDE_RUNTIME_READINESS" = "1" ] || [ "$INCLUDE_DEVICE_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SURFACE_LAYOUT" = "1" ] || [ "$INCLUDE_CHAT_LOCAL_ONLY_POLICY" = "1" ] || [ "$INCLUDE_CHAT_PREFERENCES" = "1" ] || [ "$INCLUDE_CHAT_SESSION_INDEX" = "1" ] || [ "$INCLUDE_CHAT_SESSION_STORE_POLICY" = "1" ] || [ "$INCLUDE_CHAT_SESSION_TITLE_POLICY" = "1" ] || [ "$INCLUDE_CHAT_MODEL_STATUS" = "1" ] || [ "$INCLUDE_CHAT_MODEL_LOAD_REQUEST" = "1" ] || [ "$INCLUDE_CHAT_READINESS" = "1" ] || [ "$INCLUDE_CHAT_COMPOSER" = "1" ] || [ "$INCLUDE_CHAT_SEND_RESULT" = "1" ] || [ "$INCLUDE_CHAT_TRANSCRIPT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_AUDIT_EVENT" = "1" ] || [ "$INCLUDE_CHAT_ERROR_TAXONOMY" = "1" ] || [ "$INCLUDE_CHAT_RESPONSE_STREAM" = "1" ] || [ "$INCLUDE_CHAT_MESSAGE_LIST" = "1" ] || [ "$INCLUDE_CHAT_ACTION_BAR" = "1" ] || [ "$INCLUDE_CHAT_ATTACHMENT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_SHORTCUT_MAP" = "1" ]; }; then
+    ERROR "--include-runtime-readiness, --include-device-session, --include-chat-session, --include-chat-surface-layout, --include-chat-local-only-policy, --include-chat-preferences, --include-chat-session-index, --include-chat-session-store-policy, --include-chat-session-title-policy, --include-chat-model-status, --include-chat-model-load-request, --include-chat-readiness, --include-chat-composer, --include-chat-send-result, --include-chat-transcript-policy, --include-chat-audit-event, --include-chat-error-taxonomy, --include-chat-response-stream, --include-chat-message-list, --include-chat-action-bar, --include-chat-attachment-policy, and --include-chat-shortcut-map are only supported in local scaffold mode"
     exit 1
 fi
 
@@ -2456,6 +2604,7 @@ if [ -z "$BACKEND" ]; then
     NOTE "chat store    : opt-in via --include-chat-session-store-policy (read-only session-store policy data)"
     NOTE "chat titles   : opt-in via --include-chat-session-title-policy (read-only title policy data)"
     NOTE "chat model    : opt-in via --include-chat-model-status (read-only model status display data)"
+    NOTE "chat load     : opt-in via --include-chat-model-load-request (read-only model-load request data)"
     NOTE "chat readiness: opt-in via --include-chat-readiness (read-only readiness and recovery data)"
     NOTE "chat composer : opt-in via --include-chat-composer (read-only input control data)"
     NOTE "chat send     : opt-in via --include-chat-send-result (read-only blocked send-result data)"
@@ -2567,6 +2716,12 @@ if [ -z "$BACKEND" ]; then
 
     if [ "$INCLUDE_CHAT_MODEL_STATUS" = "1" ]; then
         if ! print_chat_model_status_summary; then
+            exit 1
+        fi
+    fi
+
+    if [ "$INCLUDE_CHAT_MODEL_LOAD_REQUEST" = "1" ]; then
+        if ! print_chat_model_load_request_summary; then
             exit 1
         fi
     fi

--- a/scripts/tests/chat_model_load_request_contract_test.py
+++ b/scripts/tests/chat_model_load_request_contract_test.py
@@ -1,0 +1,404 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Fixture tests for the standalone chat model-load request contract."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "contracts" / "chat_model_load_request_contract.py"
+FIXTURE_PATH = (
+    ROOT
+    / "contracts"
+    / "fixtures"
+    / "chat-model-load-request.gemma3n-e4b-kv260-placeholder.json"
+)
+SCRIPT_PATH = ROOT / "scripts" / "chat-model-load-request-stub.sh"
+STATUS_TEST_PATH = ROOT / "scripts" / "tests" / "status-chat-model-load-request.sh"
+DOC_PATH = ROOT / "docs" / "STANDALONE_CHAT_SESSION_CONTRACT.md"
+README_PATH = ROOT / "README.md"
+TEST_PATH = Path(__file__).resolve()
+CI_PATH = ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location(
+        "chat_model_load_request_contract",
+        MODULE_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def iter_state_values(value):
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            if (
+                key == "state"
+                or key.endswith("State")
+                or key.endswith("Status")
+            ) and isinstance(nested, str):
+                yield nested
+            yield from iter_state_values(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            yield from iter_state_values(nested)
+
+
+def iter_keys(value):
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            yield key
+            yield from iter_keys(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            yield from iter_keys(nested)
+
+
+def assert_no_private_or_generated_data(text: str) -> None:
+    forbidden_patterns = [
+        r"/home/[^\s\"']+",
+        r"/Users/[^\s\"']+",
+        r"[A-Za-z]:\\Users\\",
+        r"\b(?:api[_-]?key|authorization|bearer|client[_-]?secret|password|private[_-]?key|secret|token)\b\s*[:=]",
+        r"\.(?:gguf|safetensors|ckpt|pt|pth|onnx)\b",
+        r"(?:weights|model_weights|model-cache)/(?:[^\"'\s]+)",
+        r"(?:raw[_-]?full[_-]?logs|hardware[_-]?dump|generated[_-]?blob)\s*[:=]",
+    ]
+    for pattern in forbidden_patterns:
+        assert not re.search(pattern, text, re.IGNORECASE), pattern
+
+
+def assert_no_runtime_implementation_terms(source: str) -> None:
+    forbidden = [
+        "subprocess",
+        "os.system",
+        "popen",
+        "socket",
+        "urllib",
+        "import " + "requests",
+        "from " + "requests",
+        "http.client",
+        "openai",
+        "anthropic",
+        "gem" + "ini",
+        "modelcontextprotocol",
+        "websocket",
+        "xmutil",
+        "xrt-smi",
+        "lsusb",
+        "dmesg",
+    ]
+    lowered = source.lower()
+    for term in forbidden:
+        assert term not in lowered, term
+
+
+def assert_no_provider_configs(value) -> None:
+    forbidden_keys = {
+        "apiKey",
+        "accessToken",
+        "refreshToken",
+        "authorization",
+        "bearerToken",
+        "provider",
+        "providers",
+        "providerConfig",
+        "providerConfigs",
+    }
+    for key in iter_keys(value):
+        assert key not in forbidden_keys, key
+
+
+def assert_no_unsupported_claims(text: str) -> None:
+    literal_claims = [
+        "production" + "-ready",
+        "marketplace" + "-ready",
+        "stable " + "API",
+        "stable " + "ABI",
+        "KV260 inference " + "works",
+        "Gemma 3N E4B " + "runs on KV260",
+        "20 tok/s " + "achieved",
+        "timing " + "closed",
+        "bitstream " + "ready",
+        "launcher executes " + "pccx-lab",
+        "IDE controls " + "launcher",
+        "AI provider integration " + "is live",
+    ]
+    lowered = text.lower()
+    for claim in literal_claims:
+        assert claim.lower() not in lowered, claim
+
+
+def test_chat_model_load_request_matches_fixture_and_is_deterministic() -> None:
+    module = load_module()
+    generated = module.create_gemma3n_e4b_kv260_chat_model_load_request()
+    fixture = json.loads(read_text(FIXTURE_PATH))
+
+    assert generated == fixture
+    assert module.chat_model_load_request_json(generated) == (
+        module.chat_model_load_request_json(generated)
+    )
+    assert module.chat_model_load_request_json(generated).endswith("\n")
+    assert json.loads(module.chat_model_load_request_json(generated)) == fixture
+
+
+def test_cli_stub_outputs_deterministic_json() -> None:
+    fixture = json.loads(read_text(FIXTURE_PATH))
+    command = [
+        "bash",
+        str(SCRIPT_PATH),
+        "--model",
+        "gemma3n-e4b",
+        "--target",
+        "kv260",
+    ]
+    first = subprocess.run(command, check=True, capture_output=True, text=True)
+    second = subprocess.run(command, check=True, capture_output=True, text=True)
+
+    assert first.stderr == ""
+    assert first.stdout == second.stdout
+    assert first.stdout.endswith("\n")
+    assert json.loads(first.stdout) == fixture
+
+
+def test_required_fields_and_allowed_states() -> None:
+    module = load_module()
+    request = module.create_gemma3n_e4b_kv260_chat_model_load_request()
+    allowed = set(module.CHAT_MODEL_LOAD_REQUEST_STATE_VALUES)
+
+    assert tuple(request.keys()) == module.CHAT_MODEL_LOAD_REQUEST_FIELDS
+    assert request["schemaVersion"] == "pccx.chatModelLoadRequest.v0"
+    assert tuple(request["loadRequestPolicy"].keys()) == (
+        module.LOAD_REQUEST_POLICY_FIELDS
+    )
+
+    states = list(iter_state_values(request))
+    assert states
+    for state in states:
+        assert state in allowed, state
+
+    for load_input in request["loadInputs"]:
+        assert tuple(load_input.keys()) == module.LOAD_INPUT_FIELDS
+    for control in request["loadControls"]:
+        assert tuple(control.keys()) == module.LOAD_CONTROL_FIELDS
+    for reason in request["blockedReasons"]:
+        assert tuple(reason.keys()) == module.BLOCKED_REASON_FIELDS
+    for ref in request["handoffRefs"]:
+        assert tuple(ref.keys()) == module.HANDOFF_REF_FIELDS
+
+
+def test_chat_model_load_request_keeps_load_disabled() -> None:
+    request = load_module().create_gemma3n_e4b_kv260_chat_model_load_request()
+    policy = request["loadRequestPolicy"]
+    load_inputs = {item["inputId"]: item for item in request["loadInputs"]}
+    controls = {control["controlId"]: control for control in request["loadControls"]}
+    reasons = {reason["reasonId"]: reason for reason in request["blockedReasons"]}
+    refs = {ref["refId"]: ref for ref in request["handoffRefs"]}
+    flags = request["safetyFlags"]
+
+    assert request["loadRequestState"] == "blocked"
+    assert request["selectedModelState"] == "target_selected"
+    assert request["descriptorState"] == "available_as_data"
+    assert request["assetInputState"] == "blocked"
+    assert request["assetPathState"] == "not_configured"
+    assert request["checksumState"] == "not_configured"
+    assert request["loadPlanState"] == "blocked"
+    assert request["runtimePreflightState"] == "blocked"
+    assert request["deviceSessionState"] == "inactive"
+    assert request["warmupState"] == "disabled"
+    assert request["unloadState"] == "disabled"
+    assert policy["descriptorSelected"] is True
+    assert policy["modelAssetsConfigured"] is False
+    assert policy["assetPathsConfigured"] is False
+    assert policy["checksumsAvailable"] is False
+    assert policy["runtimeReady"] is False
+    assert policy["deviceSessionReady"] is False
+    assert policy["loadEnabled"] is False
+    assert policy["warmupEnabled"] is False
+    assert policy["unloadEnabled"] is False
+    assert set(load_inputs) == {
+        "model_descriptor",
+        "local_asset_path",
+        "model_weight_file",
+        "tokenizer_asset",
+        "checksum_manifest",
+        "runtime_profile",
+        "device_session",
+    }
+    assert all(item["enabled"] is False for item in load_inputs.values())
+    assert set(controls) == {
+        "select_model_descriptor",
+        "configure_asset_path",
+        "validate_assets",
+        "build_load_plan",
+        "start_runtime",
+        "load_model",
+        "warmup_model",
+        "unload_model",
+        "persist_load_request",
+    }
+    assert all(control["enabled"] is False for control in controls.values())
+    assert controls["configure_asset_path"]["sideEffectPolicy"] == "no_config_or_path_read"
+    assert controls["validate_assets"]["sideEffectPolicy"] == "no_model_asset_read"
+    assert controls["load_model"]["sideEffectPolicy"] == "no_model_load"
+    assert set(reasons) == {
+        "model_asset_input_boundary_absent",
+        "model_asset_path_boundary_absent",
+        "model_integrity_evidence_absent",
+        "runtime_readiness_blocked",
+        "device_session_inactive",
+        "model_load_executor_absent",
+        "unload_policy_absent",
+        "local_only_policy_required",
+    }
+    assert set(refs) == {
+        "chat_model_status",
+        "runtime_readiness",
+        "device_session_status",
+        "chat_readiness",
+        "chat_local_only_policy",
+    }
+    assert flags["readOnly"] is True
+    assert flags["dataOnly"] is True
+    assert flags["loadRequestDisplayOnly"] is True
+    assert flags["modelDescriptorMetadataOnly"] is True
+    for name in [
+        "modelAssetsConfigured",
+        "modelAssetPathsConfigured",
+        "modelAssetPathsIncluded",
+        "modelWeightPathsIncluded",
+        "modelAssetRead",
+        "modelWeightRead",
+        "tokenizerRead",
+        "checksumManifestRead",
+        "checksumValuesIncluded",
+        "modelIntegrityChecked",
+        "configRead",
+        "configWrite",
+        "environmentRead",
+        "promptContentIncluded",
+        "responseContentIncluded",
+        "runtimePreflightExecuted",
+        "runtimeStarted",
+        "runtimeExecution",
+        "modelLoadAttempted",
+        "modelLoaded",
+        "modelUnloadAttempted",
+        "modelExecution",
+        "warmupAttempted",
+        "kv260Access",
+        "hardwareAccess",
+        "networkCalls",
+        "providerCalls",
+        "cloudCalls",
+        "writesArtifacts",
+        "readsArtifacts",
+        "executesPccxLab",
+    ]:
+        assert flags[name] is False, name
+
+
+def test_chat_model_load_request_docs_and_ci_are_wired() -> None:
+    doc = read_text(DOC_PATH)
+    readme = read_text(README_PATH)
+    status_test = read_text(STATUS_TEST_PATH)
+    ci = read_text(CI_PATH)
+
+    assert "contracts/chat_model_load_request_contract.py" in doc
+    assert (
+        "contracts/fixtures/chat-model-load-request.gemma3n-e4b-kv260-placeholder.json"
+        in doc
+    )
+    assert "scripts/chat-model-load-request-stub.sh" in doc
+    assert "scripts/tests/chat_model_load_request_contract_test.py" in doc
+    assert "scripts/tests/status-chat-model-load-request.sh" in doc
+    assert "chat-model-load-request-stub.sh" in readme
+    assert "--include-chat-model-load-request" in readme
+    assert "chat_model_load_request_contract_test.py" in ci
+    assert "status-chat-model-load-request.sh" in ci
+    assert "--include-chat-model-load-request" in status_test
+    assert "no model asset path/read/load/runtime" in status_test
+
+
+def test_chat_model_load_request_has_no_runtime_or_private_surface() -> None:
+    module = load_module()
+    request = module.create_gemma3n_e4b_kv260_chat_model_load_request()
+    fixture_text = read_text(FIXTURE_PATH)
+    contract_source = read_text(MODULE_PATH)
+    stub_source = read_text(SCRIPT_PATH)
+    docs = "\n".join(
+        [
+            fixture_text,
+            contract_source,
+            stub_source,
+            read_text(DOC_PATH),
+            read_text(README_PATH),
+            read_text(STATUS_TEST_PATH),
+        ]
+    )
+
+    assert_no_provider_configs(request)
+    assert_no_private_or_generated_data(docs)
+    assert_no_unsupported_claims(docs)
+    assert_no_runtime_implementation_terms(contract_source)
+    assert_no_runtime_implementation_terms(stub_source)
+    assert "modelPathValue" not in fixture_text
+    assert "assetPathValue" not in fixture_text
+    assert "weightFilename" not in fixture_text
+    assert '"checksumValue"' not in fixture_text
+    assert "promptText" not in fixture_text
+    assert "responseText" not in fixture_text
+    assert "transcriptText" not in fixture_text
+
+
+def test_source_headers_for_touched_code_files() -> None:
+    expected_headers = {
+        MODULE_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        SCRIPT_PATH: [
+            "#!/usr/bin/env bash",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        STATUS_TEST_PATH: [
+            "#!/usr/bin/env bash",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        TEST_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        CI_PATH: [
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+    }
+
+    for path, headers in expected_headers.items():
+        assert read_text(path).splitlines()[: len(headers)] == headers, path
+
+
+if __name__ == "__main__":
+    for name, func in sorted(globals().items()):
+        if name.startswith("test_") and callable(func):
+            func()
+    print("chat model-load request contract tests ok")

--- a/scripts/tests/status-chat-model-load-request.sh
+++ b/scripts/tests/status-chat-model-load-request.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+# scripts/tests/status-chat-model-load-request.sh - status model-load request tests.
+#
+# Usage: bash scripts/tests/status-chat-model-load-request.sh [path/to/status-stub.sh]
+
+set -eu
+
+PASS() { printf '[PASS]  %s\n' "$*"; }
+FAIL() { printf '[FAIL] %s\n' "$*" >&2; }
+HEAD() { printf '\n=== %s ===\n' "$*"; }
+
+STUB="${1:-scripts/status-stub.sh}"
+
+if [ ! -x "$STUB" ]; then
+    chmod +x "$STUB"
+fi
+
+contains() {
+    case "$1" in
+        *"$2"*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+require_contains() {
+    local output="$1"
+    local expected="$2"
+    if ! contains "$output" "$expected"; then
+        FAIL "expected output to contain: $expected"
+        printf '%s\n' "$output" >&2
+        exit 1
+    fi
+}
+
+require_not_contains() {
+    local output="$1"
+    local forbidden="$2"
+    if contains "$output" "$forbidden"; then
+        FAIL "output contained forbidden text: $forbidden"
+        printf '%s\n' "$output" >&2
+        exit 1
+    fi
+}
+
+HEAD "1: status can include chat model-load request"
+OUTPUT="$("$STUB" --include-chat-model-load-request)"
+require_contains "$OUTPUT" "=== chat model load request ==="
+require_contains "$OUTPUT" "source     : scripts/chat-model-load-request-stub.sh --model gemma3n-e4b --target kv260"
+require_contains "$OUTPUT" "boundary   : read-only data; no model asset path/read/load/runtime/provider/hardware/lab/IDE execution"
+require_contains "$OUTPUT" "target     : kv260"
+require_contains "$OUTPUT" "model      : gemma3n-e4b"
+require_contains "$OUTPUT" "request    : blocked"
+require_contains "$OUTPUT" "selected   : target_selected"
+require_contains "$OUTPUT" "descriptor : available_as_data"
+require_contains "$OUTPUT" "assets     : blocked"
+require_contains "$OUTPUT" "paths      : not_configured"
+require_contains "$OUTPUT" "checksums  : not_configured"
+require_contains "$OUTPUT" "plan       : blocked"
+require_contains "$OUTPUT" "preflight  : blocked"
+require_contains "$OUTPUT" "device     : inactive"
+require_contains "$OUTPUT" "warmup     : disabled"
+require_contains "$OUTPUT" "unload     : disabled"
+require_contains "$OUTPUT" "privacy    : summary_only"
+PASS "chat model-load request section is present and conservative"
+
+HEAD "2: policy, inputs, and controls stay disabled"
+require_contains "$OUTPUT" "model-load-request : blocked mode=disabled_until_reviewed_model_load_boundary_exists"
+require_contains "$OUTPUT" "descriptorSelected=true"
+require_contains "$OUTPUT" "modelAssetsConfigured=false"
+require_contains "$OUTPUT" "assetPathsConfigured=false"
+require_contains "$OUTPUT" "checksumsAvailable=false"
+require_contains "$OUTPUT" "runtimeReady=false"
+require_contains "$OUTPUT" "deviceSessionReady=false"
+require_contains "$OUTPUT" "loadEnabled=false"
+require_contains "$OUTPUT" "warmupEnabled=false"
+require_contains "$OUTPUT" "unloadEnabled=false"
+require_contains "$OUTPUT" "inputs     : model_descriptor=available_as_data:false"
+require_contains "$OUTPUT" "local_asset_path=not_configured:false"
+require_contains "$OUTPUT" "model_weight_file=blocked:false"
+require_contains "$OUTPUT" "tokenizer_asset=blocked:false"
+require_contains "$OUTPUT" "checksum_manifest=not_configured:false"
+require_contains "$OUTPUT" "runtime_profile=blocked:false"
+require_contains "$OUTPUT" "device_session=inactive:false"
+require_contains "$OUTPUT" "controls   : select_model_descriptor=target_selected:false"
+require_contains "$OUTPUT" "configure_asset_path=blocked:false"
+require_contains "$OUTPUT" "validate_assets=blocked:false"
+require_contains "$OUTPUT" "build_load_plan=blocked:false"
+require_contains "$OUTPUT" "start_runtime=disabled:false"
+require_contains "$OUTPUT" "load_model=disabled:false"
+require_contains "$OUTPUT" "warmup_model=disabled:false"
+require_contains "$OUTPUT" "unload_model=disabled:false"
+require_contains "$OUTPUT" "persist_load_request=disabled:false"
+PASS "model-load request metadata is summarized without asset reads"
+
+HEAD "3: blocked reasons stay explicit"
+require_contains "$OUTPUT" "blocked    : model_asset_input_boundary_absent=blocked"
+require_contains "$OUTPUT" "model_asset_path_boundary_absent=not_configured"
+require_contains "$OUTPUT" "model_integrity_evidence_absent=requires_evidence"
+require_contains "$OUTPUT" "runtime_readiness_blocked=blocked"
+require_contains "$OUTPUT" "device_session_inactive=inactive"
+require_contains "$OUTPUT" "model_load_executor_absent=disabled"
+require_contains "$OUTPUT" "unload_policy_absent=planned"
+require_contains "$OUTPUT" "local_only_policy_required=planned"
+PASS "model-load blockers remain visible"
+
+HEAD "4: safety flags stay read-only and non-executing"
+require_contains "$OUTPUT" "readOnly=true"
+require_contains "$OUTPUT" "dataOnly=true"
+require_contains "$OUTPUT" "deterministic=true"
+require_contains "$OUTPUT" "loadRequestDisplayOnly=true"
+require_contains "$OUTPUT" "modelDescriptorMetadataOnly=true"
+require_contains "$OUTPUT" "modelAssetsConfigured=false"
+require_contains "$OUTPUT" "modelAssetPathsConfigured=false"
+require_contains "$OUTPUT" "modelAssetPathsIncluded=false"
+require_contains "$OUTPUT" "modelWeightPathsIncluded=false"
+require_contains "$OUTPUT" "modelAssetRead=false"
+require_contains "$OUTPUT" "modelWeightRead=false"
+require_contains "$OUTPUT" "tokenizerRead=false"
+require_contains "$OUTPUT" "checksumManifestRead=false"
+require_contains "$OUTPUT" "checksumValuesIncluded=false"
+require_contains "$OUTPUT" "modelIntegrityChecked=false"
+require_contains "$OUTPUT" "configRead=false"
+require_contains "$OUTPUT" "configWrite=false"
+require_contains "$OUTPUT" "environmentRead=false"
+require_contains "$OUTPUT" "promptContentIncluded=false"
+require_contains "$OUTPUT" "responseContentIncluded=false"
+require_contains "$OUTPUT" "runtimePreflightExecuted=false"
+require_contains "$OUTPUT" "runtimeStarted=false"
+require_contains "$OUTPUT" "runtimeExecution=false"
+require_contains "$OUTPUT" "modelLoadAttempted=false"
+require_contains "$OUTPUT" "modelLoaded=false"
+require_contains "$OUTPUT" "modelUnloadAttempted=false"
+require_contains "$OUTPUT" "modelExecution=false"
+require_contains "$OUTPUT" "warmupAttempted=false"
+require_contains "$OUTPUT" "kv260Access=false"
+require_contains "$OUTPUT" "hardwareAccess=false"
+require_contains "$OUTPUT" "networkCalls=false"
+require_contains "$OUTPUT" "providerCalls=false"
+require_contains "$OUTPUT" "cloudCalls=false"
+require_contains "$OUTPUT" "writesArtifacts=false"
+require_contains "$OUTPUT" "readsArtifacts=false"
+require_contains "$OUTPUT" "executesPccxLab=false"
+PASS "execution, asset read, and persistence flags remain false"
+
+HEAD "5: output is deterministic"
+OUTPUT_AGAIN="$("$STUB" --include-chat-model-load-request)"
+if [ "$OUTPUT" != "$OUTPUT_AGAIN" ]; then
+    FAIL "status chat model-load request output changed between runs"
+    exit 1
+fi
+PASS "status chat model-load request output is deterministic"
+
+HEAD "6: chat model-load request option does not combine with pccx-lab backend"
+if "$STUB" --include-chat-model-load-request --backend pccx-lab >/dev/null 2>&1; then
+    FAIL "expected combined chat-model-load-request/backend mode to fail"
+    exit 1
+fi
+PASS "chat model-load request remains separate from backend execution"
+
+HEAD "7: output avoids known overclaims and content"
+FORBIDDEN_PREFIX="KV260 inference"
+FORBIDDEN_CLAIM="${FORBIDDEN_PREFIX} works"
+require_not_contains "$OUTPUT" "$FORBIDDEN_CLAIM"
+THROUGHPUT_PREFIX="20 tok/s"
+THROUGHPUT_CLAIM="${THROUGHPUT_PREFIX} achieved"
+require_not_contains "$OUTPUT" "$THROUGHPUT_CLAIM"
+GGUF_EXT=".g""guf"
+SAFETENSORS_EXT=".safe""tensors"
+require_not_contains "$OUTPUT" "$GGUF_EXT"
+require_not_contains "$OUTPUT" "$SAFETENSORS_EXT"
+require_not_contains "$OUTPUT" "assistant response:"
+require_not_contains "$OUTPUT" "hello"
+PASS "no model-load overclaim or asset/content leakage in status output"
+
+printf '\n[DONE]  all status-chat-model-load-request tests passed\n'


### PR DESCRIPTION
## Summary

- Add a checked data-only `pccx.chatModelLoadRequest.v0` fixture for the disabled local model-load request boundary.
- Wire the JSON stub and opt-in `status-stub.sh --include-chat-model-load-request` summary.
- Document the disabled asset path, validation, runtime preflight, load, warmup, unload, and persistence gates in README and standalone chat docs.
- Extend CI coverage for the new contract and status surface.

## Safety scope

- No config, environment, model asset path, model weight, tokenizer, checksum manifest, prompt, response, transcript, runtime log, private path, or artifact read/write.
- No runtime preflight, model load, warmup, unload, model execution, provider/cloud/network call, hardware access, pccx-lab execution, or IDE execution.

## Validation

- `python3 scripts/tests/chat_model_load_request_contract_test.py`
- `bash scripts/tests/status-chat-model-load-request.sh scripts/status-stub.sh`
- `python3 -m json.tool contracts/fixtures/chat-model-load-request.gemma3n-e4b-kv260-placeholder.json`
- `cmp -s contracts/fixtures/chat-model-load-request.gemma3n-e4b-kv260-placeholder.json <(python3 contracts/chat_model_load_request_contract.py --model gemma3n-e4b --target kv260)`
- `python3 -m py_compile contracts/chat_model_load_request_contract.py scripts/tests/chat_model_load_request_contract_test.py`
- `find scripts -type f -name '*.sh' -print0 | xargs -0 bash -n`
- `for t in scripts/tests/*_test.py; do python3 "$t"; done`
- `for t in scripts/tests/status-*.sh; do bash "$t" scripts/status-stub.sh; done`
- `bash scripts/status-stub.sh`
- `bash scripts/check.sh`
- `bash scripts/check-device-stub.sh`
- `bash scripts/install-stub.sh`
- `bash scripts/launch-stub.sh --dry-run`
- `bash scripts/chat-stub.sh --dry-run --prompt hello`
- local forbidden-claim scan matching CI guard
- `git diff --check`
- `git diff --cached --check`

Local note: `shellcheck` is not installed on this host; CI installs and runs it.

Refs #9.