### PR TITLE
Add chat model-selection policy boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,7 @@ jobs:
                    scripts/device-session-status-stub.sh \
                    scripts/runtime-readiness-stub.sh \
                    scripts/chat-model-status-stub.sh \
+                   scripts/chat-model-selection-policy-stub.sh \
                    scripts/chat-model-load-request-stub.sh \
                    scripts/chat-session-stub.sh \
                    scripts/chat-session-lifecycle-stub.sh \
@@ -177,6 +178,10 @@ jobs:
         run: ./scripts/status-stub.sh --include-chat-model-status
       - name: run scripts/chat-model-status-stub.sh
         run: ./scripts/chat-model-status-stub.sh --model gemma3n-e4b --target kv260
+      - name: run scripts/status-stub.sh with chat model-selection policy
+        run: ./scripts/status-stub.sh --include-chat-model-selection-policy
+      - name: run scripts/chat-model-selection-policy-stub.sh
+        run: ./scripts/chat-model-selection-policy-stub.sh --model gemma3n-e4b --target kv260
       - name: run scripts/status-stub.sh with chat model-load request
         run: ./scripts/status-stub.sh --include-chat-model-load-request
       - name: run scripts/chat-model-load-request-stub.sh
@@ -279,6 +284,8 @@ jobs:
         run: python3 scripts/tests/chat_session_contract_test.py
       - name: run chat model status contract tests
         run: python3 scripts/tests/chat_model_status_contract_test.py
+      - name: run chat model-selection policy contract tests
+        run: python3 scripts/tests/chat_model_selection_policy_contract_test.py
       - name: run chat model-load request contract tests
         run: python3 scripts/tests/chat_model_load_request_contract_test.py
       - name: run chat/session lifecycle contract tests
@@ -330,6 +337,7 @@ jobs:
           chmod +x scripts/status-stub.sh
           chmod +x scripts/chat-stub.sh
           chmod +x scripts/chat-model-status-stub.sh
+          chmod +x scripts/chat-model-selection-policy-stub.sh
           chmod +x scripts/chat-model-load-request-stub.sh
           chmod +x scripts/chat-session-stub.sh
           chmod +x scripts/chat-session-lifecycle-stub.sh
@@ -355,6 +363,7 @@ jobs:
           chmod +x scripts/tests/status-device-session.sh
           chmod +x scripts/tests/status-readiness.sh
           chmod +x scripts/tests/status-chat-model-status.sh
+          chmod +x scripts/tests/status-chat-model-selection-policy.sh
           chmod +x scripts/tests/status-chat-model-load-request.sh
           chmod +x scripts/tests/status-chat-session.sh
           chmod +x scripts/tests/status-chat-surface-layout.sh
@@ -382,6 +391,7 @@ jobs:
           shellcheck scripts/tests/status-device-session.sh
           shellcheck scripts/tests/status-readiness.sh
           shellcheck scripts/tests/status-chat-model-status.sh
+          shellcheck scripts/tests/status-chat-model-selection-policy.sh
           shellcheck scripts/tests/status-chat-model-load-request.sh
           shellcheck scripts/tests/status-chat-session.sh
           shellcheck scripts/tests/status-chat-surface-layout.sh
@@ -409,6 +419,8 @@ jobs:
         run: bash scripts/tests/status-readiness.sh scripts/status-stub.sh
       - name: run status-chat-model-status tests
         run: bash scripts/tests/status-chat-model-status.sh scripts/status-stub.sh
+      - name: run status-chat-model-selection-policy tests
+        run: bash scripts/tests/status-chat-model-selection-policy.sh scripts/status-stub.sh
       - name: run status-chat-model-load-request tests
         run: bash scripts/tests/status-chat-model-load-request.sh scripts/status-stub.sh
       - name: run status-chat-session tests

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ and verify host-side prerequisites before the real engine lands.
 | [`scripts/check.sh`](./scripts/check.sh) | Probe host info, tooling availability, edge-device hints. Always exits 0. |
 | [`scripts/check-device-stub.sh`](./scripts/check-device-stub.sh) | Narrowly scoped device-tree / FPGA-node probe (KV260 / Kria detection only). Always exits 0. |
 | [`scripts/install-stub.sh`](./scripts/install-stub.sh) | Preview of the planned install flow; reports which host runtime pieces are present, lists device-side pieces as future deliverables. Always exits 0. |
-| [`scripts/status-stub.sh`](./scripts/status-stub.sh) | Launcher state summary. Default mode: local scaffold output, always exits 0. With `--include-chat-action-bar`, adds read-only disabled chat action-bar data. With `--include-chat-attachment-policy`, adds read-only disabled chat attachment-policy data. With `--include-chat-shortcut-map`, adds read-only disabled chat shortcut-map data. With `--include-chat-message-list`, adds read-only empty chat message-list data. With `--include-chat-response-stream`, adds read-only blocked chat response stream data. With `--include-chat-error-taxonomy`, adds read-only chat error taxonomy data. With `--include-chat-audit-event`, adds read-only blocked chat audit-event metadata. With `--include-chat-surface-layout`, adds read-only chat surface layout data. With `--include-chat-local-only-policy`, adds read-only local-only/cloud-block policy data. With `--include-chat-preferences`, adds read-only chat preferences/settings data. With `--include-chat-session-index`, adds read-only empty chat session index data. With `--include-chat-session-store-policy`, adds read-only disabled chat session-store policy data. With `--include-chat-session-title-policy`, adds read-only placeholder session-title policy data. With `--include-chat-transcript-policy`, adds read-only chat transcript retention/export policy data. With `--include-chat-send-result`, adds read-only blocked chat send-result data. With `--include-chat-composer`, adds read-only chat composer/input-control data. With `--include-chat-model-status`, adds read-only blocked chat model-status display data. With `--include-chat-model-load-request`, adds read-only disabled chat model-load request data. With `--include-chat-session`, adds read-only blocked chat/session and lifecycle summaries. With `--include-chat-readiness`, adds read-only chat readiness checks and recovery actions. With `--include-device-session`, adds a read-only device/session status panel. With `--include-runtime-readiness`, adds a read-only runtime readiness summary. With `--backend pccx-lab`, calls `pccx-lab status --format json` and forwards the run-status envelope (exits non-zero if binary is missing or output is invalid). |
+| [`scripts/status-stub.sh`](./scripts/status-stub.sh) | Launcher state summary. Default mode: local scaffold output, always exits 0. With `--include-chat-action-bar`, adds read-only disabled chat action-bar data. With `--include-chat-attachment-policy`, adds read-only disabled chat attachment-policy data. With `--include-chat-shortcut-map`, adds read-only disabled chat shortcut-map data. With `--include-chat-message-list`, adds read-only empty chat message-list data. With `--include-chat-response-stream`, adds read-only blocked chat response stream data. With `--include-chat-error-taxonomy`, adds read-only chat error taxonomy data. With `--include-chat-audit-event`, adds read-only blocked chat audit-event metadata. With `--include-chat-surface-layout`, adds read-only chat surface layout data. With `--include-chat-local-only-policy`, adds read-only local-only/cloud-block policy data. With `--include-chat-preferences`, adds read-only chat preferences/settings data. With `--include-chat-session-index`, adds read-only empty chat session index data. With `--include-chat-session-store-policy`, adds read-only disabled chat session-store policy data. With `--include-chat-session-title-policy`, adds read-only placeholder session-title policy data. With `--include-chat-transcript-policy`, adds read-only chat transcript retention/export policy data. With `--include-chat-send-result`, adds read-only blocked chat send-result data. With `--include-chat-composer`, adds read-only chat composer/input-control data. With `--include-chat-model-status`, adds read-only blocked chat model-status display data. With `--include-chat-model-selection-policy`, adds read-only disabled chat model-selection data. With `--include-chat-model-load-request`, adds read-only disabled chat model-load request data. With `--include-chat-session`, adds read-only blocked chat/session and lifecycle summaries. With `--include-chat-readiness`, adds read-only chat readiness checks and recovery actions. With `--include-device-session`, adds a read-only device/session status panel. With `--include-runtime-readiness`, adds a read-only runtime readiness summary. With `--backend pccx-lab`, calls `pccx-lab status --format json` and forwards the run-status envelope (exits non-zero if binary is missing or output is invalid). |
 | [`scripts/device-session-status-stub.sh`](./scripts/device-session-status-stub.sh) | Data-only device/session status JSON for the Gemma 3N E4B + KV260 target. Reports connection, model load, session, diagnostics, readiness, discovery paths, flow steps, and error taxonomy as placeholder / blocked. |
 | [`scripts/runtime-readiness-stub.sh`](./scripts/runtime-readiness-stub.sh) | Data-only runtime readiness JSON for the Gemma 3N E4B + KV260 target. Reports blocked / not yet evidence-backed. |
 | [`scripts/chat-session-stub.sh`](./scripts/chat-session-stub.sh) | Data-only standalone chat/session JSON for the Gemma 3N E4B + KV260 target. Reports disabled send controls, inactive session state, no prompt/response persistence, and readiness handoff references. |
@@ -99,6 +99,7 @@ and verify host-side prerequisites before the real engine lands.
 | [`scripts/chat-session-store-policy-stub.sh`](./scripts/chat-session-store-policy-stub.sh) | Data-only chat session-store policy JSON for the Gemma 3N E4B + KV260 target. Reports disabled store configuration, path, manifest, read, write, delete, retention, and migration gates without reading config, paths, manifests, session records, transcripts, titles, prompts, responses, summaries, model paths, runtime logs, or artifacts. |
 | [`scripts/chat-session-title-policy-stub.sh`](./scripts/chat-session-title-policy-stub.sh) | Data-only chat session-title policy JSON for the Gemma 3N E4B + KV260 target. Reports static placeholder display names and disabled title read, generation, rename, and persistence controls without reading stores, transcripts, prompts, responses, summaries, titles, or paths. |
 | [`scripts/chat-model-status-stub.sh`](./scripts/chat-model-status-stub.sh) | Data-only chat model-status JSON for the Gemma 3N E4B + KV260 target. Reports descriptor, asset, load, runtime, context, and response display rows as blocked, disabled, or unavailable. |
+| [`scripts/chat-model-selection-policy-stub.sh`](./scripts/chat-model-selection-policy-stub.sh) | Data-only chat model-selection policy JSON for the Gemma 3N E4B + KV260 target. Reports a static placeholder model option and disabled catalog, picker, asset discovery, provider fallback, persistence, and load-request gates without reading config, catalogs, model paths, assets, prompts, responses, transcripts, runtime logs, or artifacts. |
 | [`scripts/chat-model-load-request-stub.sh`](./scripts/chat-model-load-request-stub.sh) | Data-only chat model-load request JSON for the Gemma 3N E4B + KV260 target. Reports disabled model asset path, validation, runtime preflight, load, warmup, unload, and persistence gates without reading config, environment values, model paths, asset paths, weights, tokenizers, checksum manifests, prompts, responses, transcripts, runtime logs, or artifacts. |
 | [`scripts/chat-readiness-stub.sh`](./scripts/chat-readiness-stub.sh) | Data-only chat readiness JSON for the Gemma 3N E4B + KV260 target. Reports readiness checks, error categories, and recovery actions as blocked, disabled, or local data only. |
 | [`scripts/chat-composer-stub.sh`](./scripts/chat-composer-stub.sh) | Data-only chat composer JSON for the Gemma 3N E4B + KV260 target. Reports input buffer, send, attachment, validation, and privacy states without reading, echoing, storing, or persisting prompt text. |
@@ -121,6 +122,7 @@ bash scripts/check-device-stub.sh
 bash scripts/install-stub.sh
 bash scripts/status-stub.sh
 bash scripts/status-stub.sh --include-chat-model-status
+bash scripts/status-stub.sh --include-chat-model-selection-policy
 bash scripts/status-stub.sh --include-chat-model-load-request
 bash scripts/status-stub.sh --include-chat-session
 bash scripts/status-stub.sh --include-chat-surface-layout
@@ -145,6 +147,7 @@ bash scripts/status-stub.sh --include-runtime-readiness
 bash scripts/device-session-status-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/runtime-readiness-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-model-status-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/chat-model-selection-policy-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-model-load-request-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-session-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-session-lifecycle-stub.sh --model gemma3n-e4b --target kv260
@@ -331,6 +334,7 @@ the planned local chat entry point:
 ```bash
 python3 contracts/chat_session_contract.py --model gemma3n-e4b --target kv260
 python3 contracts/chat_model_status_contract.py --model gemma3n-e4b --target kv260
+python3 contracts/chat_model_selection_policy_contract.py --model gemma3n-e4b --target kv260
 python3 contracts/chat_model_load_request_contract.py --model gemma3n-e4b --target kv260
 python3 contracts/chat_readiness_contract.py --model gemma3n-e4b --target kv260
 python3 contracts/chat_audit_event_contract.py --model gemma3n-e4b --target kv260
@@ -342,6 +346,7 @@ python3 contracts/chat_session_store_policy_contract.py --model gemma3n-e4b --ta
 python3 contracts/chat_shortcut_map_contract.py --model gemma3n-e4b --target kv260
 python3 contracts/chat_session_title_policy_contract.py --model gemma3n-e4b --target kv260
 bash scripts/chat-model-status-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/chat-model-selection-policy-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-model-load-request-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-session-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-session-lifecycle-stub.sh --model gemma3n-e4b --target kv260
@@ -356,6 +361,7 @@ bash scripts/chat-attachment-policy-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-shortcut-map-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-surface-preview.sh --model gemma3n-e4b --target kv260
 bash scripts/status-stub.sh --include-chat-model-status
+bash scripts/status-stub.sh --include-chat-model-selection-policy
 bash scripts/status-stub.sh --include-chat-model-load-request
 bash scripts/status-stub.sh --include-chat-session
 bash scripts/status-stub.sh --include-chat-readiness
@@ -369,6 +375,7 @@ bash scripts/status-stub.sh --include-chat-shortcut-map
 bash scripts/status-stub.sh --include-chat-session-title-policy
 python3 scripts/tests/chat_session_contract_test.py
 python3 scripts/tests/chat_model_status_contract_test.py
+python3 scripts/tests/chat_model_selection_policy_contract_test.py
 python3 scripts/tests/chat_model_load_request_contract_test.py
 python3 scripts/tests/chat_session_lifecycle_contract_test.py
 python3 scripts/tests/chat_session_title_policy_contract_test.py
@@ -382,6 +389,7 @@ python3 scripts/tests/chat_session_store_policy_contract_test.py
 python3 scripts/tests/chat_shortcut_map_contract_test.py
 python3 scripts/tests/chat_surface_preview_test.py
 bash scripts/tests/status-chat-model-status.sh
+bash scripts/tests/status-chat-model-selection-policy.sh
 bash scripts/tests/status-chat-model-load-request.sh
 bash scripts/tests/status-chat-session.sh
 bash scripts/tests/status-chat-readiness.sh
@@ -466,6 +474,13 @@ store path, manifest, read, write, delete, retention, and migration gates
 without reading configuration, paths, manifests, session records,
 transcripts, titles, prompts, responses, summaries, model paths, runtime
 logs, or artifacts.
+
+The chat model-selection policy fixture defines the disabled model picker
+boundary for the planned chat surface. It records a static placeholder
+model option plus disabled catalog, picker, asset discovery, provider
+fallback, selection persistence, and load-request gates without reading
+configuration, catalogs, model paths, assets, prompts, responses,
+transcripts, runtime logs, or artifacts.
 
 The chat model-load request fixture defines the disabled local model-load
 boundary for the planned chat surface. It records descriptor selection,

--- a/contracts/chat_model_selection_policy_contract.py
+++ b/contracts/chat_model_selection_policy_contract.py
@@ -1,0 +1,431 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Data-only chat model-selection policy contract for the planned launcher UI.
+
+The contract describes the disabled model picker and catalog boundary for the
+standalone chat surface. It does not read configuration, environment values,
+model catalogs, model paths, model assets, prompts, responses, transcripts,
+runtime logs, private paths, or artifacts; it does not persist a selection,
+load a model, start a runtime, call providers, invoke pccx-lab, or touch
+KV260 hardware.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import sys
+
+
+SCHEMA_VERSION = "pccx.chatModelSelectionPolicy.v0"
+
+CHAT_MODEL_SELECTION_POLICY_FIELDS = (
+    "schemaVersion",
+    "selectionPolicyId",
+    "fixtureVersion",
+    "lastUpdatedSource",
+    "targetDevice",
+    "targetBoard",
+    "targetModel",
+    "selectionState",
+    "catalogState",
+    "pickerState",
+    "selectedModelState",
+    "descriptorState",
+    "assetDiscoveryState",
+    "assetPathState",
+    "providerFallbackState",
+    "loadRequestState",
+    "privacyState",
+    "chatModelStatusRef",
+    "chatModelLoadRequestRef",
+    "chatLocalOnlyPolicyRef",
+    "chatReadinessRef",
+    "selectionPolicy",
+    "modelOptions",
+    "selectionControls",
+    "blockedReasons",
+    "handoffRefs",
+    "safetyFlags",
+    "limitations",
+    "issueRefs",
+)
+
+SELECTION_POLICY_FIELDS = (
+    "state",
+    "mode",
+    "sourcePolicy",
+    "staticOptionCount",
+    "dynamicCatalogConfigured",
+    "localCatalogRead",
+    "assetDiscoveryEnabled",
+    "selectionEnabled",
+    "selectionPersistenceEnabled",
+    "providerFallbackEnabled",
+    "loadRequestEnabled",
+    "sideEffectPolicy",
+    "contentPolicy",
+)
+
+MODEL_OPTION_FIELDS = (
+    "optionId",
+    "label",
+    "state",
+    "selected",
+    "enabled",
+    "modelFamily",
+    "targetDevice",
+    "descriptorRef",
+    "assetPolicy",
+    "runtimePolicy",
+    "contentPolicy",
+)
+
+SELECTION_CONTROL_FIELDS = (
+    "controlId",
+    "label",
+    "state",
+    "enabled",
+    "userAction",
+    "launcherAction",
+    "sideEffectPolicy",
+    "blockedReasonRef",
+)
+
+BLOCKED_REASON_FIELDS = (
+    "reasonId",
+    "state",
+    "summary",
+    "requiredBefore",
+)
+
+HANDOFF_REF_FIELDS = (
+    "refId",
+    "schemaVersion",
+    "fixturePath",
+    "state",
+    "summary",
+)
+
+CHAT_MODEL_SELECTION_POLICY_STATE_VALUES = (
+    "available_as_data",
+    "blocked",
+    "disabled",
+    "external_not_configured",
+    "inactive",
+    "not_configured",
+    "not_loaded",
+    "not_started",
+    "not_used",
+    "placeholder",
+    "planned",
+    "requires_evidence",
+    "static_placeholder",
+    "summary_only",
+    "target_selected",
+    "unavailable",
+)
+
+_CHAT_MODEL_SELECTION_POLICY = {
+    "schemaVersion": SCHEMA_VERSION,
+    "selectionPolicyId": "chat_model_selection_policy_gemma3n_e4b_kv260_placeholder",
+    "fixtureVersion": "chat-model-selection-policy.gemma3n-e4b-kv260.2026-05-05",
+    "lastUpdatedSource": "pccx_launcher_issue_9_chat_model_selection_policy_boundary_2026-05-05",
+    "targetDevice": "kv260",
+    "targetBoard": "xilinx_kria_kv260",
+    "targetModel": "gemma3n-e4b",
+    "selectionState": "blocked",
+    "catalogState": "static_placeholder",
+    "pickerState": "disabled",
+    "selectedModelState": "target_selected",
+    "descriptorState": "available_as_data",
+    "assetDiscoveryState": "blocked",
+    "assetPathState": "not_configured",
+    "providerFallbackState": "disabled",
+    "loadRequestState": "blocked",
+    "privacyState": "summary_only",
+    "chatModelStatusRef": "chat_model_status_gemma3n_e4b_kv260_placeholder",
+    "chatModelLoadRequestRef": "chat_model_load_request_gemma3n_e4b_kv260_placeholder",
+    "chatLocalOnlyPolicyRef": "chat_local_only_policy_gemma3n_e4b_kv260_placeholder",
+    "chatReadinessRef": "chat_readiness_gemma3n_e4b_kv260_placeholder",
+    "selectionPolicy": {
+        "state": "blocked",
+        "mode": "disabled_until_reviewed_model_catalog_and_selection_boundary_exists",
+        "sourcePolicy": "checked fixture only; no config, environment, model catalog, model path, asset path, weight file, tokenizer file, prompt, response, transcript, artifact, or runtime log is read",
+        "staticOptionCount": 1,
+        "dynamicCatalogConfigured": False,
+        "localCatalogRead": False,
+        "assetDiscoveryEnabled": False,
+        "selectionEnabled": False,
+        "selectionPersistenceEnabled": False,
+        "providerFallbackEnabled": False,
+        "loadRequestEnabled": False,
+        "sideEffectPolicy": "local_render_only",
+        "contentPolicy": "model selection metadata only; no model path, asset path, catalog body, file name, checksum value, prompt text, response text, transcript text, runtime log, or private path is included",
+    },
+    "modelOptions": [
+        {
+            "optionId": "gemma3n_e4b_kv260_placeholder",
+            "label": "Gemma 3N E4B on KV260 target",
+            "state": "target_selected",
+            "selected": True,
+            "enabled": False,
+            "modelFamily": "gemma3n",
+            "targetDevice": "kv260",
+            "descriptorRef": "model_runtime_descriptor_gemma3n_e4b_kv260_placeholder",
+            "assetPolicy": "placeholder_descriptor_only_no_asset_path",
+            "runtimePolicy": "not_loaded_no_runtime_started",
+            "contentPolicy": "target label, family, and descriptor reference only",
+        }
+    ],
+    "selectionControls": [
+        {
+            "controlId": "review_static_target",
+            "label": "review static target",
+            "state": "available_as_data",
+            "enabled": False,
+            "userAction": "Review the checked target model label in the future chat UI.",
+            "launcherAction": "Render static descriptor metadata from checked fixtures only.",
+            "sideEffectPolicy": "local_render_only",
+            "blockedReasonRef": "selection_executor_absent",
+        },
+        {
+            "controlId": "open_model_catalog",
+            "label": "open model catalog",
+            "state": "blocked",
+            "enabled": False,
+            "userAction": "Open a local catalog only after catalog source and redaction rules are reviewed.",
+            "launcherAction": "Keep catalog discovery disabled and do not read files, paths, config, or manifests.",
+            "sideEffectPolicy": "no_catalog_or_config_read",
+            "blockedReasonRef": "dynamic_catalog_boundary_absent",
+        },
+        {
+            "controlId": "select_model_option",
+            "label": "select model option",
+            "state": "disabled",
+            "enabled": False,
+            "userAction": "Select a model only after the reviewed picker boundary exists.",
+            "launcherAction": "Keep selection disabled and do not persist choices.",
+            "sideEffectPolicy": "no_selection_persistence",
+            "blockedReasonRef": "selection_executor_absent",
+        },
+        {
+            "controlId": "discover_local_assets",
+            "label": "discover local assets",
+            "state": "blocked",
+            "enabled": False,
+            "userAction": "Discover assets only after a reviewed local asset boundary exists.",
+            "launcherAction": "Do not scan directories, read model paths, or inspect model files.",
+            "sideEffectPolicy": "no_model_asset_read",
+            "blockedReasonRef": "model_asset_discovery_blocked",
+        },
+        {
+            "controlId": "configure_provider_fallback",
+            "label": "configure provider fallback",
+            "state": "disabled",
+            "enabled": False,
+            "userAction": "Provider fallback is out of scope for core local chat behavior.",
+            "launcherAction": "Keep provider and cloud fallback disabled.",
+            "sideEffectPolicy": "no_provider_or_network_call",
+            "blockedReasonRef": "provider_fallback_disabled",
+        },
+        {
+            "controlId": "handoff_to_load_request",
+            "label": "handoff to load request",
+            "state": "blocked",
+            "enabled": False,
+            "userAction": "Create a load request only after model assets and runtime evidence are reviewed.",
+            "launcherAction": "Render blocked handoff metadata only.",
+            "sideEffectPolicy": "no_model_load",
+            "blockedReasonRef": "load_request_blocked",
+        },
+    ],
+    "blockedReasons": [
+        {
+            "reasonId": "dynamic_catalog_boundary_absent",
+            "state": "not_configured",
+            "summary": "No reviewed local model catalog source or redaction boundary exists.",
+            "requiredBefore": "dynamic_catalog_enabled",
+        },
+        {
+            "reasonId": "selection_executor_absent",
+            "state": "disabled",
+            "summary": "No reviewed picker executor or selection persistence boundary exists.",
+            "requiredBefore": "model_picker_enabled",
+        },
+        {
+            "reasonId": "model_asset_discovery_blocked",
+            "state": "blocked",
+            "summary": "Model asset discovery is blocked until asset path and manifest handling are reviewed.",
+            "requiredBefore": "asset_discovery_enabled",
+        },
+        {
+            "reasonId": "provider_fallback_disabled",
+            "state": "disabled",
+            "summary": "Provider and cloud fallback are disabled by the local-only policy.",
+            "requiredBefore": "fallback_policy_reviewed",
+        },
+        {
+            "reasonId": "load_request_blocked",
+            "state": "blocked",
+            "summary": "The downstream model-load request boundary remains blocked and data-only.",
+            "requiredBefore": "load_request_enabled",
+        },
+        {
+            "reasonId": "runtime_evidence_absent",
+            "state": "requires_evidence",
+            "summary": "Runtime readiness evidence is absent.",
+            "requiredBefore": "runtime_dependent_selection_enabled",
+        },
+        {
+            "reasonId": "hardware_evidence_absent",
+            "state": "requires_evidence",
+            "summary": "No KV260 runtime or model execution evidence is available in this repository.",
+            "requiredBefore": "hardware_target_selection_enabled",
+        },
+    ],
+    "handoffRefs": [
+        {
+            "refId": "chat_model_status",
+            "schemaVersion": "pccx.chatModelStatus.v0",
+            "fixturePath": "contracts/fixtures/chat-model-status.gemma3n-e4b-kv260-placeholder.json",
+            "state": "blocked",
+            "summary": "Model status display keeps model loading blocked and disabled.",
+        },
+        {
+            "refId": "chat_model_load_request",
+            "schemaVersion": "pccx.chatModelLoadRequest.v0",
+            "fixturePath": "contracts/fixtures/chat-model-load-request.gemma3n-e4b-kv260-placeholder.json",
+            "state": "blocked",
+            "summary": "Model-load request remains disabled and does not read assets or start runtime.",
+        },
+        {
+            "refId": "chat_local_only_policy",
+            "schemaVersion": "pccx.chatLocalOnlyPolicy.v0",
+            "fixturePath": "contracts/fixtures/chat-local-only-policy.gemma3n-e4b-kv260-placeholder.json",
+            "state": "blocked",
+            "summary": "Local-only policy keeps provider, cloud, and fallback paths blocked.",
+        },
+        {
+            "refId": "chat_readiness",
+            "schemaVersion": "pccx.chatReadiness.v0",
+            "fixturePath": "contracts/fixtures/chat-readiness.gemma3n-e4b-kv260-placeholder.json",
+            "state": "blocked",
+            "summary": "Chat readiness keeps send and recovery actions blocked.",
+        },
+    ],
+    "safetyFlags": {
+        "dataOnly": True,
+        "readOnly": True,
+        "deterministic": True,
+        "selectionPolicyDisplayOnly": True,
+        "staticOptionOnly": True,
+        "dynamicCatalogConfigured": False,
+        "modelCatalogRead": False,
+        "dynamicCatalogDiscovery": False,
+        "modelSelectionPersisted": False,
+        "modelSelectionAcceptedFromUser": False,
+        "modelOptionsFromConfig": False,
+        "modelAssetPathsIncluded": False,
+        "modelWeightPathsIncluded": False,
+        "modelAssetPathRead": False,
+        "modelAssetRead": False,
+        "modelWeightRead": False,
+        "tokenizerRead": False,
+        "checksumManifestRead": False,
+        "checksumValuesIncluded": False,
+        "configRead": False,
+        "configWrite": False,
+        "environmentRead": False,
+        "providerConfigRead": False,
+        "providerCalls": False,
+        "cloudCalls": False,
+        "networkCalls": False,
+        "promptContentIncluded": False,
+        "promptCapture": False,
+        "responseContentIncluded": False,
+        "responseGenerated": False,
+        "transcriptContentIncluded": False,
+        "transcriptPersistence": False,
+        "sessionPersistence": False,
+        "runtimePreflightExecuted": False,
+        "runtimeStarted": False,
+        "runtimeExecution": False,
+        "modelLoadAttempted": False,
+        "modelLoaded": False,
+        "modelExecution": False,
+        "kv260Access": False,
+        "hardwareAccess": False,
+        "readsArtifacts": False,
+        "writesArtifacts": False,
+        "privatePathsIncluded": False,
+        "secretsIncluded": False,
+        "tokensIncluded": False,
+        "telemetry": False,
+        "automaticUpload": False,
+        "writeBack": False,
+        "executesPccxLab": False,
+        "executesSystemverilogIde": False,
+        "mcpServerImplemented": False,
+        "lspImplemented": False,
+        "compatibilityClaim": False,
+    },
+    "limitations": [
+        "Data-only chat model-selection policy fixture; the selected target is static placeholder metadata.",
+        "No model catalog, configuration file, environment value, model path, asset path, model weight, tokenizer, checksum manifest, prompt, response, transcript, runtime log, private path, secret, or token is read.",
+        "No user model selection is accepted, persisted, or handed to a runtime.",
+        "No model asset discovery, provider fallback, network call, runtime preflight, model load, model execution, telemetry, upload, or artifact write is performed.",
+        "No KV260 hardware access, pccx-lab invocation, or systemverilog-ide invocation is performed.",
+        "This is not a release, tag, compatibility commitment, marketplace flow, provider integration, storage layer, runtime, model-loader, or hardware implementation.",
+    ],
+    "issueRefs": [
+        "pccxai/pccx-llm-launcher#9",
+    ],
+}
+
+
+def create_gemma3n_e4b_kv260_chat_model_selection_policy() -> dict:
+    """Return the checked Gemma 3N E4B plus KV260 model-selection fixture."""
+    return copy.deepcopy(_CHAT_MODEL_SELECTION_POLICY)
+
+
+def chat_model_selection_policy_json(policy: dict | None = None) -> str:
+    """Render a deterministic JSON representation."""
+    return json.dumps(
+        policy
+        if policy is not None
+        else create_gemma3n_e4b_kv260_chat_model_selection_policy(),
+        indent=2,
+        sort_keys=True,
+    ) + "\n"
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Print data-only chat model-selection policy JSON.",
+    )
+    parser.add_argument(
+        "--model",
+        default="gemma3n-e4b",
+        choices=("gemma3n-e4b",),
+        help="model descriptor target",
+    )
+    parser.add_argument(
+        "--target",
+        default="kv260",
+        choices=("kv260",),
+        help="target board/device",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parse_args(sys.argv[1:] if argv is None else argv)
+    sys.stdout.write(chat_model_selection_policy_json())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contracts/fixtures/chat-model-selection-policy.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-model-selection-policy.gemma3n-e4b-kv260-placeholder.json
@@ -1,0 +1,256 @@
+{
+  "assetDiscoveryState": "blocked",
+  "assetPathState": "not_configured",
+  "blockedReasons": [
+    {
+      "reasonId": "dynamic_catalog_boundary_absent",
+      "requiredBefore": "dynamic_catalog_enabled",
+      "state": "not_configured",
+      "summary": "No reviewed local model catalog source or redaction boundary exists."
+    },
+    {
+      "reasonId": "selection_executor_absent",
+      "requiredBefore": "model_picker_enabled",
+      "state": "disabled",
+      "summary": "No reviewed picker executor or selection persistence boundary exists."
+    },
+    {
+      "reasonId": "model_asset_discovery_blocked",
+      "requiredBefore": "asset_discovery_enabled",
+      "state": "blocked",
+      "summary": "Model asset discovery is blocked until asset path and manifest handling are reviewed."
+    },
+    {
+      "reasonId": "provider_fallback_disabled",
+      "requiredBefore": "fallback_policy_reviewed",
+      "state": "disabled",
+      "summary": "Provider and cloud fallback are disabled by the local-only policy."
+    },
+    {
+      "reasonId": "load_request_blocked",
+      "requiredBefore": "load_request_enabled",
+      "state": "blocked",
+      "summary": "The downstream model-load request boundary remains blocked and data-only."
+    },
+    {
+      "reasonId": "runtime_evidence_absent",
+      "requiredBefore": "runtime_dependent_selection_enabled",
+      "state": "requires_evidence",
+      "summary": "Runtime readiness evidence is absent."
+    },
+    {
+      "reasonId": "hardware_evidence_absent",
+      "requiredBefore": "hardware_target_selection_enabled",
+      "state": "requires_evidence",
+      "summary": "No KV260 runtime or model execution evidence is available in this repository."
+    }
+  ],
+  "catalogState": "static_placeholder",
+  "chatLocalOnlyPolicyRef": "chat_local_only_policy_gemma3n_e4b_kv260_placeholder",
+  "chatModelLoadRequestRef": "chat_model_load_request_gemma3n_e4b_kv260_placeholder",
+  "chatModelStatusRef": "chat_model_status_gemma3n_e4b_kv260_placeholder",
+  "chatReadinessRef": "chat_readiness_gemma3n_e4b_kv260_placeholder",
+  "descriptorState": "available_as_data",
+  "fixtureVersion": "chat-model-selection-policy.gemma3n-e4b-kv260.2026-05-05",
+  "handoffRefs": [
+    {
+      "fixturePath": "contracts/fixtures/chat-model-status.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_model_status",
+      "schemaVersion": "pccx.chatModelStatus.v0",
+      "state": "blocked",
+      "summary": "Model status display keeps model loading blocked and disabled."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-model-load-request.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_model_load_request",
+      "schemaVersion": "pccx.chatModelLoadRequest.v0",
+      "state": "blocked",
+      "summary": "Model-load request remains disabled and does not read assets or start runtime."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-local-only-policy.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_local_only_policy",
+      "schemaVersion": "pccx.chatLocalOnlyPolicy.v0",
+      "state": "blocked",
+      "summary": "Local-only policy keeps provider, cloud, and fallback paths blocked."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-readiness.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_readiness",
+      "schemaVersion": "pccx.chatReadiness.v0",
+      "state": "blocked",
+      "summary": "Chat readiness keeps send and recovery actions blocked."
+    }
+  ],
+  "issueRefs": [
+    "pccxai/pccx-llm-launcher#9"
+  ],
+  "lastUpdatedSource": "pccx_launcher_issue_9_chat_model_selection_policy_boundary_2026-05-05",
+  "limitations": [
+    "Data-only chat model-selection policy fixture; the selected target is static placeholder metadata.",
+    "No model catalog, configuration file, environment value, model path, asset path, model weight, tokenizer, checksum manifest, prompt, response, transcript, runtime log, private path, secret, or token is read.",
+    "No user model selection is accepted, persisted, or handed to a runtime.",
+    "No model asset discovery, provider fallback, network call, runtime preflight, model load, model execution, telemetry, upload, or artifact write is performed.",
+    "No KV260 hardware access, pccx-lab invocation, or systemverilog-ide invocation is performed.",
+    "This is not a release, tag, compatibility commitment, marketplace flow, provider integration, storage layer, runtime, model-loader, or hardware implementation."
+  ],
+  "loadRequestState": "blocked",
+  "modelOptions": [
+    {
+      "assetPolicy": "placeholder_descriptor_only_no_asset_path",
+      "contentPolicy": "target label, family, and descriptor reference only",
+      "descriptorRef": "model_runtime_descriptor_gemma3n_e4b_kv260_placeholder",
+      "enabled": false,
+      "label": "Gemma 3N E4B on KV260 target",
+      "modelFamily": "gemma3n",
+      "optionId": "gemma3n_e4b_kv260_placeholder",
+      "runtimePolicy": "not_loaded_no_runtime_started",
+      "selected": true,
+      "state": "target_selected",
+      "targetDevice": "kv260"
+    }
+  ],
+  "pickerState": "disabled",
+  "privacyState": "summary_only",
+  "providerFallbackState": "disabled",
+  "safetyFlags": {
+    "automaticUpload": false,
+    "checksumManifestRead": false,
+    "checksumValuesIncluded": false,
+    "cloudCalls": false,
+    "compatibilityClaim": false,
+    "configRead": false,
+    "configWrite": false,
+    "dataOnly": true,
+    "deterministic": true,
+    "dynamicCatalogConfigured": false,
+    "dynamicCatalogDiscovery": false,
+    "environmentRead": false,
+    "executesPccxLab": false,
+    "executesSystemverilogIde": false,
+    "hardwareAccess": false,
+    "kv260Access": false,
+    "lspImplemented": false,
+    "mcpServerImplemented": false,
+    "modelAssetPathRead": false,
+    "modelAssetPathsIncluded": false,
+    "modelAssetRead": false,
+    "modelCatalogRead": false,
+    "modelExecution": false,
+    "modelLoadAttempted": false,
+    "modelLoaded": false,
+    "modelOptionsFromConfig": false,
+    "modelSelectionAcceptedFromUser": false,
+    "modelSelectionPersisted": false,
+    "modelWeightPathsIncluded": false,
+    "modelWeightRead": false,
+    "networkCalls": false,
+    "privatePathsIncluded": false,
+    "promptCapture": false,
+    "promptContentIncluded": false,
+    "providerCalls": false,
+    "providerConfigRead": false,
+    "readOnly": true,
+    "readsArtifacts": false,
+    "responseContentIncluded": false,
+    "responseGenerated": false,
+    "runtimeExecution": false,
+    "runtimePreflightExecuted": false,
+    "runtimeStarted": false,
+    "secretsIncluded": false,
+    "selectionPolicyDisplayOnly": true,
+    "sessionPersistence": false,
+    "staticOptionOnly": true,
+    "telemetry": false,
+    "tokenizerRead": false,
+    "tokensIncluded": false,
+    "transcriptContentIncluded": false,
+    "transcriptPersistence": false,
+    "writeBack": false,
+    "writesArtifacts": false
+  },
+  "schemaVersion": "pccx.chatModelSelectionPolicy.v0",
+  "selectedModelState": "target_selected",
+  "selectionControls": [
+    {
+      "blockedReasonRef": "selection_executor_absent",
+      "controlId": "review_static_target",
+      "enabled": false,
+      "label": "review static target",
+      "launcherAction": "Render static descriptor metadata from checked fixtures only.",
+      "sideEffectPolicy": "local_render_only",
+      "state": "available_as_data",
+      "userAction": "Review the checked target model label in the future chat UI."
+    },
+    {
+      "blockedReasonRef": "dynamic_catalog_boundary_absent",
+      "controlId": "open_model_catalog",
+      "enabled": false,
+      "label": "open model catalog",
+      "launcherAction": "Keep catalog discovery disabled and do not read files, paths, config, or manifests.",
+      "sideEffectPolicy": "no_catalog_or_config_read",
+      "state": "blocked",
+      "userAction": "Open a local catalog only after catalog source and redaction rules are reviewed."
+    },
+    {
+      "blockedReasonRef": "selection_executor_absent",
+      "controlId": "select_model_option",
+      "enabled": false,
+      "label": "select model option",
+      "launcherAction": "Keep selection disabled and do not persist choices.",
+      "sideEffectPolicy": "no_selection_persistence",
+      "state": "disabled",
+      "userAction": "Select a model only after the reviewed picker boundary exists."
+    },
+    {
+      "blockedReasonRef": "model_asset_discovery_blocked",
+      "controlId": "discover_local_assets",
+      "enabled": false,
+      "label": "discover local assets",
+      "launcherAction": "Do not scan directories, read model paths, or inspect model files.",
+      "sideEffectPolicy": "no_model_asset_read",
+      "state": "blocked",
+      "userAction": "Discover assets only after a reviewed local asset boundary exists."
+    },
+    {
+      "blockedReasonRef": "provider_fallback_disabled",
+      "controlId": "configure_provider_fallback",
+      "enabled": false,
+      "label": "configure provider fallback",
+      "launcherAction": "Keep provider and cloud fallback disabled.",
+      "sideEffectPolicy": "no_provider_or_network_call",
+      "state": "disabled",
+      "userAction": "Provider fallback is out of scope for core local chat behavior."
+    },
+    {
+      "blockedReasonRef": "load_request_blocked",
+      "controlId": "handoff_to_load_request",
+      "enabled": false,
+      "label": "handoff to load request",
+      "launcherAction": "Render blocked handoff metadata only.",
+      "sideEffectPolicy": "no_model_load",
+      "state": "blocked",
+      "userAction": "Create a load request only after model assets and runtime evidence are reviewed."
+    }
+  ],
+  "selectionPolicy": {
+    "assetDiscoveryEnabled": false,
+    "contentPolicy": "model selection metadata only; no model path, asset path, catalog body, file name, checksum value, prompt text, response text, transcript text, runtime log, or private path is included",
+    "dynamicCatalogConfigured": false,
+    "loadRequestEnabled": false,
+    "localCatalogRead": false,
+    "mode": "disabled_until_reviewed_model_catalog_and_selection_boundary_exists",
+    "providerFallbackEnabled": false,
+    "selectionEnabled": false,
+    "selectionPersistenceEnabled": false,
+    "sideEffectPolicy": "local_render_only",
+    "sourcePolicy": "checked fixture only; no config, environment, model catalog, model path, asset path, weight file, tokenizer file, prompt, response, transcript, artifact, or runtime log is read",
+    "state": "blocked",
+    "staticOptionCount": 1
+  },
+  "selectionPolicyId": "chat_model_selection_policy_gemma3n_e4b_kv260_placeholder",
+  "selectionState": "blocked",
+  "targetBoard": "xilinx_kria_kv260",
+  "targetDevice": "kv260",
+  "targetModel": "gemma3n-e4b"
+}

--- a/docs/STANDALONE_CHAT_SESSION_CONTRACT.md
+++ b/docs/STANDALONE_CHAT_SESSION_CONTRACT.md
@@ -10,6 +10,7 @@ The implementation lives in:
 
 - `contracts/chat_session_contract.py`
 - `contracts/chat_model_status_contract.py`
+- `contracts/chat_model_selection_policy_contract.py`
 - `contracts/chat_model_load_request_contract.py`
 - `contracts/chat_session_lifecycle_contract.py`
 - `contracts/chat_surface_layout_contract.py`
@@ -30,6 +31,7 @@ The implementation lives in:
 - `contracts/chat_shortcut_map_contract.py`
 - `contracts/fixtures/chat-session.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-model-status.gemma3n-e4b-kv260-placeholder.json`
+- `contracts/fixtures/chat-model-selection-policy.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-model-load-request.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-session-lifecycle.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-surface-layout.gemma3n-e4b-kv260-placeholder.json`
@@ -50,6 +52,7 @@ The implementation lives in:
 - `contracts/fixtures/chat-shortcut-map.gemma3n-e4b-kv260-placeholder.json`
 - `scripts/chat-session-stub.sh`
 - `scripts/chat-model-status-stub.sh`
+- `scripts/chat-model-selection-policy-stub.sh`
 - `scripts/chat-model-load-request-stub.sh`
 - `scripts/chat-session-lifecycle-stub.sh`
 - `scripts/chat-surface-layout-stub.sh`
@@ -71,6 +74,7 @@ The implementation lives in:
 - `scripts/chat-surface-preview.sh`
 - `scripts/tests/chat_session_contract_test.py`
 - `scripts/tests/chat_model_status_contract_test.py`
+- `scripts/tests/chat_model_selection_policy_contract_test.py`
 - `scripts/tests/chat_model_load_request_contract_test.py`
 - `scripts/tests/chat_session_lifecycle_contract_test.py`
 - `scripts/tests/chat_surface_layout_contract_test.py`
@@ -91,6 +95,7 @@ The implementation lives in:
 - `scripts/tests/chat_shortcut_map_contract_test.py`
 - `scripts/tests/chat_surface_preview_test.py`
 - `scripts/tests/status-chat-model-status.sh`
+- `scripts/tests/status-chat-model-selection-policy.sh`
 - `scripts/tests/status-chat-model-load-request.sh`
 - `scripts/tests/status-chat-surface-layout.sh`
 - `scripts/tests/status-chat-local-only-policy.sh`
@@ -116,6 +121,9 @@ The chat/session contract records:
 
 - target model and KV260-class target identity
 - chat surface, model-load, input, send, and session states
+- a disabled model-selection policy boundary for static target option,
+  model catalog, picker, asset discovery, provider fallback, persistence,
+  and load-request gates
 - a disabled model-load request boundary for descriptor selection, asset
   paths, checksums, runtime preflight, load, warmup, and unload gates
 - disabled session controls for new session, model status, send,
@@ -170,6 +178,23 @@ bash scripts/status-stub.sh --include-chat-model-status
 Model loading stays blocked and disabled. The model-status fixture does
 not read model paths, load weights, start runtimes, generate responses,
 touch hardware, call providers, invoke pccx-lab, or write artifacts.
+
+The chat model-selection policy fixture records the disabled local picker
+and model catalog boundary for future chat model selection:
+
+```bash
+bash scripts/chat-model-selection-policy-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/status-stub.sh --include-chat-model-selection-policy
+```
+
+It reports one static placeholder option plus disabled catalog, picker,
+asset discovery, provider fallback, selection persistence, and
+load-request gates. The fixture does not read configuration files,
+environment values, model catalogs, model paths, asset paths, model
+weights, tokenizer files, checksum manifests, private paths, prompts,
+responses, transcripts, runtime logs, or artifacts, and it does not
+accept or persist model selections, call providers, validate assets,
+load models, start runtimes, or write model-selection data.
 
 The chat model-load request fixture records the disabled local load
 boundary for future chat model loading:
@@ -669,6 +694,10 @@ runtime execution, provider state, local stores, and message content:
 The standalone chat surface depends on the existing launcher model
 descriptor, readiness, and device/session status contracts. The
 model-status contract adds reviewable display rows for model-load state.
+The model-selection policy contract adds a disabled picker/catalog shape
+without configuration reads, model catalog reads, model path reads, asset
+path reads, provider fallback, selection persistence, runtime execution,
+model loading, hardware access, or artifact access.
 The lifecycle contract adds a reviewable session-management shape, but
 these contracts do not add runtime execution, model loading, provider
 calls, persistence, target access, artifact reads, or artifact writes.
@@ -756,6 +785,10 @@ This chat/session surface does not add:
   runtime traces, raw logs, or audit export behavior
 - error recovery execution, provider/config reads, model asset reads, or
   taxonomy persistence
+- model-selection execution, model catalog reads, dynamic catalog
+  discovery, model option reads from configuration, user selection
+  acceptance, selection persistence, provider fallback, model path reads,
+  asset path reads, model asset reads, or load-request handoff execution
 - model-load request execution, configuration reads, environment reads,
   model path reads, asset path reads, weight reads, tokenizer reads,
   checksum manifest reads, runtime preflight, model loading, model

--- a/scripts/chat-model-selection-policy-stub.sh
+++ b/scripts/chat-model-selection-policy-stub.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+# Print the data-only chat model-selection policy contract.
+
+set -eu
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+
+python3 "$ROOT_DIR/contracts/chat_model_selection_policy_contract.py" "$@"

--- a/scripts/status-stub.sh
+++ b/scripts/status-stub.sh
@@ -34,6 +34,9 @@
 # Chat model status display plan (explicit opt-in, read-only local data):
 #   --include-chat-model-status
 #
+# Chat model-selection policy boundary (explicit opt-in, read-only local data):
+#   --include-chat-model-selection-policy
+#
 # Chat model-load request boundary (explicit opt-in, read-only local data):
 #   --include-chat-model-load-request
 #
@@ -95,6 +98,7 @@ INCLUDE_CHAT_SESSION_INDEX="0"
 INCLUDE_CHAT_SESSION_STORE_POLICY="0"
 INCLUDE_CHAT_SESSION_TITLE_POLICY="0"
 INCLUDE_CHAT_MODEL_STATUS="0"
+INCLUDE_CHAT_MODEL_SELECTION_POLICY="0"
 INCLUDE_CHAT_MODEL_LOAD_REQUEST="0"
 INCLUDE_CHAT_READINESS="0"
 INCLUDE_CHAT_COMPOSER="0"
@@ -2075,6 +2079,140 @@ print(
     printf '%s\n' "$CHAT_MODEL_STATUS_SUMMARY"
 }
 
+print_chat_model_selection_policy_summary() {
+    SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+    ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+    CHAT_MODEL_SELECTION_POLICY_STUB="$ROOT_DIR/scripts/chat-model-selection-policy-stub.sh"
+
+    if [ ! -f "$CHAT_MODEL_SELECTION_POLICY_STUB" ]; then
+        ERROR "chat model-selection policy stub not found: $CHAT_MODEL_SELECTION_POLICY_STUB"
+        return 1
+    fi
+
+    if ! CHAT_MODEL_SELECTION_POLICY_JSON="$(bash "$CHAT_MODEL_SELECTION_POLICY_STUB" --model gemma3n-e4b --target kv260 2>&1)"; then
+        ERROR "chat model-selection policy stub failed"
+        printf '%s\n' "$CHAT_MODEL_SELECTION_POLICY_JSON" >&2
+        return 1
+    fi
+
+    if ! CHAT_MODEL_SELECTION_POLICY_SUMMARY="$(
+        printf '%s\n' "$CHAT_MODEL_SELECTION_POLICY_JSON" | python3 -c '
+import json
+import sys
+
+data = json.load(sys.stdin)
+flags = data["safetyFlags"]
+policy = data["selectionPolicy"]
+
+def b(value):
+    return "true" if value else "false"
+
+options = " ".join(
+    "{}={}:{}:{}".format(
+        option["optionId"],
+        option["state"],
+        b(option["selected"]),
+        b(option["enabled"]),
+    )
+    for option in data["modelOptions"]
+)
+controls = " ".join(
+    "{}={}:{}".format(control["controlId"], control["state"], b(control["enabled"]))
+    for control in data["selectionControls"]
+)
+blocked = " ".join(
+    "{}={}".format(reason["reasonId"], reason["state"])
+    for reason in data["blockedReasons"]
+)
+
+print("[INFO]  source     : scripts/chat-model-selection-policy-stub.sh --model gemma3n-e4b --target kv260")
+print("[INFO]  boundary   : read-only data; no catalog/config/model asset path/read/load/runtime/provider/hardware/lab/IDE execution")
+print("[INFO]  target     : {}".format(data["targetDevice"]))
+print("[INFO]  model      : {}".format(data["targetModel"]))
+print("[INFO]  selection  : {}".format(data["selectionState"]))
+print("[INFO]  catalog    : {}".format(data["catalogState"]))
+print("[INFO]  picker     : {}".format(data["pickerState"]))
+print("[INFO]  selected   : {}".format(data["selectedModelState"]))
+print("[INFO]  descriptor : {}".format(data["descriptorState"]))
+print("[INFO]  asset disc : {}".format(data["assetDiscoveryState"]))
+print("[INFO]  asset paths: {}".format(data["assetPathState"]))
+print("[INFO]  fallback   : {}".format(data["providerFallbackState"]))
+print("[INFO]  load req   : {}".format(data["loadRequestState"]))
+print("[INFO]  privacy    : {}".format(data["privacyState"]))
+print(
+    "[INFO]  model-selection : {} mode={} staticOptionCount={} "
+    "dynamicCatalogConfigured={} localCatalogRead={} "
+    "assetDiscoveryEnabled={} selectionEnabled={} "
+    "selectionPersistenceEnabled={} providerFallbackEnabled={} "
+    "loadRequestEnabled={}".format(
+        policy["state"],
+        policy["mode"],
+        policy["staticOptionCount"],
+        b(policy["dynamicCatalogConfigured"]),
+        b(policy["localCatalogRead"]),
+        b(policy["assetDiscoveryEnabled"]),
+        b(policy["selectionEnabled"]),
+        b(policy["selectionPersistenceEnabled"]),
+        b(policy["providerFallbackEnabled"]),
+        b(policy["loadRequestEnabled"]),
+    )
+)
+print("[INFO]  options    : {}".format(options))
+print("[INFO]  controls   : {}".format(controls))
+print("[INFO]  blocked    : {}".format(blocked))
+print(
+    "[INFO]  flags      : readOnly={} dataOnly={} deterministic={} "
+    "selectionPolicyDisplayOnly={} staticOptionOnly={} "
+    "dynamicCatalogConfigured={} modelCatalogRead={} "
+    "dynamicCatalogDiscovery={} modelSelectionPersisted={} "
+    "modelSelectionAcceptedFromUser={} modelOptionsFromConfig={} "
+    "modelAssetPathsIncluded={} modelAssetPathRead={} modelAssetRead={} "
+    "configRead={} environmentRead={} providerConfigRead={} "
+    "providerCalls={} cloudCalls={} networkCalls={} "
+    "modelLoadAttempted={} modelLoaded={} modelExecution={} "
+    "runtimeExecution={} kv260Access={} hardwareAccess={} "
+    "writesArtifacts={} readsArtifacts={} executesPccxLab={}".format(
+        b(flags["readOnly"]),
+        b(flags["dataOnly"]),
+        b(flags["deterministic"]),
+        b(flags["selectionPolicyDisplayOnly"]),
+        b(flags["staticOptionOnly"]),
+        b(flags["dynamicCatalogConfigured"]),
+        b(flags["modelCatalogRead"]),
+        b(flags["dynamicCatalogDiscovery"]),
+        b(flags["modelSelectionPersisted"]),
+        b(flags["modelSelectionAcceptedFromUser"]),
+        b(flags["modelOptionsFromConfig"]),
+        b(flags["modelAssetPathsIncluded"]),
+        b(flags["modelAssetPathRead"]),
+        b(flags["modelAssetRead"]),
+        b(flags["configRead"]),
+        b(flags["environmentRead"]),
+        b(flags["providerConfigRead"]),
+        b(flags["providerCalls"]),
+        b(flags["cloudCalls"]),
+        b(flags["networkCalls"]),
+        b(flags["modelLoadAttempted"]),
+        b(flags["modelLoaded"]),
+        b(flags["modelExecution"]),
+        b(flags["runtimeExecution"]),
+        b(flags["kv260Access"]),
+        b(flags["hardwareAccess"]),
+        b(flags["writesArtifacts"]),
+        b(flags["readsArtifacts"]),
+        b(flags["executesPccxLab"]),
+    )
+)
+'
+    )"; then
+        ERROR "chat model-selection policy JSON could not be summarized"
+        return 1
+    fi
+
+    HEAD "chat model selection policy"
+    printf '%s\n' "$CHAT_MODEL_SELECTION_POLICY_SUMMARY"
+}
+
 print_chat_model_load_request_summary() {
     SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
     ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
@@ -2517,6 +2655,10 @@ while [ $# -gt 0 ]; do
             INCLUDE_CHAT_MODEL_STATUS="1"
             shift
             ;;
+        --include-chat-model-selection-policy)
+            INCLUDE_CHAT_MODEL_SELECTION_POLICY="1"
+            shift
+            ;;
         --include-chat-model-load-request)
             INCLUDE_CHAT_MODEL_LOAD_REQUEST="1"
             shift
@@ -2580,8 +2722,8 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-if [ -n "$BACKEND" ] && { [ "$INCLUDE_RUNTIME_READINESS" = "1" ] || [ "$INCLUDE_DEVICE_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SURFACE_LAYOUT" = "1" ] || [ "$INCLUDE_CHAT_LOCAL_ONLY_POLICY" = "1" ] || [ "$INCLUDE_CHAT_PREFERENCES" = "1" ] || [ "$INCLUDE_CHAT_SESSION_INDEX" = "1" ] || [ "$INCLUDE_CHAT_SESSION_STORE_POLICY" = "1" ] || [ "$INCLUDE_CHAT_SESSION_TITLE_POLICY" = "1" ] || [ "$INCLUDE_CHAT_MODEL_STATUS" = "1" ] || [ "$INCLUDE_CHAT_MODEL_LOAD_REQUEST" = "1" ] || [ "$INCLUDE_CHAT_READINESS" = "1" ] || [ "$INCLUDE_CHAT_COMPOSER" = "1" ] || [ "$INCLUDE_CHAT_SEND_RESULT" = "1" ] || [ "$INCLUDE_CHAT_TRANSCRIPT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_AUDIT_EVENT" = "1" ] || [ "$INCLUDE_CHAT_ERROR_TAXONOMY" = "1" ] || [ "$INCLUDE_CHAT_RESPONSE_STREAM" = "1" ] || [ "$INCLUDE_CHAT_MESSAGE_LIST" = "1" ] || [ "$INCLUDE_CHAT_ACTION_BAR" = "1" ] || [ "$INCLUDE_CHAT_ATTACHMENT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_SHORTCUT_MAP" = "1" ]; }; then
-    ERROR "--include-runtime-readiness, --include-device-session, --include-chat-session, --include-chat-surface-layout, --include-chat-local-only-policy, --include-chat-preferences, --include-chat-session-index, --include-chat-session-store-policy, --include-chat-session-title-policy, --include-chat-model-status, --include-chat-model-load-request, --include-chat-readiness, --include-chat-composer, --include-chat-send-result, --include-chat-transcript-policy, --include-chat-audit-event, --include-chat-error-taxonomy, --include-chat-response-stream, --include-chat-message-list, --include-chat-action-bar, --include-chat-attachment-policy, and --include-chat-shortcut-map are only supported in local scaffold mode"
+if [ -n "$BACKEND" ] && { [ "$INCLUDE_RUNTIME_READINESS" = "1" ] || [ "$INCLUDE_DEVICE_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SURFACE_LAYOUT" = "1" ] || [ "$INCLUDE_CHAT_LOCAL_ONLY_POLICY" = "1" ] || [ "$INCLUDE_CHAT_PREFERENCES" = "1" ] || [ "$INCLUDE_CHAT_SESSION_INDEX" = "1" ] || [ "$INCLUDE_CHAT_SESSION_STORE_POLICY" = "1" ] || [ "$INCLUDE_CHAT_SESSION_TITLE_POLICY" = "1" ] || [ "$INCLUDE_CHAT_MODEL_STATUS" = "1" ] || [ "$INCLUDE_CHAT_MODEL_SELECTION_POLICY" = "1" ] || [ "$INCLUDE_CHAT_MODEL_LOAD_REQUEST" = "1" ] || [ "$INCLUDE_CHAT_READINESS" = "1" ] || [ "$INCLUDE_CHAT_COMPOSER" = "1" ] || [ "$INCLUDE_CHAT_SEND_RESULT" = "1" ] || [ "$INCLUDE_CHAT_TRANSCRIPT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_AUDIT_EVENT" = "1" ] || [ "$INCLUDE_CHAT_ERROR_TAXONOMY" = "1" ] || [ "$INCLUDE_CHAT_RESPONSE_STREAM" = "1" ] || [ "$INCLUDE_CHAT_MESSAGE_LIST" = "1" ] || [ "$INCLUDE_CHAT_ACTION_BAR" = "1" ] || [ "$INCLUDE_CHAT_ATTACHMENT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_SHORTCUT_MAP" = "1" ]; }; then
+    ERROR "--include-runtime-readiness, --include-device-session, --include-chat-session, --include-chat-surface-layout, --include-chat-local-only-policy, --include-chat-preferences, --include-chat-session-index, --include-chat-session-store-policy, --include-chat-session-title-policy, --include-chat-model-status, --include-chat-model-selection-policy, --include-chat-model-load-request, --include-chat-readiness, --include-chat-composer, --include-chat-send-result, --include-chat-transcript-policy, --include-chat-audit-event, --include-chat-error-taxonomy, --include-chat-response-stream, --include-chat-message-list, --include-chat-action-bar, --include-chat-attachment-policy, and --include-chat-shortcut-map are only supported in local scaffold mode"
     exit 1
 fi
 
@@ -2604,6 +2746,7 @@ if [ -z "$BACKEND" ]; then
     NOTE "chat store    : opt-in via --include-chat-session-store-policy (read-only session-store policy data)"
     NOTE "chat titles   : opt-in via --include-chat-session-title-policy (read-only title policy data)"
     NOTE "chat model    : opt-in via --include-chat-model-status (read-only model status display data)"
+    NOTE "chat select   : opt-in via --include-chat-model-selection-policy (read-only model-selection data)"
     NOTE "chat load     : opt-in via --include-chat-model-load-request (read-only model-load request data)"
     NOTE "chat readiness: opt-in via --include-chat-readiness (read-only readiness and recovery data)"
     NOTE "chat composer : opt-in via --include-chat-composer (read-only input control data)"
@@ -2716,6 +2859,12 @@ if [ -z "$BACKEND" ]; then
 
     if [ "$INCLUDE_CHAT_MODEL_STATUS" = "1" ]; then
         if ! print_chat_model_status_summary; then
+            exit 1
+        fi
+    fi
+
+    if [ "$INCLUDE_CHAT_MODEL_SELECTION_POLICY" = "1" ]; then
+        if ! print_chat_model_selection_policy_summary; then
             exit 1
         fi
     fi

--- a/scripts/tests/chat_model_selection_policy_contract_test.py
+++ b/scripts/tests/chat_model_selection_policy_contract_test.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Fixture tests for the standalone chat model-selection policy contract."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "contracts" / "chat_model_selection_policy_contract.py"
+FIXTURE_PATH = (
+    ROOT
+    / "contracts"
+    / "fixtures"
+    / "chat-model-selection-policy.gemma3n-e4b-kv260-placeholder.json"
+)
+SCRIPT_PATH = ROOT / "scripts" / "chat-model-selection-policy-stub.sh"
+STATUS_TEST_PATH = ROOT / "scripts" / "tests" / "status-chat-model-selection-policy.sh"
+DOC_PATH = ROOT / "docs" / "STANDALONE_CHAT_SESSION_CONTRACT.md"
+README_PATH = ROOT / "README.md"
+TEST_PATH = Path(__file__).resolve()
+CI_PATH = ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location(
+        "chat_model_selection_policy_contract",
+        MODULE_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def iter_state_values(value):
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            if (
+                key == "state"
+                or key.endswith("State")
+                or key.endswith("Status")
+            ) and isinstance(nested, str):
+                yield nested
+            yield from iter_state_values(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            yield from iter_state_values(nested)
+
+
+def iter_keys(value):
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            yield key
+            yield from iter_keys(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            yield from iter_keys(nested)
+
+
+def assert_no_private_or_generated_data(text: str) -> None:
+    forbidden_patterns = [
+        r"/home/[^\s\"']+",
+        r"/Users/[^\s\"']+",
+        r"[A-Za-z]:\\Users\\",
+        r"\b(?:api[_-]?key|authorization|bearer|client[_-]?secret|password|private[_-]?key|secret|token)\b\s*[:=]",
+        r"\.(?:gguf|safetensors|ckpt|pt|pth|onnx)\b",
+        r"(?:weights|model_weights|model-cache)/(?:[^\"'\s]+)",
+        r"(?:raw[_-]?full[_-]?logs|hardware[_-]?dump|generated[_-]?blob)\s*[:=]",
+    ]
+    for pattern in forbidden_patterns:
+        assert not re.search(pattern, text, re.IGNORECASE), pattern
+
+
+def assert_no_runtime_implementation_terms(source: str) -> None:
+    forbidden = [
+        "subprocess",
+        "os.system",
+        "popen",
+        "socket",
+        "urllib",
+        "import " + "requests",
+        "from " + "requests",
+        "http.client",
+        "openai",
+        "anthropic",
+        "gem" + "ini",
+        "modelcontextprotocol",
+        "websocket",
+        "xmutil",
+        "xrt-smi",
+        "lsusb",
+        "dmesg",
+    ]
+    lowered = source.lower()
+    for term in forbidden:
+        assert term not in lowered, term
+
+
+def assert_no_provider_configs(value) -> None:
+    forbidden_keys = {
+        "apiKey",
+        "accessToken",
+        "refreshToken",
+        "authorization",
+        "bearerToken",
+        "provider",
+        "providers",
+        "providerConfig",
+        "providerConfigs",
+    }
+    for key in iter_keys(value):
+        assert key not in forbidden_keys, key
+
+
+def assert_no_unsupported_claims(text: str) -> None:
+    literal_claims = [
+        "production" + "-ready",
+        "marketplace" + "-ready",
+        "stable " + "API",
+        "stable " + "ABI",
+        "KV260 inference " + "works",
+        "Gemma 3N E4B " + "runs on KV260",
+        "20 tok/s " + "achieved",
+        "timing " + "closed",
+        "bitstream " + "ready",
+        "launcher executes " + "pccx-lab",
+        "IDE controls " + "launcher",
+        "AI provider integration " + "is live",
+    ]
+    lowered = text.lower()
+    for claim in literal_claims:
+        assert claim.lower() not in lowered, claim
+
+
+def test_chat_model_selection_policy_matches_fixture_and_is_deterministic() -> None:
+    module = load_module()
+    generated = module.create_gemma3n_e4b_kv260_chat_model_selection_policy()
+    fixture = json.loads(read_text(FIXTURE_PATH))
+
+    assert generated == fixture
+    assert module.chat_model_selection_policy_json(generated) == (
+        module.chat_model_selection_policy_json(generated)
+    )
+    assert module.chat_model_selection_policy_json(generated).endswith("\n")
+    assert json.loads(module.chat_model_selection_policy_json(generated)) == fixture
+
+
+def test_cli_stub_outputs_deterministic_json() -> None:
+    fixture = json.loads(read_text(FIXTURE_PATH))
+    command = [
+        "bash",
+        str(SCRIPT_PATH),
+        "--model",
+        "gemma3n-e4b",
+        "--target",
+        "kv260",
+    ]
+    first = subprocess.run(command, check=True, capture_output=True, text=True)
+    second = subprocess.run(command, check=True, capture_output=True, text=True)
+
+    assert first.stderr == ""
+    assert first.stdout == second.stdout
+    assert first.stdout.endswith("\n")
+    assert json.loads(first.stdout) == fixture
+
+
+def test_required_fields_and_allowed_states() -> None:
+    module = load_module()
+    policy = module.create_gemma3n_e4b_kv260_chat_model_selection_policy()
+    allowed = set(module.CHAT_MODEL_SELECTION_POLICY_STATE_VALUES)
+
+    assert tuple(policy.keys()) == module.CHAT_MODEL_SELECTION_POLICY_FIELDS
+    assert policy["schemaVersion"] == "pccx.chatModelSelectionPolicy.v0"
+    assert tuple(policy["selectionPolicy"].keys()) == (
+        module.SELECTION_POLICY_FIELDS
+    )
+
+    states = list(iter_state_values(policy))
+    assert states
+    for state in states:
+        assert state in allowed, state
+
+    for option in policy["modelOptions"]:
+        assert tuple(option.keys()) == module.MODEL_OPTION_FIELDS
+    for control in policy["selectionControls"]:
+        assert tuple(control.keys()) == module.SELECTION_CONTROL_FIELDS
+    for reason in policy["blockedReasons"]:
+        assert tuple(reason.keys()) == module.BLOCKED_REASON_FIELDS
+    for ref in policy["handoffRefs"]:
+        assert tuple(ref.keys()) == module.HANDOFF_REF_FIELDS
+
+
+def test_chat_model_selection_policy_keeps_picker_disabled() -> None:
+    policy = load_module().create_gemma3n_e4b_kv260_chat_model_selection_policy()
+    selection_policy = policy["selectionPolicy"]
+    options = {option["optionId"]: option for option in policy["modelOptions"]}
+    controls = {
+        control["controlId"]: control for control in policy["selectionControls"]
+    }
+    reasons = {reason["reasonId"]: reason for reason in policy["blockedReasons"]}
+    refs = {ref["refId"]: ref for ref in policy["handoffRefs"]}
+    flags = policy["safetyFlags"]
+
+    assert policy["selectionState"] == "blocked"
+    assert policy["catalogState"] == "static_placeholder"
+    assert policy["pickerState"] == "disabled"
+    assert policy["selectedModelState"] == "target_selected"
+    assert policy["descriptorState"] == "available_as_data"
+    assert policy["assetDiscoveryState"] == "blocked"
+    assert policy["assetPathState"] == "not_configured"
+    assert policy["providerFallbackState"] == "disabled"
+    assert policy["loadRequestState"] == "blocked"
+    assert selection_policy["staticOptionCount"] == 1
+    assert selection_policy["dynamicCatalogConfigured"] is False
+    assert selection_policy["localCatalogRead"] is False
+    assert selection_policy["assetDiscoveryEnabled"] is False
+    assert selection_policy["selectionEnabled"] is False
+    assert selection_policy["selectionPersistenceEnabled"] is False
+    assert selection_policy["providerFallbackEnabled"] is False
+    assert selection_policy["loadRequestEnabled"] is False
+
+    option = options["gemma3n_e4b_kv260_placeholder"]
+    assert option["selected"] is True
+    assert option["enabled"] is False
+    assert option["assetPolicy"] == "placeholder_descriptor_only_no_asset_path"
+
+    for control in controls.values():
+        assert control["enabled"] is False
+    assert controls["open_model_catalog"]["state"] == "blocked"
+    assert controls["select_model_option"]["state"] == "disabled"
+    assert controls["discover_local_assets"]["state"] == "blocked"
+    assert controls["handoff_to_load_request"]["state"] == "blocked"
+
+    assert reasons["dynamic_catalog_boundary_absent"]["state"] == "not_configured"
+    assert reasons["selection_executor_absent"]["state"] == "disabled"
+    assert reasons["model_asset_discovery_blocked"]["state"] == "blocked"
+    assert reasons["provider_fallback_disabled"]["state"] == "disabled"
+    assert reasons["load_request_blocked"]["state"] == "blocked"
+    assert refs["chat_model_load_request"]["state"] == "blocked"
+
+    true_flags = {
+        "dataOnly",
+        "readOnly",
+        "deterministic",
+        "selectionPolicyDisplayOnly",
+        "staticOptionOnly",
+    }
+    false_flags = set(flags) - true_flags
+    for flag in true_flags:
+        assert flags[flag] is True, flag
+    for flag in false_flags:
+        assert flags[flag] is False, flag
+
+
+def test_chat_model_selection_policy_docs_and_ci_are_wired() -> None:
+    doc = read_text(DOC_PATH)
+    readme = read_text(README_PATH)
+    status_test = read_text(STATUS_TEST_PATH)
+    ci = read_text(CI_PATH)
+
+    assert "contracts/chat_model_selection_policy_contract.py" in doc
+    assert (
+        "contracts/fixtures/chat-model-selection-policy.gemma3n-e4b-kv260-placeholder.json"
+        in doc
+    )
+    assert "scripts/chat-model-selection-policy-stub.sh" in doc
+    assert "scripts/tests/chat_model_selection_policy_contract_test.py" in doc
+    assert "scripts/tests/status-chat-model-selection-policy.sh" in doc
+    assert "chat-model-selection-policy-stub.sh" in readme
+    assert "--include-chat-model-selection-policy" in readme
+    assert "chat_model_selection_policy_contract_test.py" in ci
+    assert "status-chat-model-selection-policy.sh" in ci
+    assert "--include-chat-model-selection-policy" in status_test
+    assert "no catalog/config/model asset path/read/load/runtime" in status_test
+
+
+def test_contract_does_not_read_runtime_provider_hardware_or_private_data() -> None:
+    source = read_text(MODULE_PATH)
+    fixture_text = read_text(FIXTURE_PATH)
+    fixture = json.loads(fixture_text)
+    combined = (
+        source
+        + fixture_text
+        + read_text(SCRIPT_PATH)
+        + read_text(STATUS_TEST_PATH)
+        + read_text(DOC_PATH)
+        + read_text(README_PATH)
+    )
+
+    assert_no_runtime_implementation_terms(source)
+    assert_no_private_or_generated_data(fixture_text)
+    assert_no_provider_configs(fixture)
+    assert_no_unsupported_claims(combined)
+
+    forbidden_fixture_keys = [
+        "promptText",
+        "responseText",
+        "transcriptText",
+        "modelPath",
+        "assetPath",
+        "tokenizerPath",
+        "checksumValue",
+        "runtimeLog",
+        "privatePath",
+    ]
+    for key in forbidden_fixture_keys:
+        assert f'"{key}"' not in fixture_text, key
+
+
+if __name__ == "__main__":
+    test_chat_model_selection_policy_matches_fixture_and_is_deterministic()
+    test_cli_stub_outputs_deterministic_json()
+    test_required_fields_and_allowed_states()
+    test_chat_model_selection_policy_keeps_picker_disabled()
+    test_chat_model_selection_policy_docs_and_ci_are_wired()
+    test_contract_does_not_read_runtime_provider_hardware_or_private_data()
+    print("chat model-selection policy contract tests passed")

--- a/scripts/tests/status-chat-model-selection-policy.sh
+++ b/scripts/tests/status-chat-model-selection-policy.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+# scripts/tests/status-chat-model-selection-policy.sh - status model-selection tests.
+#
+# Usage: bash scripts/tests/status-chat-model-selection-policy.sh [path/to/status-stub.sh]
+
+set -eu
+
+PASS() { printf '[PASS]  %s\n' "$*"; }
+FAIL() { printf '[FAIL] %s\n' "$*" >&2; }
+HEAD() { printf '\n=== %s ===\n' "$*"; }
+
+STUB="${1:-scripts/status-stub.sh}"
+
+if [ ! -x "$STUB" ]; then
+    chmod +x "$STUB"
+fi
+
+contains() {
+    case "$1" in
+        *"$2"*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+require_contains() {
+    local output="$1"
+    local expected="$2"
+    if ! contains "$output" "$expected"; then
+        FAIL "expected output to contain: $expected"
+        printf '%s\n' "$output" >&2
+        exit 1
+    fi
+}
+
+require_not_contains() {
+    local output="$1"
+    local forbidden="$2"
+    if contains "$output" "$forbidden"; then
+        FAIL "output contained forbidden text: $forbidden"
+        printf '%s\n' "$output" >&2
+        exit 1
+    fi
+}
+
+HEAD "1: status can include chat model-selection policy"
+OUTPUT="$("$STUB" --include-chat-model-selection-policy)"
+require_contains "$OUTPUT" "=== chat model selection policy ==="
+require_contains "$OUTPUT" "source     : scripts/chat-model-selection-policy-stub.sh --model gemma3n-e4b --target kv260"
+require_contains "$OUTPUT" "boundary   : read-only data; no catalog/config/model asset path/read/load/runtime/provider/hardware/lab/IDE execution"
+require_contains "$OUTPUT" "target     : kv260"
+require_contains "$OUTPUT" "model      : gemma3n-e4b"
+require_contains "$OUTPUT" "selection  : blocked"
+require_contains "$OUTPUT" "catalog    : static_placeholder"
+require_contains "$OUTPUT" "picker     : disabled"
+require_contains "$OUTPUT" "selected   : target_selected"
+require_contains "$OUTPUT" "descriptor : available_as_data"
+require_contains "$OUTPUT" "asset disc : blocked"
+require_contains "$OUTPUT" "asset paths: not_configured"
+require_contains "$OUTPUT" "fallback   : disabled"
+require_contains "$OUTPUT" "load req   : blocked"
+require_contains "$OUTPUT" "privacy    : summary_only"
+PASS "chat model-selection section is present and conservative"
+
+HEAD "2: policy, options, and controls stay disabled"
+require_contains "$OUTPUT" "model-selection : blocked mode=disabled_until_reviewed_model_catalog_and_selection_boundary_exists"
+require_contains "$OUTPUT" "staticOptionCount=1"
+require_contains "$OUTPUT" "dynamicCatalogConfigured=false"
+require_contains "$OUTPUT" "localCatalogRead=false"
+require_contains "$OUTPUT" "assetDiscoveryEnabled=false"
+require_contains "$OUTPUT" "selectionEnabled=false"
+require_contains "$OUTPUT" "selectionPersistenceEnabled=false"
+require_contains "$OUTPUT" "providerFallbackEnabled=false"
+require_contains "$OUTPUT" "loadRequestEnabled=false"
+require_contains "$OUTPUT" "options    : gemma3n_e4b_kv260_placeholder=target_selected:true:false"
+require_contains "$OUTPUT" "controls   : review_static_target=available_as_data:false"
+require_contains "$OUTPUT" "open_model_catalog=blocked:false"
+require_contains "$OUTPUT" "select_model_option=disabled:false"
+require_contains "$OUTPUT" "discover_local_assets=blocked:false"
+require_contains "$OUTPUT" "configure_provider_fallback=disabled:false"
+require_contains "$OUTPUT" "handoff_to_load_request=blocked:false"
+PASS "model-selection metadata is summarized without catalog or asset reads"
+
+HEAD "3: blocked reasons stay explicit"
+require_contains "$OUTPUT" "blocked    : dynamic_catalog_boundary_absent=not_configured"
+require_contains "$OUTPUT" "selection_executor_absent=disabled"
+require_contains "$OUTPUT" "model_asset_discovery_blocked=blocked"
+require_contains "$OUTPUT" "provider_fallback_disabled=disabled"
+require_contains "$OUTPUT" "load_request_blocked=blocked"
+require_contains "$OUTPUT" "runtime_evidence_absent=requires_evidence"
+require_contains "$OUTPUT" "hardware_evidence_absent=requires_evidence"
+PASS "model-selection blockers remain visible"
+
+HEAD "4: safety flags stay read-only and non-executing"
+require_contains "$OUTPUT" "readOnly=true"
+require_contains "$OUTPUT" "dataOnly=true"
+require_contains "$OUTPUT" "deterministic=true"
+require_contains "$OUTPUT" "selectionPolicyDisplayOnly=true"
+require_contains "$OUTPUT" "staticOptionOnly=true"
+require_contains "$OUTPUT" "dynamicCatalogConfigured=false"
+require_contains "$OUTPUT" "modelCatalogRead=false"
+require_contains "$OUTPUT" "dynamicCatalogDiscovery=false"
+require_contains "$OUTPUT" "modelSelectionPersisted=false"
+require_contains "$OUTPUT" "modelSelectionAcceptedFromUser=false"
+require_contains "$OUTPUT" "modelOptionsFromConfig=false"
+require_contains "$OUTPUT" "modelAssetPathsIncluded=false"
+require_contains "$OUTPUT" "modelAssetPathRead=false"
+require_contains "$OUTPUT" "modelAssetRead=false"
+require_contains "$OUTPUT" "configRead=false"
+require_contains "$OUTPUT" "environmentRead=false"
+require_contains "$OUTPUT" "providerConfigRead=false"
+require_contains "$OUTPUT" "providerCalls=false"
+require_contains "$OUTPUT" "cloudCalls=false"
+require_contains "$OUTPUT" "networkCalls=false"
+require_contains "$OUTPUT" "modelLoadAttempted=false"
+require_contains "$OUTPUT" "modelLoaded=false"
+require_contains "$OUTPUT" "modelExecution=false"
+require_contains "$OUTPUT" "runtimeExecution=false"
+require_contains "$OUTPUT" "kv260Access=false"
+require_contains "$OUTPUT" "hardwareAccess=false"
+require_contains "$OUTPUT" "writesArtifacts=false"
+require_contains "$OUTPUT" "readsArtifacts=false"
+require_contains "$OUTPUT" "executesPccxLab=false"
+PASS "catalog, selection, runtime, and asset flags remain disabled"
+
+HEAD "5: output is deterministic"
+OUTPUT_AGAIN="$("$STUB" --include-chat-model-selection-policy)"
+if [ "$OUTPUT" != "$OUTPUT_AGAIN" ]; then
+    FAIL "status chat model-selection output changed between runs"
+    exit 1
+fi
+PASS "status chat model-selection output is deterministic"
+
+HEAD "6: chat model-selection option does not combine with pccx-lab backend"
+if "$STUB" --include-chat-model-selection-policy --backend pccx-lab >/dev/null 2>&1; then
+    FAIL "expected combined chat-model-selection/backend mode to fail"
+    exit 1
+fi
+PASS "chat model-selection remains separate from backend execution"
+
+HEAD "7: output avoids known overclaims and content"
+FORBIDDEN_PREFIX="KV260 inference"
+FORBIDDEN_CLAIM="${FORBIDDEN_PREFIX} works"
+require_not_contains "$OUTPUT" "$FORBIDDEN_CLAIM"
+THROUGHPUT_PREFIX="20 tok/s"
+THROUGHPUT_CLAIM="${THROUGHPUT_PREFIX} achieved"
+require_not_contains "$OUTPUT" "$THROUGHPUT_CLAIM"
+GGUF_EXT=".g""guf"
+SAFETENSORS_EXT=".safe""tensors"
+require_not_contains "$OUTPUT" "$GGUF_EXT"
+require_not_contains "$OUTPUT" "$SAFETENSORS_EXT"
+require_not_contains "$OUTPUT" "assistant response:"
+require_not_contains "$OUTPUT" "hello"
+PASS "no model-selection overclaim or asset/content leakage in status output"
+
+printf '\n[DONE]  all status-chat-model-selection-policy tests passed\n'


### PR DESCRIPTION
Refs #9

Summary:
- Add data-only `pccx.chatModelSelectionPolicy.v0` contract, fixture, and stub for the disabled standalone chat model picker/catalog boundary.
- Wire the status stub, status tests, contract tests, README/docs, and CI coverage.
- Keep summary-only: no model catalog discovery, config/env reads, model path/asset reads, user selection acceptance, selection persistence, provider/cloud/network calls, runtime preflight, model load/execution, pccx-lab/IDE execution, hardware/KV260 access, artifact access, compatibility claim, marketplace claim, runtime claim, hardware claim, or stable API/ABI claim.

Validation:
- `python3 scripts/tests/chat_model_selection_policy_contract_test.py`
- `bash scripts/tests/status-chat-model-selection-policy.sh scripts/status-stub.sh`
- `bash scripts/status-stub.sh --include-chat-model-selection-policy`
- `python3 -m py_compile contracts/chat_model_selection_policy_contract.py scripts/tests/chat_model_selection_policy_contract_test.py`
- `python3 -m json.tool contracts/fixtures/chat-model-selection-policy.gemma3n-e4b-kv260-placeholder.json`
- `cmp -s contracts/fixtures/chat-model-selection-policy.gemma3n-e4b-kv260-placeholder.json <(bash scripts/chat-model-selection-policy-stub.sh --model gemma3n-e4b --target kv260)`
- `find scripts -type f -name '*.sh' -print0 | xargs -0 bash -n`
- `for t in scripts/tests/*_test.py; do python3 "$t"; done`
- `for t in scripts/tests/status-*.sh; do bash "$t" scripts/status-stub.sh; done`
- `bash scripts/status-stub.sh`
- `bash scripts/check.sh`
- `bash scripts/check-device-stub.sh`
- `bash scripts/install-stub.sh`
- `bash scripts/launch-stub.sh --dry-run`
- `bash scripts/chat-stub.sh --dry-run --prompt hello`
- local claim scan matching CI guard
- `git diff --check`
- `git diff --cached --check`