### PR TITLE
Add chat empty-state boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,7 @@ jobs:
                    scripts/chat-session-stub.sh \
                    scripts/chat-session-lifecycle-stub.sh \
                    scripts/chat-surface-layout-stub.sh \
+                   scripts/chat-empty-state-stub.sh \
                    scripts/chat-local-only-policy-stub.sh \
                    scripts/chat-preferences-stub.sh \
                    scripts/chat-session-index-stub.sh \
@@ -199,6 +200,10 @@ jobs:
         run: ./scripts/status-stub.sh --include-chat-surface-layout
       - name: run scripts/chat-surface-layout-stub.sh
         run: ./scripts/chat-surface-layout-stub.sh --model gemma3n-e4b --target kv260
+      - name: run scripts/status-stub.sh with chat empty state
+        run: ./scripts/status-stub.sh --include-chat-empty-state
+      - name: run scripts/chat-empty-state-stub.sh
+        run: ./scripts/chat-empty-state-stub.sh --model gemma3n-e4b --target kv260
       - name: run scripts/status-stub.sh with chat local-only policy
         run: ./scripts/status-stub.sh --include-chat-local-only-policy
       - name: run scripts/chat-local-only-policy-stub.sh
@@ -299,6 +304,8 @@ jobs:
         run: python3 scripts/tests/chat_session_lifecycle_contract_test.py
       - name: run chat surface-layout contract tests
         run: python3 scripts/tests/chat_surface_layout_contract_test.py
+      - name: run chat empty-state contract tests
+        run: python3 scripts/tests/chat_empty_state_contract_test.py
       - name: run chat local-only policy contract tests
         run: python3 scripts/tests/chat_local_only_policy_contract_test.py
       - name: run chat preferences contract tests
@@ -350,6 +357,7 @@ jobs:
           chmod +x scripts/chat-session-stub.sh
           chmod +x scripts/chat-session-lifecycle-stub.sh
           chmod +x scripts/chat-surface-layout-stub.sh
+          chmod +x scripts/chat-empty-state-stub.sh
           chmod +x scripts/chat-local-only-policy-stub.sh
           chmod +x scripts/chat-preferences-stub.sh
           chmod +x scripts/chat-session-index-stub.sh
@@ -376,6 +384,7 @@ jobs:
           chmod +x scripts/tests/status-chat-model-load-request.sh
           chmod +x scripts/tests/status-chat-session.sh
           chmod +x scripts/tests/status-chat-surface-layout.sh
+          chmod +x scripts/tests/status-chat-empty-state.sh
           chmod +x scripts/tests/status-chat-local-only-policy.sh
           chmod +x scripts/tests/status-chat-preferences.sh
           chmod +x scripts/tests/status-chat-session-index.sh
@@ -405,6 +414,7 @@ jobs:
           shellcheck scripts/tests/status-chat-model-load-request.sh
           shellcheck scripts/tests/status-chat-session.sh
           shellcheck scripts/tests/status-chat-surface-layout.sh
+          shellcheck scripts/tests/status-chat-empty-state.sh
           shellcheck scripts/tests/status-chat-local-only-policy.sh
           shellcheck scripts/tests/status-chat-preferences.sh
           shellcheck scripts/tests/status-chat-session-index.sh
@@ -439,6 +449,8 @@ jobs:
         run: bash scripts/tests/status-chat-session.sh scripts/status-stub.sh
       - name: run status-chat-surface-layout tests
         run: bash scripts/tests/status-chat-surface-layout.sh scripts/status-stub.sh
+      - name: run status-chat-empty-state tests
+        run: bash scripts/tests/status-chat-empty-state.sh scripts/status-stub.sh
       - name: run status-chat-local-only-policy tests
         run: bash scripts/tests/status-chat-local-only-policy.sh scripts/status-stub.sh
       - name: run status-chat-preferences tests

--- a/README.md
+++ b/README.md
@@ -87,12 +87,13 @@ and verify host-side prerequisites before the real engine lands.
 | [`scripts/check.sh`](./scripts/check.sh) | Probe host info, tooling availability, edge-device hints. Always exits 0. |
 | [`scripts/check-device-stub.sh`](./scripts/check-device-stub.sh) | Narrowly scoped device-tree / FPGA-node probe (KV260 / Kria detection only). Always exits 0. |
 | [`scripts/install-stub.sh`](./scripts/install-stub.sh) | Preview of the planned install flow; reports which host runtime pieces are present, lists device-side pieces as future deliverables. Always exits 0. |
-| [`scripts/status-stub.sh`](./scripts/status-stub.sh) | Launcher state summary. Default mode: local scaffold output, always exits 0. With `--include-chat-action-bar`, adds read-only disabled chat action-bar data. With `--include-chat-attachment-policy`, adds read-only disabled chat attachment-policy data. With `--include-chat-shortcut-map`, adds read-only disabled chat shortcut-map data. With `--include-chat-message-list`, adds read-only empty chat message-list data. With `--include-chat-response-stream`, adds read-only blocked chat response stream data. With `--include-chat-error-taxonomy`, adds read-only chat error taxonomy data. With `--include-chat-audit-event`, adds read-only blocked chat audit-event metadata. With `--include-chat-surface-layout`, adds read-only chat surface layout data. With `--include-chat-local-only-policy`, adds read-only local-only/cloud-block policy data. With `--include-chat-preferences`, adds read-only chat preferences/settings data. With `--include-chat-session-index`, adds read-only empty chat session index data. With `--include-chat-session-store-policy`, adds read-only disabled chat session-store policy data. With `--include-chat-session-title-policy`, adds read-only placeholder session-title policy data. With `--include-chat-transcript-policy`, adds read-only chat transcript retention/export policy data. With `--include-chat-send-result`, adds read-only blocked chat send-result data. With `--include-chat-composer`, adds read-only chat composer/input-control data. With `--include-chat-model-status`, adds read-only blocked chat model-status display data. With `--include-chat-model-selection-policy`, adds read-only disabled chat model-selection data. With `--include-chat-context-policy`, adds read-only disabled chat context-window/tokenization policy data. With `--include-chat-model-load-request`, adds read-only disabled chat model-load request data. With `--include-chat-session`, adds read-only blocked chat/session and lifecycle summaries. With `--include-chat-readiness`, adds read-only chat readiness checks and recovery actions. With `--include-device-session`, adds a read-only device/session status panel. With `--include-runtime-readiness`, adds a read-only runtime readiness summary. With `--backend pccx-lab`, calls `pccx-lab status --format json` and forwards the run-status envelope (exits non-zero if binary is missing or output is invalid). |
+| [`scripts/status-stub.sh`](./scripts/status-stub.sh) | Launcher state summary. Default mode: local scaffold output, always exits 0. With `--include-chat-action-bar`, adds read-only disabled chat action-bar data. With `--include-chat-attachment-policy`, adds read-only disabled chat attachment-policy data. With `--include-chat-shortcut-map`, adds read-only disabled chat shortcut-map data. With `--include-chat-message-list`, adds read-only empty chat message-list data. With `--include-chat-response-stream`, adds read-only blocked chat response stream data. With `--include-chat-error-taxonomy`, adds read-only chat error taxonomy data. With `--include-chat-audit-event`, adds read-only blocked chat audit-event metadata. With `--include-chat-surface-layout`, adds read-only chat surface layout data. With `--include-chat-empty-state`, adds read-only display-only chat empty-state data. With `--include-chat-local-only-policy`, adds read-only local-only/cloud-block policy data. With `--include-chat-preferences`, adds read-only chat preferences/settings data. With `--include-chat-session-index`, adds read-only empty chat session index data. With `--include-chat-session-store-policy`, adds read-only disabled chat session-store policy data. With `--include-chat-session-title-policy`, adds read-only placeholder session-title policy data. With `--include-chat-transcript-policy`, adds read-only chat transcript retention/export policy data. With `--include-chat-send-result`, adds read-only blocked chat send-result data. With `--include-chat-composer`, adds read-only chat composer/input-control data. With `--include-chat-model-status`, adds read-only blocked chat model-status display data. With `--include-chat-model-selection-policy`, adds read-only disabled chat model-selection data. With `--include-chat-context-policy`, adds read-only disabled chat context-window/tokenization policy data. With `--include-chat-model-load-request`, adds read-only disabled chat model-load request data. With `--include-chat-session`, adds read-only blocked chat/session and lifecycle summaries. With `--include-chat-readiness`, adds read-only chat readiness checks and recovery actions. With `--include-device-session`, adds a read-only device/session status panel. With `--include-runtime-readiness`, adds a read-only runtime readiness summary. With `--backend pccx-lab`, calls `pccx-lab status --format json` and forwards the run-status envelope (exits non-zero if binary is missing or output is invalid). |
 | [`scripts/device-session-status-stub.sh`](./scripts/device-session-status-stub.sh) | Data-only device/session status JSON for the Gemma 3N E4B + KV260 target. Reports connection, model load, session, diagnostics, readiness, discovery paths, flow steps, and error taxonomy as placeholder / blocked. |
 | [`scripts/runtime-readiness-stub.sh`](./scripts/runtime-readiness-stub.sh) | Data-only runtime readiness JSON for the Gemma 3N E4B + KV260 target. Reports blocked / not yet evidence-backed. |
 | [`scripts/chat-session-stub.sh`](./scripts/chat-session-stub.sh) | Data-only standalone chat/session JSON for the Gemma 3N E4B + KV260 target. Reports disabled send controls, inactive session state, no prompt/response persistence, and readiness handoff references. |
 | [`scripts/chat-session-lifecycle-stub.sh`](./scripts/chat-session-lifecycle-stub.sh) | Data-only chat session lifecycle JSON for the Gemma 3N E4B + KV260 target. Reports create, restore, clear, close, and export-summary operations as disabled, blocked, inactive, or unavailable. |
 | [`scripts/chat-surface-layout-stub.sh`](./scripts/chat-surface-layout-stub.sh) | Data-only chat surface layout JSON for the Gemma 3N E4B + KV260 target. Reports planned shell regions and navigation items as local metadata without prompt/response/transcript/session-store reads or runtime actions. |
+| [`scripts/chat-empty-state-stub.sh`](./scripts/chat-empty-state-stub.sh) | Data-only chat empty-state JSON for the Gemma 3N E4B + KV260 target. Reports static placeholder display slots and disabled hints without prompts, responses, transcripts, session-store reads, command dispatch, model loads, runtime execution, target access, or provider calls. |
 | [`scripts/chat-local-only-policy-stub.sh`](./scripts/chat-local-only-policy-stub.sh) | Data-only chat local-only policy JSON for the Gemma 3N E4B + KV260 target. Reports cloud/provider/network dependency and fallback paths as not used, disabled, or blocked while local runtime evidence remains gated. |
 | [`scripts/chat-preferences-stub.sh`](./scripts/chat-preferences-stub.sh) | Data-only chat preferences JSON for the Gemma 3N E4B + KV260 target. Reports planned settings panels and disabled controls without reading configuration, provider settings, model paths, session stores, prompts, transcripts, or artifacts. |
 | [`scripts/chat-session-index-stub.sh`](./scripts/chat-session-index-stub.sh) | Data-only chat session index JSON for the Gemma 3N E4B + KV260 target. Reports an empty, not-configured session list/sidebar boundary without reading a store, session titles, prompts, responses, transcripts, or summaries. |
@@ -128,6 +129,7 @@ bash scripts/status-stub.sh --include-chat-context-policy
 bash scripts/status-stub.sh --include-chat-model-load-request
 bash scripts/status-stub.sh --include-chat-session
 bash scripts/status-stub.sh --include-chat-surface-layout
+bash scripts/status-stub.sh --include-chat-empty-state
 bash scripts/status-stub.sh --include-chat-local-only-policy
 bash scripts/status-stub.sh --include-chat-preferences
 bash scripts/status-stub.sh --include-chat-session-index
@@ -155,6 +157,7 @@ bash scripts/chat-model-load-request-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-session-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-session-lifecycle-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-surface-layout-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/chat-empty-state-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-local-only-policy-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-preferences-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-session-index-stub.sh --model gemma3n-e4b --target kv260
@@ -348,6 +351,7 @@ python3 contracts/chat_attachment_policy_contract.py --model gemma3n-e4b --targe
 python3 contracts/chat_session_store_policy_contract.py --model gemma3n-e4b --target kv260
 python3 contracts/chat_shortcut_map_contract.py --model gemma3n-e4b --target kv260
 python3 contracts/chat_session_title_policy_contract.py --model gemma3n-e4b --target kv260
+python3 contracts/chat_empty_state_contract.py --model gemma3n-e4b --target kv260
 bash scripts/chat-model-status-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-model-selection-policy-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-model-load-request-stub.sh --model gemma3n-e4b --target kv260
@@ -355,6 +359,7 @@ bash scripts/chat-session-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-session-lifecycle-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-session-store-policy-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-session-title-policy-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/chat-empty-state-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-readiness-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-audit-event-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-error-taxonomy-stub.sh --model gemma3n-e4b --target kv260
@@ -376,6 +381,7 @@ bash scripts/status-stub.sh --include-chat-attachment-policy
 bash scripts/status-stub.sh --include-chat-session-store-policy
 bash scripts/status-stub.sh --include-chat-shortcut-map
 bash scripts/status-stub.sh --include-chat-session-title-policy
+bash scripts/status-stub.sh --include-chat-empty-state
 python3 scripts/tests/chat_session_contract_test.py
 python3 scripts/tests/chat_model_status_contract_test.py
 python3 scripts/tests/chat_model_selection_policy_contract_test.py
@@ -390,6 +396,7 @@ python3 scripts/tests/chat_action_bar_contract_test.py
 python3 scripts/tests/chat_attachment_policy_contract_test.py
 python3 scripts/tests/chat_session_store_policy_contract_test.py
 python3 scripts/tests/chat_shortcut_map_contract_test.py
+python3 scripts/tests/chat_empty_state_contract_test.py
 python3 scripts/tests/chat_surface_preview_test.py
 bash scripts/tests/status-chat-model-status.sh
 bash scripts/tests/status-chat-model-selection-policy.sh
@@ -404,6 +411,7 @@ bash scripts/tests/status-chat-attachment-policy.sh
 bash scripts/tests/status-chat-session-store-policy.sh
 bash scripts/tests/status-chat-shortcut-map.sh
 bash scripts/tests/status-chat-session-title-policy.sh
+bash scripts/tests/status-chat-empty-state.sh
 ```
 
 The checked chat/session fixture reports the chat surface as blocked,

--- a/contracts/chat_empty_state_contract.py
+++ b/contracts/chat_empty_state_contract.py
@@ -1,0 +1,451 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Data-only chat empty-state contract for the planned launcher UI.
+
+The contract describes the static empty-state surface for the standalone
+chat shell while keeping prompts, responses, transcripts, session stores,
+model assets, runtime handoff, providers, target hardware, pccx-lab, IDE
+integration, and artifact paths disabled or absent.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import sys
+
+
+SCHEMA_VERSION = "pccx.chatEmptyState.v0"
+
+CHAT_EMPTY_STATE_FIELDS = (
+    "schemaVersion",
+    "emptyStateId",
+    "fixtureVersion",
+    "lastUpdatedSource",
+    "targetDevice",
+    "targetBoard",
+    "targetModel",
+    "emptyStateState",
+    "surfaceState",
+    "sessionState",
+    "modelState",
+    "readinessState",
+    "promptState",
+    "transcriptState",
+    "actionState",
+    "runtimeState",
+    "privacyState",
+    "chatSurfaceLayoutRef",
+    "chatSessionIndexRef",
+    "chatReadinessRef",
+    "chatComposerRef",
+    "chatModelStatusRef",
+    "chatActionBarRef",
+    "emptyStatePolicy",
+    "displaySlots",
+    "affordanceHints",
+    "blockedReasons",
+    "handoffRefs",
+    "safetyFlags",
+    "limitations",
+    "issueRefs",
+)
+
+EMPTY_STATE_POLICY_FIELDS = (
+    "state",
+    "renderMode",
+    "messagePolicy",
+    "hintPolicy",
+    "contentPolicy",
+    "sideEffectPolicy",
+    "externalDependencyPolicy",
+)
+
+DISPLAY_SLOT_FIELDS = (
+    "slotId",
+    "label",
+    "state",
+    "visible",
+    "enabled",
+    "sourceRef",
+    "displayRole",
+    "contentPolicy",
+)
+
+AFFORDANCE_HINT_FIELDS = (
+    "hintId",
+    "label",
+    "state",
+    "visible",
+    "enabled",
+    "sourceRef",
+    "blockedReasonRef",
+    "contentPolicy",
+)
+
+BLOCKED_REASON_FIELDS = (
+    "reasonId",
+    "state",
+    "summary",
+    "requiredBefore",
+)
+
+HANDOFF_REF_FIELDS = (
+    "refId",
+    "schemaVersion",
+    "fixturePath",
+    "state",
+    "summary",
+)
+
+CHAT_EMPTY_STATE_VALUES = (
+    "available_as_data",
+    "blocked",
+    "disabled",
+    "empty_not_captured",
+    "inactive",
+    "not_configured",
+    "not_loaded",
+    "not_started",
+    "not_used",
+    "placeholder",
+    "planned",
+    "summary_only",
+    "target_selected",
+    "unavailable",
+)
+
+_CHAT_EMPTY_STATE = {
+    "schemaVersion": SCHEMA_VERSION,
+    "emptyStateId": "chat_empty_state_gemma3n_e4b_kv260_placeholder",
+    "fixtureVersion": "chat-empty-state.gemma3n-e4b-kv260.2026-05-05",
+    "lastUpdatedSource": "pccx_launcher_issue_9_chat_empty_state_boundary_2026-05-05",
+    "targetDevice": "kv260",
+    "targetBoard": "xilinx_kria_kv260",
+    "targetModel": "gemma3n-e4b",
+    "emptyStateState": "available_as_data",
+    "surfaceState": "placeholder",
+    "sessionState": "inactive",
+    "modelState": "not_loaded",
+    "readinessState": "blocked",
+    "promptState": "empty_not_captured",
+    "transcriptState": "empty_not_captured",
+    "actionState": "disabled",
+    "runtimeState": "not_started",
+    "privacyState": "summary_only",
+    "chatSurfaceLayoutRef": "chat_surface_layout_gemma3n_e4b_kv260_placeholder",
+    "chatSessionIndexRef": "chat_session_index_gemma3n_e4b_kv260_placeholder",
+    "chatReadinessRef": "chat_readiness_gemma3n_e4b_kv260_placeholder",
+    "chatComposerRef": "chat_composer_gemma3n_e4b_kv260_placeholder",
+    "chatModelStatusRef": "chat_model_status_gemma3n_e4b_kv260_placeholder",
+    "chatActionBarRef": "chat_action_bar_gemma3n_e4b_kv260_placeholder",
+    "emptyStatePolicy": {
+        "state": "available_as_data",
+        "renderMode": "future_local_chat_empty_state",
+        "messagePolicy": "static placeholder text only; no prompt, response, transcript, session title, summary, or generated content is read",
+        "hintPolicy": "disabled affordance hints only; no command ids, command dispatch, or action execution is included",
+        "contentPolicy": "empty-state metadata only; no message body, transcript text, prompt text, response text, file path, model path, runtime log, or private path is included",
+        "sideEffectPolicy": "local_render_only",
+        "externalDependencyPolicy": "no provider, network, hardware, pccx-lab, IDE, model asset, session store, or artifact dependency is used",
+    },
+    "displaySlots": [
+        {
+            "slotId": "target_banner",
+            "label": "target banner",
+            "state": "target_selected",
+            "visible": True,
+            "enabled": True,
+            "sourceRef": "chat_model_status",
+            "displayRole": "status",
+            "contentPolicy": "target labels only; no model asset, model path, tokenizer, runtime, or hardware evidence is included",
+        },
+        {
+            "slotId": "empty_transcript_notice",
+            "label": "empty transcript notice",
+            "state": "empty_not_captured",
+            "visible": True,
+            "enabled": True,
+            "sourceRef": "chat_message_list",
+            "displayRole": "primary",
+            "contentPolicy": "no prompt, response, message body, transcript text, session title, or summary is included",
+        },
+        {
+            "slotId": "readiness_notice",
+            "label": "readiness notice",
+            "state": "blocked",
+            "visible": True,
+            "enabled": True,
+            "sourceRef": "chat_readiness",
+            "displayRole": "readiness",
+            "contentPolicy": "readiness labels only; no log, runtime output, hardware probe, or provider state is included",
+        },
+        {
+            "slotId": "composer_disabled_notice",
+            "label": "composer disabled notice",
+            "state": "disabled",
+            "visible": True,
+            "enabled": True,
+            "sourceRef": "chat_composer",
+            "displayRole": "input",
+            "contentPolicy": "input affordance metadata only; no prompt capture, echo, validation, or persistence is included",
+        },
+        {
+            "slotId": "local_only_notice",
+            "label": "local-only notice",
+            "state": "summary_only",
+            "visible": True,
+            "enabled": True,
+            "sourceRef": "chat_local_only_policy",
+            "displayRole": "policy",
+            "contentPolicy": "local-only policy labels only; no provider configuration, network state, or fallback path is included",
+        },
+    ],
+    "affordanceHints": [
+        {
+            "hintId": "start_new_session_hint",
+            "label": "start new session hint",
+            "state": "disabled",
+            "visible": True,
+            "enabled": False,
+            "sourceRef": "chat_session_lifecycle",
+            "blockedReasonRef": "session_store_not_configured",
+            "contentPolicy": "display label only; no session creation, title generation, store read, store write, or command dispatch",
+        },
+        {
+            "hintId": "select_model_hint",
+            "label": "select model hint",
+            "state": "blocked",
+            "visible": True,
+            "enabled": False,
+            "sourceRef": "chat_model_selection_policy",
+            "blockedReasonRef": "model_asset_boundary_absent",
+            "contentPolicy": "display label only; no catalog read, model path read, asset validation, or model selection persistence",
+        },
+        {
+            "hintId": "review_readiness_hint",
+            "label": "review readiness hint",
+            "state": "available_as_data",
+            "visible": True,
+            "enabled": False,
+            "sourceRef": "chat_readiness",
+            "blockedReasonRef": "runtime_evidence_absent",
+            "contentPolicy": "display label only; no runtime check, log read, hardware probe, or provider call",
+        },
+        {
+            "hintId": "focus_composer_hint",
+            "label": "focus composer hint",
+            "state": "disabled",
+            "visible": True,
+            "enabled": False,
+            "sourceRef": "chat_composer",
+            "blockedReasonRef": "prompt_capture_blocked",
+            "contentPolicy": "display label only; no focus change, prompt read, prompt capture, or key event capture",
+        },
+    ],
+    "blockedReasons": [
+        {
+            "reasonId": "runtime_evidence_absent",
+            "state": "blocked",
+            "summary": "No reviewed local chat runtime evidence exists for enabling conversation output.",
+            "requiredBefore": "assistant_response_display_enabled",
+        },
+        {
+            "reasonId": "model_asset_boundary_absent",
+            "state": "not_configured",
+            "summary": "No reviewed model asset input, validation, or load boundary exists.",
+            "requiredBefore": "model_picker_enabled",
+        },
+        {
+            "reasonId": "session_store_not_configured",
+            "state": "not_configured",
+            "summary": "No reviewed session store, retention, or title boundary is enabled.",
+            "requiredBefore": "session_creation_enabled",
+        },
+        {
+            "reasonId": "prompt_capture_blocked",
+            "state": "empty_not_captured",
+            "summary": "Prompt capture remains disabled by the composer and send-result boundaries.",
+            "requiredBefore": "composer_focus_or_send_enabled",
+        },
+        {
+            "reasonId": "transcript_content_absent",
+            "state": "empty_not_captured",
+            "summary": "No prompt, response, message body, transcript, session title, or summary content exists in this fixture.",
+            "requiredBefore": "message_list_rendered_from_store",
+        },
+        {
+            "reasonId": "action_execution_disabled",
+            "state": "disabled",
+            "summary": "Empty-state hints are display-only and do not dispatch commands.",
+            "requiredBefore": "empty_state_affordances_enabled",
+        },
+    ],
+    "handoffRefs": [
+        {
+            "refId": "chat_surface_layout",
+            "schemaVersion": "pccx.chatSurfaceLayout.v0",
+            "fixturePath": "contracts/fixtures/chat-surface-layout.gemma3n-e4b-kv260-placeholder.json",
+            "state": "placeholder",
+            "summary": "Surface layout defines the planned shell regions for the empty state.",
+        },
+        {
+            "refId": "chat_readiness",
+            "schemaVersion": "pccx.chatReadiness.v0",
+            "fixturePath": "contracts/fixtures/chat-readiness.gemma3n-e4b-kv260-placeholder.json",
+            "state": "blocked",
+            "summary": "Readiness metadata keeps model, runtime, and target checks blocked.",
+        },
+        {
+            "refId": "chat_model_status",
+            "schemaVersion": "pccx.chatModelStatus.v0",
+            "fixturePath": "contracts/fixtures/chat-model-status.gemma3n-e4b-kv260-placeholder.json",
+            "state": "blocked",
+            "summary": "Model status keeps descriptor, load, runtime, context, and response rows blocked.",
+        },
+        {
+            "refId": "chat_session_index",
+            "schemaVersion": "pccx.chatSessionIndex.v0",
+            "fixturePath": "contracts/fixtures/chat-session-index.gemma3n-e4b-kv260-placeholder.json",
+            "state": "empty_not_captured",
+            "summary": "Session index remains empty and does not read titles, summaries, or stores.",
+        },
+        {
+            "refId": "chat_composer",
+            "schemaVersion": "pccx.chatComposer.v0",
+            "fixturePath": "contracts/fixtures/chat-composer.gemma3n-e4b-kv260-placeholder.json",
+            "state": "blocked",
+            "summary": "Composer metadata keeps prompt capture and send disabled.",
+        },
+        {
+            "refId": "chat_message_list",
+            "schemaVersion": "pccx.chatMessageList.v0",
+            "fixturePath": "contracts/fixtures/chat-message-list.gemma3n-e4b-kv260-placeholder.json",
+            "state": "empty_not_captured",
+            "summary": "Message list remains empty without message bodies or transcript content.",
+        },
+        {
+            "refId": "chat_action_bar",
+            "schemaVersion": "pccx.chatActionBar.v0",
+            "fixturePath": "contracts/fixtures/chat-action-bar.gemma3n-e4b-kv260-placeholder.json",
+            "state": "disabled",
+            "summary": "Action-bar metadata keeps conversation controls disabled.",
+        },
+        {
+            "refId": "chat_local_only_policy",
+            "schemaVersion": "pccx.chatLocalOnlyPolicy.v0",
+            "fixturePath": "contracts/fixtures/chat-local-only-policy.gemma3n-e4b-kv260-placeholder.json",
+            "state": "summary_only",
+            "summary": "Local-only policy keeps provider, cloud, and fallback paths unavailable.",
+        },
+    ],
+    "safetyFlags": {
+        "dataOnly": True,
+        "readOnly": True,
+        "deterministic": True,
+        "emptyStateDisplayOnly": True,
+        "emptyStateTextOnly": True,
+        "localRenderOnly": True,
+        "promptCapture": False,
+        "promptRead": False,
+        "promptContentIncluded": False,
+        "promptEchoed": False,
+        "inputAccepted": False,
+        "responseContentIncluded": False,
+        "responseGenerated": False,
+        "transcriptContentIncluded": False,
+        "messageContentIncluded": False,
+        "sessionTitleIncluded": False,
+        "summaryIncluded": False,
+        "readsSessionStore": False,
+        "writesSessionStore": False,
+        "actionExecution": False,
+        "commandDispatch": False,
+        "focusChanged": False,
+        "keyboardCapture": False,
+        "clipboardRead": False,
+        "clipboardWrite": False,
+        "attachmentReads": False,
+        "filePickerOpened": False,
+        "modelAssetRead": False,
+        "modelPathIncluded": False,
+        "modelLoadAttempted": False,
+        "modelLoaded": False,
+        "modelExecution": False,
+        "runtimeStarted": False,
+        "runtimeExecution": False,
+        "runtimeOutputIncluded": False,
+        "kv260Access": False,
+        "hardwareAccess": False,
+        "providerCalls": False,
+        "cloudCalls": False,
+        "networkCalls": False,
+        "configRead": False,
+        "environmentRead": False,
+        "providerConfigRead": False,
+        "readsArtifacts": False,
+        "writesArtifacts": False,
+        "privatePathsIncluded": False,
+        "secretsIncluded": False,
+        "telemetry": False,
+        "upload": False,
+        "executesPccxLab": False,
+        "executesSystemverilogIde": False,
+        "mcpServerImplemented": False,
+        "lspImplemented": False,
+        "compatibilityClaim": False,
+    },
+    "limitations": [
+        "Data-only chat empty-state fixture; all displayed values are checked metadata for the planned local chat shell.",
+        "No prompt, response, transcript, message body, summary, session title, session store, configuration file, environment value, model path, tokenizer path, runtime log, private path, secret, or token is read.",
+        "No prompt capture, input acceptance, response generation, model asset read, model load, runtime start, target access, provider call, command dispatch, focus change, clipboard access, attachment read, telemetry, upload, or artifact write is performed.",
+        "No pccx-lab invocation, systemverilog-ide invocation, MCP server, LSP, compatibility promise, storage layer, runtime, model-loader, or hardware implementation is included.",
+    ],
+    "issueRefs": [
+        "pccxai/pccx-llm-launcher#9",
+    ],
+}
+
+
+def create_gemma3n_e4b_kv260_chat_empty_state() -> dict:
+    """Return the checked Gemma 3N E4B plus KV260 empty-state fixture."""
+    return copy.deepcopy(_CHAT_EMPTY_STATE)
+
+
+def chat_empty_state_json(state: dict | None = None) -> str:
+    """Render a deterministic JSON representation."""
+    return json.dumps(
+        state if state is not None else create_gemma3n_e4b_kv260_chat_empty_state(),
+        indent=2,
+        sort_keys=True,
+    ) + "\n"
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Print data-only chat empty-state JSON.",
+    )
+    parser.add_argument(
+        "--model",
+        default="gemma3n-e4b",
+        choices=("gemma3n-e4b",),
+        help="model descriptor target",
+    )
+    parser.add_argument(
+        "--target",
+        default="kv260",
+        choices=("kv260",),
+        help="target board/device",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parse_args(sys.argv[1:] if argv is None else argv)
+    sys.stdout.write(chat_empty_state_json())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contracts/fixtures/chat-empty-state.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-empty-state.gemma3n-e4b-kv260-placeholder.json
@@ -1,0 +1,289 @@
+{
+  "actionState": "disabled",
+  "affordanceHints": [
+    {
+      "blockedReasonRef": "session_store_not_configured",
+      "contentPolicy": "display label only; no session creation, title generation, store read, store write, or command dispatch",
+      "enabled": false,
+      "hintId": "start_new_session_hint",
+      "label": "start new session hint",
+      "sourceRef": "chat_session_lifecycle",
+      "state": "disabled",
+      "visible": true
+    },
+    {
+      "blockedReasonRef": "model_asset_boundary_absent",
+      "contentPolicy": "display label only; no catalog read, model path read, asset validation, or model selection persistence",
+      "enabled": false,
+      "hintId": "select_model_hint",
+      "label": "select model hint",
+      "sourceRef": "chat_model_selection_policy",
+      "state": "blocked",
+      "visible": true
+    },
+    {
+      "blockedReasonRef": "runtime_evidence_absent",
+      "contentPolicy": "display label only; no runtime check, log read, hardware probe, or provider call",
+      "enabled": false,
+      "hintId": "review_readiness_hint",
+      "label": "review readiness hint",
+      "sourceRef": "chat_readiness",
+      "state": "available_as_data",
+      "visible": true
+    },
+    {
+      "blockedReasonRef": "prompt_capture_blocked",
+      "contentPolicy": "display label only; no focus change, prompt read, prompt capture, or key event capture",
+      "enabled": false,
+      "hintId": "focus_composer_hint",
+      "label": "focus composer hint",
+      "sourceRef": "chat_composer",
+      "state": "disabled",
+      "visible": true
+    }
+  ],
+  "blockedReasons": [
+    {
+      "reasonId": "runtime_evidence_absent",
+      "requiredBefore": "assistant_response_display_enabled",
+      "state": "blocked",
+      "summary": "No reviewed local chat runtime evidence exists for enabling conversation output."
+    },
+    {
+      "reasonId": "model_asset_boundary_absent",
+      "requiredBefore": "model_picker_enabled",
+      "state": "not_configured",
+      "summary": "No reviewed model asset input, validation, or load boundary exists."
+    },
+    {
+      "reasonId": "session_store_not_configured",
+      "requiredBefore": "session_creation_enabled",
+      "state": "not_configured",
+      "summary": "No reviewed session store, retention, or title boundary is enabled."
+    },
+    {
+      "reasonId": "prompt_capture_blocked",
+      "requiredBefore": "composer_focus_or_send_enabled",
+      "state": "empty_not_captured",
+      "summary": "Prompt capture remains disabled by the composer and send-result boundaries."
+    },
+    {
+      "reasonId": "transcript_content_absent",
+      "requiredBefore": "message_list_rendered_from_store",
+      "state": "empty_not_captured",
+      "summary": "No prompt, response, message body, transcript, session title, or summary content exists in this fixture."
+    },
+    {
+      "reasonId": "action_execution_disabled",
+      "requiredBefore": "empty_state_affordances_enabled",
+      "state": "disabled",
+      "summary": "Empty-state hints are display-only and do not dispatch commands."
+    }
+  ],
+  "chatActionBarRef": "chat_action_bar_gemma3n_e4b_kv260_placeholder",
+  "chatComposerRef": "chat_composer_gemma3n_e4b_kv260_placeholder",
+  "chatModelStatusRef": "chat_model_status_gemma3n_e4b_kv260_placeholder",
+  "chatReadinessRef": "chat_readiness_gemma3n_e4b_kv260_placeholder",
+  "chatSessionIndexRef": "chat_session_index_gemma3n_e4b_kv260_placeholder",
+  "chatSurfaceLayoutRef": "chat_surface_layout_gemma3n_e4b_kv260_placeholder",
+  "displaySlots": [
+    {
+      "contentPolicy": "target labels only; no model asset, model path, tokenizer, runtime, or hardware evidence is included",
+      "displayRole": "status",
+      "enabled": true,
+      "label": "target banner",
+      "slotId": "target_banner",
+      "sourceRef": "chat_model_status",
+      "state": "target_selected",
+      "visible": true
+    },
+    {
+      "contentPolicy": "no prompt, response, message body, transcript text, session title, or summary is included",
+      "displayRole": "primary",
+      "enabled": true,
+      "label": "empty transcript notice",
+      "slotId": "empty_transcript_notice",
+      "sourceRef": "chat_message_list",
+      "state": "empty_not_captured",
+      "visible": true
+    },
+    {
+      "contentPolicy": "readiness labels only; no log, runtime output, hardware probe, or provider state is included",
+      "displayRole": "readiness",
+      "enabled": true,
+      "label": "readiness notice",
+      "slotId": "readiness_notice",
+      "sourceRef": "chat_readiness",
+      "state": "blocked",
+      "visible": true
+    },
+    {
+      "contentPolicy": "input affordance metadata only; no prompt capture, echo, validation, or persistence is included",
+      "displayRole": "input",
+      "enabled": true,
+      "label": "composer disabled notice",
+      "slotId": "composer_disabled_notice",
+      "sourceRef": "chat_composer",
+      "state": "disabled",
+      "visible": true
+    },
+    {
+      "contentPolicy": "local-only policy labels only; no provider configuration, network state, or fallback path is included",
+      "displayRole": "policy",
+      "enabled": true,
+      "label": "local-only notice",
+      "slotId": "local_only_notice",
+      "sourceRef": "chat_local_only_policy",
+      "state": "summary_only",
+      "visible": true
+    }
+  ],
+  "emptyStateId": "chat_empty_state_gemma3n_e4b_kv260_placeholder",
+  "emptyStatePolicy": {
+    "contentPolicy": "empty-state metadata only; no message body, transcript text, prompt text, response text, file path, model path, runtime log, or private path is included",
+    "externalDependencyPolicy": "no provider, network, hardware, pccx-lab, IDE, model asset, session store, or artifact dependency is used",
+    "hintPolicy": "disabled affordance hints only; no command ids, command dispatch, or action execution is included",
+    "messagePolicy": "static placeholder text only; no prompt, response, transcript, session title, summary, or generated content is read",
+    "renderMode": "future_local_chat_empty_state",
+    "sideEffectPolicy": "local_render_only",
+    "state": "available_as_data"
+  },
+  "emptyStateState": "available_as_data",
+  "fixtureVersion": "chat-empty-state.gemma3n-e4b-kv260.2026-05-05",
+  "handoffRefs": [
+    {
+      "fixturePath": "contracts/fixtures/chat-surface-layout.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_surface_layout",
+      "schemaVersion": "pccx.chatSurfaceLayout.v0",
+      "state": "placeholder",
+      "summary": "Surface layout defines the planned shell regions for the empty state."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-readiness.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_readiness",
+      "schemaVersion": "pccx.chatReadiness.v0",
+      "state": "blocked",
+      "summary": "Readiness metadata keeps model, runtime, and target checks blocked."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-model-status.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_model_status",
+      "schemaVersion": "pccx.chatModelStatus.v0",
+      "state": "blocked",
+      "summary": "Model status keeps descriptor, load, runtime, context, and response rows blocked."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-session-index.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_session_index",
+      "schemaVersion": "pccx.chatSessionIndex.v0",
+      "state": "empty_not_captured",
+      "summary": "Session index remains empty and does not read titles, summaries, or stores."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-composer.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_composer",
+      "schemaVersion": "pccx.chatComposer.v0",
+      "state": "blocked",
+      "summary": "Composer metadata keeps prompt capture and send disabled."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-message-list.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_message_list",
+      "schemaVersion": "pccx.chatMessageList.v0",
+      "state": "empty_not_captured",
+      "summary": "Message list remains empty without message bodies or transcript content."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-action-bar.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_action_bar",
+      "schemaVersion": "pccx.chatActionBar.v0",
+      "state": "disabled",
+      "summary": "Action-bar metadata keeps conversation controls disabled."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-local-only-policy.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_local_only_policy",
+      "schemaVersion": "pccx.chatLocalOnlyPolicy.v0",
+      "state": "summary_only",
+      "summary": "Local-only policy keeps provider, cloud, and fallback paths unavailable."
+    }
+  ],
+  "issueRefs": [
+    "pccxai/pccx-llm-launcher#9"
+  ],
+  "lastUpdatedSource": "pccx_launcher_issue_9_chat_empty_state_boundary_2026-05-05",
+  "limitations": [
+    "Data-only chat empty-state fixture; all displayed values are checked metadata for the planned local chat shell.",
+    "No prompt, response, transcript, message body, summary, session title, session store, configuration file, environment value, model path, tokenizer path, runtime log, private path, secret, or token is read.",
+    "No prompt capture, input acceptance, response generation, model asset read, model load, runtime start, target access, provider call, command dispatch, focus change, clipboard access, attachment read, telemetry, upload, or artifact write is performed.",
+    "No pccx-lab invocation, systemverilog-ide invocation, MCP server, LSP, compatibility promise, storage layer, runtime, model-loader, or hardware implementation is included."
+  ],
+  "modelState": "not_loaded",
+  "privacyState": "summary_only",
+  "promptState": "empty_not_captured",
+  "readinessState": "blocked",
+  "runtimeState": "not_started",
+  "safetyFlags": {
+    "actionExecution": false,
+    "attachmentReads": false,
+    "clipboardRead": false,
+    "clipboardWrite": false,
+    "cloudCalls": false,
+    "commandDispatch": false,
+    "compatibilityClaim": false,
+    "configRead": false,
+    "dataOnly": true,
+    "deterministic": true,
+    "emptyStateDisplayOnly": true,
+    "emptyStateTextOnly": true,
+    "environmentRead": false,
+    "executesPccxLab": false,
+    "executesSystemverilogIde": false,
+    "filePickerOpened": false,
+    "focusChanged": false,
+    "hardwareAccess": false,
+    "inputAccepted": false,
+    "keyboardCapture": false,
+    "kv260Access": false,
+    "localRenderOnly": true,
+    "lspImplemented": false,
+    "mcpServerImplemented": false,
+    "messageContentIncluded": false,
+    "modelAssetRead": false,
+    "modelExecution": false,
+    "modelLoadAttempted": false,
+    "modelLoaded": false,
+    "modelPathIncluded": false,
+    "networkCalls": false,
+    "privatePathsIncluded": false,
+    "promptCapture": false,
+    "promptContentIncluded": false,
+    "promptEchoed": false,
+    "promptRead": false,
+    "providerCalls": false,
+    "providerConfigRead": false,
+    "readOnly": true,
+    "readsArtifacts": false,
+    "readsSessionStore": false,
+    "responseContentIncluded": false,
+    "responseGenerated": false,
+    "runtimeExecution": false,
+    "runtimeOutputIncluded": false,
+    "runtimeStarted": false,
+    "secretsIncluded": false,
+    "sessionTitleIncluded": false,
+    "summaryIncluded": false,
+    "telemetry": false,
+    "transcriptContentIncluded": false,
+    "upload": false,
+    "writesArtifacts": false,
+    "writesSessionStore": false
+  },
+  "schemaVersion": "pccx.chatEmptyState.v0",
+  "sessionState": "inactive",
+  "surfaceState": "placeholder",
+  "targetBoard": "xilinx_kria_kv260",
+  "targetDevice": "kv260",
+  "targetModel": "gemma3n-e4b",
+  "transcriptState": "empty_not_captured"
+}

--- a/docs/STANDALONE_CHAT_SESSION_CONTRACT.md
+++ b/docs/STANDALONE_CHAT_SESSION_CONTRACT.md
@@ -15,6 +15,7 @@ The implementation lives in:
 - `contracts/chat_model_load_request_contract.py`
 - `contracts/chat_session_lifecycle_contract.py`
 - `contracts/chat_surface_layout_contract.py`
+- `contracts/chat_empty_state_contract.py`
 - `contracts/chat_local_only_policy_contract.py`
 - `contracts/chat_preferences_contract.py`
 - `contracts/chat_session_index_contract.py`
@@ -37,6 +38,7 @@ The implementation lives in:
 - `contracts/fixtures/chat-model-load-request.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-session-lifecycle.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-surface-layout.gemma3n-e4b-kv260-placeholder.json`
+- `contracts/fixtures/chat-empty-state.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-local-only-policy.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-preferences.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-session-index.gemma3n-e4b-kv260-placeholder.json`
@@ -59,6 +61,7 @@ The implementation lives in:
 - `scripts/chat-model-load-request-stub.sh`
 - `scripts/chat-session-lifecycle-stub.sh`
 - `scripts/chat-surface-layout-stub.sh`
+- `scripts/chat-empty-state-stub.sh`
 - `scripts/chat-local-only-policy-stub.sh`
 - `scripts/chat-preferences-stub.sh`
 - `scripts/chat-session-index-stub.sh`
@@ -82,6 +85,7 @@ The implementation lives in:
 - `scripts/tests/chat_model_load_request_contract_test.py`
 - `scripts/tests/chat_session_lifecycle_contract_test.py`
 - `scripts/tests/chat_surface_layout_contract_test.py`
+- `scripts/tests/chat_empty_state_contract_test.py`
 - `scripts/tests/chat_local_only_policy_contract_test.py`
 - `scripts/tests/chat_preferences_contract_test.py`
 - `scripts/tests/chat_session_index_contract_test.py`
@@ -103,6 +107,7 @@ The implementation lives in:
 - `scripts/tests/status-chat-context-policy.sh`
 - `scripts/tests/status-chat-model-load-request.sh`
 - `scripts/tests/status-chat-surface-layout.sh`
+- `scripts/tests/status-chat-empty-state.sh`
 - `scripts/tests/status-chat-local-only-policy.sh`
 - `scripts/tests/status-chat-preferences.sh`
 - `scripts/tests/status-chat-session-index.sh`
@@ -138,6 +143,8 @@ The chat/session contract records:
   clear, and export actions
 - planned shell regions and navigation items for the blocked chat
   surface layout
+- static empty-state display slots and disabled hints for the blocked
+  chat surface without command dispatch or action execution
 - local-only policy metadata that keeps cloud/provider/network fallback
   paths disabled or not used
 - planned preferences panels for model/target display, privacy,
@@ -265,6 +272,23 @@ and audit footer. The fixture does not implement an app shell, read
 prompt/response/transcript/session-store content, focus the composer,
 start runtime code, load a model, touch hardware, call providers,
 invoke pccx-lab, or write artifacts.
+
+The chat empty-state fixture records static placeholder display slots
+and disabled hints for the planned standalone chat UI:
+
+```bash
+bash scripts/chat-empty-state-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/status-stub.sh --include-chat-empty-state
+```
+
+It reports target, empty transcript, readiness, disabled composer, and
+local-only display slots plus disabled hints for future session, model,
+readiness, and composer affordances. The fixture does not read prompts,
+responses, transcripts, session stores, model paths, configuration,
+environment values, runtime logs, private paths, or artifacts, and it
+does not accept input, dispatch commands, change focus, load models,
+start runtimes, access a target, call providers, invoke pccx-lab, or
+write artifacts.
 
 The chat local-only policy fixture records the cloud/provider/network
 dependency boundary for the planned standalone chat UI:

--- a/scripts/chat-empty-state-stub.sh
+++ b/scripts/chat-empty-state-stub.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+# Print the data-only chat empty-state contract.
+
+set -eu
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+
+python3 "$ROOT_DIR/contracts/chat_empty_state_contract.py" "$@"

--- a/scripts/status-stub.sh
+++ b/scripts/status-stub.sh
@@ -16,6 +16,9 @@
 # Chat surface layout/chrome plan (explicit opt-in, read-only local data):
 #   --include-chat-surface-layout
 #
+# Chat empty-state display boundary (explicit opt-in, read-only local data):
+#   --include-chat-empty-state
+#
 # Chat local-only/cloud-block policy (explicit opt-in, read-only local data):
 #   --include-chat-local-only-policy
 #
@@ -95,6 +98,7 @@ INCLUDE_RUNTIME_READINESS="0"
 INCLUDE_DEVICE_SESSION="0"
 INCLUDE_CHAT_SESSION="0"
 INCLUDE_CHAT_SURFACE_LAYOUT="0"
+INCLUDE_CHAT_EMPTY_STATE="0"
 INCLUDE_CHAT_LOCAL_ONLY_POLICY="0"
 INCLUDE_CHAT_PREFERENCES="0"
 INCLUDE_CHAT_SESSION_INDEX="0"
@@ -1067,6 +1071,126 @@ print(
 
     HEAD "chat surface layout"
     printf '%s\n' "$CHAT_SURFACE_LAYOUT_SUMMARY"
+}
+
+print_chat_empty_state_summary() {
+    SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+    ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+    CHAT_EMPTY_STATE_STUB="$ROOT_DIR/scripts/chat-empty-state-stub.sh"
+
+    if [ ! -f "$CHAT_EMPTY_STATE_STUB" ]; then
+        ERROR "chat empty-state stub not found: $CHAT_EMPTY_STATE_STUB"
+        return 1
+    fi
+
+    if ! CHAT_EMPTY_STATE_JSON="$(bash "$CHAT_EMPTY_STATE_STUB" --model gemma3n-e4b --target kv260 2>&1)"; then
+        ERROR "chat empty-state stub failed"
+        printf '%s\n' "$CHAT_EMPTY_STATE_JSON" >&2
+        return 1
+    fi
+
+    if ! CHAT_EMPTY_STATE_SUMMARY="$(
+        printf '%s\n' "$CHAT_EMPTY_STATE_JSON" | python3 -c '
+import json
+import sys
+
+data = json.load(sys.stdin)
+flags = data["safetyFlags"]
+policy = data["emptyStatePolicy"]
+
+def b(value):
+    return "true" if value else "false"
+
+slots = " ".join(
+    "{}={}:{}".format(slot["slotId"], slot["state"], b(slot["enabled"]))
+    for slot in data["displaySlots"]
+)
+hints = " ".join(
+    "{}={}:{}".format(hint["hintId"], hint["state"], b(hint["enabled"]))
+    for hint in data["affordanceHints"]
+)
+blocked = " ".join(
+    "{}={}".format(reason["reasonId"], reason["state"])
+    for reason in data["blockedReasons"]
+)
+
+print("[INFO]  source     : scripts/chat-empty-state-stub.sh --model gemma3n-e4b --target kv260")
+print("[INFO]  boundary   : read-only data; no prompt/response/transcript/session-store/model/runtime/hardware/lab/IDE execution")
+print("[INFO]  target     : {}".format(data["targetDevice"]))
+print("[INFO]  model      : {}".format(data["targetModel"]))
+print("[INFO]  empty      : {}".format(data["emptyStateState"]))
+print("[INFO]  surface    : {}".format(data["surfaceState"]))
+print("[INFO]  session    : {}".format(data["sessionState"]))
+print("[INFO]  modelstate : {}".format(data["modelState"]))
+print("[INFO]  readiness  : {}".format(data["readinessState"]))
+print("[INFO]  prompt     : {}".format(data["promptState"]))
+print("[INFO]  transcript : {}".format(data["transcriptState"]))
+print("[INFO]  actions    : {}".format(data["actionState"]))
+print("[INFO]  runtime    : {}".format(data["runtimeState"]))
+print("[INFO]  privacy    : {}".format(data["privacyState"]))
+print(
+    "[INFO]  empty-policy : {} renderMode={} sideEffectPolicy={}".format(
+        policy["state"],
+        policy["renderMode"],
+        policy["sideEffectPolicy"],
+    )
+)
+print("[INFO]  slots      : {}".format(slots))
+print("[INFO]  hints      : {}".format(hints))
+print("[INFO]  blocked    : {}".format(blocked))
+print(
+    "[INFO]  flags      : readOnly={} dataOnly={} deterministic={} "
+    "emptyStateDisplayOnly={} emptyStateTextOnly={} localRenderOnly={} "
+    "promptCapture={} promptRead={} promptContentIncluded={} "
+    "inputAccepted={} responseContentIncluded={} responseGenerated={} "
+    "transcriptContentIncluded={} messageContentIncluded={} "
+    "sessionTitleIncluded={} summaryIncluded={} readsSessionStore={} "
+    "writesSessionStore={} actionExecution={} commandDispatch={} "
+    "modelAssetRead={} modelLoadAttempted={} modelExecution={} "
+    "runtimeExecution={} kv260Access={} hardwareAccess={} networkCalls={} "
+    "providerCalls={} readsArtifacts={} writesArtifacts={} "
+    "executesPccxLab={}".format(
+        b(flags["readOnly"]),
+        b(flags["dataOnly"]),
+        b(flags["deterministic"]),
+        b(flags["emptyStateDisplayOnly"]),
+        b(flags["emptyStateTextOnly"]),
+        b(flags["localRenderOnly"]),
+        b(flags["promptCapture"]),
+        b(flags["promptRead"]),
+        b(flags["promptContentIncluded"]),
+        b(flags["inputAccepted"]),
+        b(flags["responseContentIncluded"]),
+        b(flags["responseGenerated"]),
+        b(flags["transcriptContentIncluded"]),
+        b(flags["messageContentIncluded"]),
+        b(flags["sessionTitleIncluded"]),
+        b(flags["summaryIncluded"]),
+        b(flags["readsSessionStore"]),
+        b(flags["writesSessionStore"]),
+        b(flags["actionExecution"]),
+        b(flags["commandDispatch"]),
+        b(flags["modelAssetRead"]),
+        b(flags["modelLoadAttempted"]),
+        b(flags["modelExecution"]),
+        b(flags["runtimeExecution"]),
+        b(flags["kv260Access"]),
+        b(flags["hardwareAccess"]),
+        b(flags["networkCalls"]),
+        b(flags["providerCalls"]),
+        b(flags["readsArtifacts"]),
+        b(flags["writesArtifacts"]),
+        b(flags["executesPccxLab"]),
+    )
+)
+'
+    )"; then
+        ERROR "chat empty-state JSON could not be summarized"
+        return 1
+    fi
+
+    HEAD "chat empty state"
+    printf '%s\n' "$CHAT_EMPTY_STATE_SUMMARY"
 }
 
 print_chat_session_index_summary() {
@@ -2767,6 +2891,10 @@ while [ $# -gt 0 ]; do
             INCLUDE_CHAT_SURFACE_LAYOUT="1"
             shift
             ;;
+        --include-chat-empty-state)
+            INCLUDE_CHAT_EMPTY_STATE="1"
+            shift
+            ;;
         --include-chat-local-only-policy)
             INCLUDE_CHAT_LOCAL_ONLY_POLICY="1"
             shift
@@ -2862,8 +2990,8 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-if [ -n "$BACKEND" ] && { [ "$INCLUDE_RUNTIME_READINESS" = "1" ] || [ "$INCLUDE_DEVICE_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SURFACE_LAYOUT" = "1" ] || [ "$INCLUDE_CHAT_LOCAL_ONLY_POLICY" = "1" ] || [ "$INCLUDE_CHAT_PREFERENCES" = "1" ] || [ "$INCLUDE_CHAT_SESSION_INDEX" = "1" ] || [ "$INCLUDE_CHAT_SESSION_STORE_POLICY" = "1" ] || [ "$INCLUDE_CHAT_SESSION_TITLE_POLICY" = "1" ] || [ "$INCLUDE_CHAT_MODEL_STATUS" = "1" ] || [ "$INCLUDE_CHAT_MODEL_SELECTION_POLICY" = "1" ] || [ "$INCLUDE_CHAT_CONTEXT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_MODEL_LOAD_REQUEST" = "1" ] || [ "$INCLUDE_CHAT_READINESS" = "1" ] || [ "$INCLUDE_CHAT_COMPOSER" = "1" ] || [ "$INCLUDE_CHAT_SEND_RESULT" = "1" ] || [ "$INCLUDE_CHAT_TRANSCRIPT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_AUDIT_EVENT" = "1" ] || [ "$INCLUDE_CHAT_ERROR_TAXONOMY" = "1" ] || [ "$INCLUDE_CHAT_RESPONSE_STREAM" = "1" ] || [ "$INCLUDE_CHAT_MESSAGE_LIST" = "1" ] || [ "$INCLUDE_CHAT_ACTION_BAR" = "1" ] || [ "$INCLUDE_CHAT_ATTACHMENT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_SHORTCUT_MAP" = "1" ]; }; then
-    ERROR "--include-runtime-readiness, --include-device-session, --include-chat-session, --include-chat-surface-layout, --include-chat-local-only-policy, --include-chat-preferences, --include-chat-session-index, --include-chat-session-store-policy, --include-chat-session-title-policy, --include-chat-model-status, --include-chat-model-selection-policy, --include-chat-context-policy, --include-chat-model-load-request, --include-chat-readiness, --include-chat-composer, --include-chat-send-result, --include-chat-transcript-policy, --include-chat-audit-event, --include-chat-error-taxonomy, --include-chat-response-stream, --include-chat-message-list, --include-chat-action-bar, --include-chat-attachment-policy, and --include-chat-shortcut-map are only supported in local scaffold mode"
+if [ -n "$BACKEND" ] && { [ "$INCLUDE_RUNTIME_READINESS" = "1" ] || [ "$INCLUDE_DEVICE_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SURFACE_LAYOUT" = "1" ] || [ "$INCLUDE_CHAT_EMPTY_STATE" = "1" ] || [ "$INCLUDE_CHAT_LOCAL_ONLY_POLICY" = "1" ] || [ "$INCLUDE_CHAT_PREFERENCES" = "1" ] || [ "$INCLUDE_CHAT_SESSION_INDEX" = "1" ] || [ "$INCLUDE_CHAT_SESSION_STORE_POLICY" = "1" ] || [ "$INCLUDE_CHAT_SESSION_TITLE_POLICY" = "1" ] || [ "$INCLUDE_CHAT_MODEL_STATUS" = "1" ] || [ "$INCLUDE_CHAT_MODEL_SELECTION_POLICY" = "1" ] || [ "$INCLUDE_CHAT_CONTEXT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_MODEL_LOAD_REQUEST" = "1" ] || [ "$INCLUDE_CHAT_READINESS" = "1" ] || [ "$INCLUDE_CHAT_COMPOSER" = "1" ] || [ "$INCLUDE_CHAT_SEND_RESULT" = "1" ] || [ "$INCLUDE_CHAT_TRANSCRIPT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_AUDIT_EVENT" = "1" ] || [ "$INCLUDE_CHAT_ERROR_TAXONOMY" = "1" ] || [ "$INCLUDE_CHAT_RESPONSE_STREAM" = "1" ] || [ "$INCLUDE_CHAT_MESSAGE_LIST" = "1" ] || [ "$INCLUDE_CHAT_ACTION_BAR" = "1" ] || [ "$INCLUDE_CHAT_ATTACHMENT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_SHORTCUT_MAP" = "1" ]; }; then
+    ERROR "--include-runtime-readiness, --include-device-session, --include-chat-session, --include-chat-surface-layout, --include-chat-empty-state, --include-chat-local-only-policy, --include-chat-preferences, --include-chat-session-index, --include-chat-session-store-policy, --include-chat-session-title-policy, --include-chat-model-status, --include-chat-model-selection-policy, --include-chat-context-policy, --include-chat-model-load-request, --include-chat-readiness, --include-chat-composer, --include-chat-send-result, --include-chat-transcript-policy, --include-chat-audit-event, --include-chat-error-taxonomy, --include-chat-response-stream, --include-chat-message-list, --include-chat-action-bar, --include-chat-attachment-policy, and --include-chat-shortcut-map are only supported in local scaffold mode"
     exit 1
 fi
 
@@ -2880,6 +3008,7 @@ if [ -z "$BACKEND" ]; then
     NOTE "device/session: opt-in via --include-device-session (read-only panel data)"
     NOTE "chat/session  : opt-in via --include-chat-session (read-only blocked chat and lifecycle data)"
     NOTE "chat layout   : opt-in via --include-chat-surface-layout (read-only surface layout data)"
+    NOTE "chat empty    : opt-in via --include-chat-empty-state (read-only empty-state data)"
     NOTE "chat local    : opt-in via --include-chat-local-only-policy (read-only local-only policy data)"
     NOTE "chat prefs    : opt-in via --include-chat-preferences (read-only preferences data)"
     NOTE "chat index    : opt-in via --include-chat-session-index (read-only empty session index data)"
@@ -2946,6 +3075,12 @@ if [ -z "$BACKEND" ]; then
 
     if [ "$INCLUDE_CHAT_SURFACE_LAYOUT" = "1" ]; then
         if ! print_chat_surface_layout_summary; then
+            exit 1
+        fi
+    fi
+
+    if [ "$INCLUDE_CHAT_EMPTY_STATE" = "1" ]; then
+        if ! print_chat_empty_state_summary; then
             exit 1
         fi
     fi

--- a/scripts/tests/chat_empty_state_contract_test.py
+++ b/scripts/tests/chat_empty_state_contract_test.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Fixture tests for the standalone chat empty-state contract."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "contracts" / "chat_empty_state_contract.py"
+FIXTURE_PATH = (
+    ROOT
+    / "contracts"
+    / "fixtures"
+    / "chat-empty-state.gemma3n-e4b-kv260-placeholder.json"
+)
+SCRIPT_PATH = ROOT / "scripts" / "chat-empty-state-stub.sh"
+STATUS_TEST_PATH = ROOT / "scripts" / "tests" / "status-chat-empty-state.sh"
+DOC_PATH = ROOT / "docs" / "STANDALONE_CHAT_SESSION_CONTRACT.md"
+README_PATH = ROOT / "README.md"
+CI_PATH = ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location(
+        "chat_empty_state_contract",
+        MODULE_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def iter_state_values(value):
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            if (
+                key == "state"
+                or key.endswith("State")
+                or key.endswith("Status")
+            ) and isinstance(nested, str):
+                yield nested
+            yield from iter_state_values(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            yield from iter_state_values(nested)
+
+
+def iter_keys(value):
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            yield key
+            yield from iter_keys(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            yield from iter_keys(nested)
+
+
+def assert_no_private_or_generated_data(text: str) -> None:
+    forbidden_patterns = [
+        r"/home/[^\s\"']+",
+        r"/Users/[^\s\"']+",
+        r"[A-Za-z]:\\Users\\",
+        r"\b(?:api[_-]?key|authorization|bearer|client[_-]?secret|password|private[_-]?key|secret|token)\b\s*[:=]",
+        r"\.(?:gguf|safetensors|ckpt|pt|pth|onnx)\b",
+        r"(?:weights|model_weights|model-cache)/(?:[^\"'\s]+)",
+        r"(?:raw[_-]?full[_-]?logs|hardware[_-]?dump|generated[_-]?blob)\s*[:=]",
+    ]
+    for pattern in forbidden_patterns:
+        assert not re.search(pattern, text, re.IGNORECASE), pattern
+
+
+def assert_no_runtime_implementation_terms(source: str) -> None:
+    forbidden = [
+        "subprocess",
+        "os.system",
+        "popen",
+        "socket",
+        "urllib",
+        "requests",
+        "http.client",
+        "openai",
+        "anthropic",
+        "gem" + "ini",
+        "modelcontextprotocol",
+        "websocket",
+        "xmutil",
+        "xrt-smi",
+        "lsusb",
+        "dmesg",
+    ]
+    lowered = source.lower()
+    for term in forbidden:
+        assert term not in lowered, term
+
+
+def assert_no_provider_configs(value) -> None:
+    forbidden_keys = {
+        "apiKey",
+        "accessToken",
+        "refreshToken",
+        "authorization",
+        "bearerToken",
+        "provider",
+        "providers",
+        "providerConfig",
+        "providerConfigs",
+    }
+    for key in iter_keys(value):
+        assert key not in forbidden_keys, key
+
+
+def assert_no_unsupported_claims(text: str) -> None:
+    literal_claims = [
+        "production" + "-ready",
+        "marketplace" + "-ready",
+        "stable " + "API",
+        "stable " + "ABI",
+        "KV260 inference " + "works",
+        "Gemma 3N E4B " + "runs on KV260",
+        "20 tok/s " + "achieved",
+        "timing " + "closed",
+        "bitstream " + "ready",
+        "launcher executes " + "pccx-lab",
+        "IDE controls " + "launcher",
+        "AI provider integration " + "is live",
+    ]
+    lowered = text.lower()
+    for claim in literal_claims:
+        assert claim.lower() not in lowered, claim
+
+
+def test_chat_empty_state_matches_fixture_and_is_deterministic() -> None:
+    module = load_module()
+    generated = module.create_gemma3n_e4b_kv260_chat_empty_state()
+    fixture = json.loads(read_text(FIXTURE_PATH))
+
+    assert generated == fixture
+    assert module.chat_empty_state_json(generated) == (
+        module.chat_empty_state_json(generated)
+    )
+    assert module.chat_empty_state_json(generated).endswith("\n")
+    assert json.loads(module.chat_empty_state_json(generated)) == fixture
+
+
+def test_cli_stub_outputs_deterministic_json() -> None:
+    fixture = json.loads(read_text(FIXTURE_PATH))
+    command = [
+        "bash",
+        str(SCRIPT_PATH),
+        "--model",
+        "gemma3n-e4b",
+        "--target",
+        "kv260",
+    ]
+    first = subprocess.run(command, check=True, capture_output=True, text=True)
+    second = subprocess.run(command, check=True, capture_output=True, text=True)
+
+    assert first.stderr == ""
+    assert first.stdout == second.stdout
+    assert first.stdout.endswith("\n")
+    assert json.loads(first.stdout) == fixture
+
+
+def test_required_fields_and_allowed_states() -> None:
+    module = load_module()
+    state = module.create_gemma3n_e4b_kv260_chat_empty_state()
+    allowed = set(module.CHAT_EMPTY_STATE_VALUES)
+
+    assert tuple(state.keys()) == module.CHAT_EMPTY_STATE_FIELDS
+    assert state["schemaVersion"] == "pccx.chatEmptyState.v0"
+    assert tuple(state["emptyStatePolicy"].keys()) == (
+        module.EMPTY_STATE_POLICY_FIELDS
+    )
+
+    states = list(iter_state_values(state))
+    assert states
+    for value in states:
+        assert value in allowed, value
+
+    for slot in state["displaySlots"]:
+        assert tuple(slot.keys()) == module.DISPLAY_SLOT_FIELDS
+    for hint in state["affordanceHints"]:
+        assert tuple(hint.keys()) == module.AFFORDANCE_HINT_FIELDS
+    for reason in state["blockedReasons"]:
+        assert tuple(reason.keys()) == module.BLOCKED_REASON_FIELDS
+    for ref in state["handoffRefs"]:
+        assert tuple(ref.keys()) == module.HANDOFF_REF_FIELDS
+
+
+def test_chat_empty_state_keeps_surface_display_only() -> None:
+    state = load_module().create_gemma3n_e4b_kv260_chat_empty_state()
+    policy = state["emptyStatePolicy"]
+    flags = state["safetyFlags"]
+    slots = {slot["slotId"]: slot for slot in state["displaySlots"]}
+    hints = {hint["hintId"]: hint for hint in state["affordanceHints"]}
+    reasons = {reason["reasonId"]: reason for reason in state["blockedReasons"]}
+    refs = {ref["refId"]: ref for ref in state["handoffRefs"]}
+
+    assert state["emptyStateState"] == "available_as_data"
+    assert state["surfaceState"] == "placeholder"
+    assert state["sessionState"] == "inactive"
+    assert state["modelState"] == "not_loaded"
+    assert state["readinessState"] == "blocked"
+    assert state["promptState"] == "empty_not_captured"
+    assert state["transcriptState"] == "empty_not_captured"
+    assert state["actionState"] == "disabled"
+    assert state["runtimeState"] == "not_started"
+    assert policy["sideEffectPolicy"] == "local_render_only"
+
+    assert set(slots) == {
+        "target_banner",
+        "empty_transcript_notice",
+        "readiness_notice",
+        "composer_disabled_notice",
+        "local_only_notice",
+    }
+    assert slots["target_banner"]["state"] == "target_selected"
+    assert slots["empty_transcript_notice"]["state"] == "empty_not_captured"
+    assert slots["readiness_notice"]["state"] == "blocked"
+    assert slots["composer_disabled_notice"]["state"] == "disabled"
+    assert slots["local_only_notice"]["state"] == "summary_only"
+    for slot in slots.values():
+        assert slot["visible"] is True
+        assert slot["enabled"] is True
+
+    assert hints["start_new_session_hint"]["state"] == "disabled"
+    assert hints["select_model_hint"]["state"] == "blocked"
+    assert hints["review_readiness_hint"]["state"] == "available_as_data"
+    assert hints["focus_composer_hint"]["state"] == "disabled"
+    for hint in hints.values():
+        assert hint["enabled"] is False
+
+    assert reasons["runtime_evidence_absent"]["state"] == "blocked"
+    assert reasons["model_asset_boundary_absent"]["state"] == "not_configured"
+    assert reasons["session_store_not_configured"]["state"] == "not_configured"
+    assert reasons["prompt_capture_blocked"]["state"] == "empty_not_captured"
+    assert reasons["transcript_content_absent"]["state"] == "empty_not_captured"
+    assert reasons["action_execution_disabled"]["state"] == "disabled"
+    assert refs["chat_surface_layout"]["state"] == "placeholder"
+    assert refs["chat_readiness"]["state"] == "blocked"
+    assert refs["chat_composer"]["state"] == "blocked"
+    assert refs["chat_action_bar"]["state"] == "disabled"
+
+    true_flags = {
+        "dataOnly",
+        "readOnly",
+        "deterministic",
+        "emptyStateDisplayOnly",
+        "emptyStateTextOnly",
+        "localRenderOnly",
+    }
+    false_flags = set(flags) - true_flags
+    for flag in true_flags:
+        assert flags[flag] is True, flag
+    for flag in false_flags:
+        assert flags[flag] is False, flag
+
+
+def test_chat_empty_state_docs_and_ci_are_wired() -> None:
+    doc = read_text(DOC_PATH)
+    readme = read_text(README_PATH)
+    status_test = read_text(STATUS_TEST_PATH)
+    ci = read_text(CI_PATH)
+
+    assert "contracts/chat_empty_state_contract.py" in doc
+    assert (
+        "contracts/fixtures/chat-empty-state.gemma3n-e4b-kv260-placeholder.json"
+        in doc
+    )
+    assert "scripts/chat-empty-state-stub.sh" in doc
+    assert "scripts/tests/chat_empty_state_contract_test.py" in doc
+    assert "scripts/tests/status-chat-empty-state.sh" in doc
+    assert "chat-empty-state-stub.sh" in readme
+    assert "--include-chat-empty-state" in readme
+    assert "chat_empty_state_contract_test.py" in ci
+    assert "status-chat-empty-state.sh" in ci
+    assert "--include-chat-empty-state" in status_test
+    assert "no prompt/response/transcript/session-store" in status_test
+
+
+def test_contract_does_not_read_runtime_provider_hardware_or_private_data() -> None:
+    source = read_text(MODULE_PATH)
+    fixture_text = read_text(FIXTURE_PATH)
+    fixture = json.loads(fixture_text)
+    combined = (
+        source
+        + fixture_text
+        + read_text(SCRIPT_PATH)
+        + read_text(STATUS_TEST_PATH)
+        + read_text(DOC_PATH)
+        + read_text(README_PATH)
+    )
+
+    assert_no_runtime_implementation_terms(source)
+    assert_no_private_or_generated_data(fixture_text)
+    assert_no_provider_configs(fixture)
+    assert_no_unsupported_claims(combined)
+
+    forbidden_fixture_keys = [
+        "promptText",
+        "responseText",
+        "transcriptText",
+        "messageBody",
+        "summaryText",
+        "sessionTitle",
+        "commandId",
+        "launcherAction",
+        "userAction",
+        "modelPath",
+        "tokenizerPath",
+        "runtimePayload",
+        "runtimeLog",
+        "privatePath",
+    ]
+    for key in forbidden_fixture_keys:
+        assert f'"{key}"' not in fixture_text, key
+
+
+if __name__ == "__main__":
+    test_chat_empty_state_matches_fixture_and_is_deterministic()
+    test_cli_stub_outputs_deterministic_json()
+    test_required_fields_and_allowed_states()
+    test_chat_empty_state_keeps_surface_display_only()
+    test_chat_empty_state_docs_and_ci_are_wired()
+    test_contract_does_not_read_runtime_provider_hardware_or_private_data()
+    print("chat empty-state contract tests passed")

--- a/scripts/tests/status-chat-empty-state.sh
+++ b/scripts/tests/status-chat-empty-state.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+# scripts/tests/status-chat-empty-state.sh - status empty-state tests.
+#
+# Usage: bash scripts/tests/status-chat-empty-state.sh [path/to/status-stub.sh]
+
+set -eu
+
+PASS() { printf '[PASS]  %s\n' "$*"; }
+FAIL() { printf '[FAIL]  %s\n' "$*" >&2; }
+HEAD() { printf '\n=== %s ===\n' "$*"; }
+
+STUB="${1:-scripts/status-stub.sh}"
+
+if [ ! -x "$STUB" ]; then
+    chmod +x "$STUB"
+fi
+
+contains() {
+    case "$1" in
+        *"$2"*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+require_contains() {
+    local output="$1"
+    local expected="$2"
+    if ! contains "$output" "$expected"; then
+        FAIL "expected output to contain: $expected"
+        printf '%s\n' "$output" >&2
+        exit 1
+    fi
+}
+
+require_not_contains() {
+    local output="$1"
+    local forbidden="$2"
+    if contains "$output" "$forbidden"; then
+        FAIL "output contained forbidden text: $forbidden"
+        printf '%s\n' "$output" >&2
+        exit 1
+    fi
+}
+
+HEAD "1: status can include chat empty state"
+OUTPUT="$("$STUB" --include-chat-empty-state)"
+require_contains "$OUTPUT" "=== chat empty state ==="
+require_contains "$OUTPUT" "source     : scripts/chat-empty-state-stub.sh --model gemma3n-e4b --target kv260"
+require_contains "$OUTPUT" "boundary   : read-only data; no prompt/response/transcript/session-store/model/runtime/hardware/lab/IDE execution"
+require_contains "$OUTPUT" "target     : kv260"
+require_contains "$OUTPUT" "model      : gemma3n-e4b"
+require_contains "$OUTPUT" "empty      : available_as_data"
+require_contains "$OUTPUT" "surface    : placeholder"
+require_contains "$OUTPUT" "session    : inactive"
+require_contains "$OUTPUT" "modelstate : not_loaded"
+require_contains "$OUTPUT" "readiness  : blocked"
+require_contains "$OUTPUT" "prompt     : empty_not_captured"
+require_contains "$OUTPUT" "transcript : empty_not_captured"
+require_contains "$OUTPUT" "actions    : disabled"
+require_contains "$OUTPUT" "runtime    : not_started"
+require_contains "$OUTPUT" "privacy    : summary_only"
+PASS "chat empty-state section is present and conservative"
+
+HEAD "2: slots and hints stay display-only"
+require_contains "$OUTPUT" "empty-policy : available_as_data renderMode=future_local_chat_empty_state sideEffectPolicy=local_render_only"
+require_contains "$OUTPUT" "slots      : target_banner=target_selected:true"
+require_contains "$OUTPUT" "empty_transcript_notice=empty_not_captured:true"
+require_contains "$OUTPUT" "readiness_notice=blocked:true"
+require_contains "$OUTPUT" "composer_disabled_notice=disabled:true"
+require_contains "$OUTPUT" "local_only_notice=summary_only:true"
+require_contains "$OUTPUT" "hints      : start_new_session_hint=disabled:false"
+require_contains "$OUTPUT" "select_model_hint=blocked:false"
+require_contains "$OUTPUT" "review_readiness_hint=available_as_data:false"
+require_contains "$OUTPUT" "focus_composer_hint=disabled:false"
+require_contains "$OUTPUT" "blocked    : runtime_evidence_absent=blocked"
+require_contains "$OUTPUT" "model_asset_boundary_absent=not_configured"
+require_contains "$OUTPUT" "session_store_not_configured=not_configured"
+require_contains "$OUTPUT" "prompt_capture_blocked=empty_not_captured"
+require_contains "$OUTPUT" "action_execution_disabled=disabled"
+PASS "empty-state metadata is summarized without actions or content"
+
+HEAD "3: safety flags stay read-only and non-executing"
+require_contains "$OUTPUT" "readOnly=true"
+require_contains "$OUTPUT" "dataOnly=true"
+require_contains "$OUTPUT" "deterministic=true"
+require_contains "$OUTPUT" "emptyStateDisplayOnly=true"
+require_contains "$OUTPUT" "emptyStateTextOnly=true"
+require_contains "$OUTPUT" "localRenderOnly=true"
+require_contains "$OUTPUT" "promptCapture=false"
+require_contains "$OUTPUT" "promptRead=false"
+require_contains "$OUTPUT" "promptContentIncluded=false"
+require_contains "$OUTPUT" "inputAccepted=false"
+require_contains "$OUTPUT" "responseContentIncluded=false"
+require_contains "$OUTPUT" "responseGenerated=false"
+require_contains "$OUTPUT" "transcriptContentIncluded=false"
+require_contains "$OUTPUT" "messageContentIncluded=false"
+require_contains "$OUTPUT" "sessionTitleIncluded=false"
+require_contains "$OUTPUT" "summaryIncluded=false"
+require_contains "$OUTPUT" "readsSessionStore=false"
+require_contains "$OUTPUT" "writesSessionStore=false"
+require_contains "$OUTPUT" "actionExecution=false"
+require_contains "$OUTPUT" "commandDispatch=false"
+require_contains "$OUTPUT" "modelAssetRead=false"
+require_contains "$OUTPUT" "modelLoadAttempted=false"
+require_contains "$OUTPUT" "modelExecution=false"
+require_contains "$OUTPUT" "runtimeExecution=false"
+require_contains "$OUTPUT" "kv260Access=false"
+require_contains "$OUTPUT" "hardwareAccess=false"
+require_contains "$OUTPUT" "networkCalls=false"
+require_contains "$OUTPUT" "providerCalls=false"
+require_contains "$OUTPUT" "readsArtifacts=false"
+require_contains "$OUTPUT" "writesArtifacts=false"
+require_contains "$OUTPUT" "executesPccxLab=false"
+PASS "empty-state execution, persistence, and content flags remain false"
+
+HEAD "4: output is deterministic"
+OUTPUT_AGAIN="$("$STUB" --include-chat-empty-state)"
+if [ "$OUTPUT" != "$OUTPUT_AGAIN" ]; then
+    FAIL "status chat empty-state output changed between runs"
+    exit 1
+fi
+PASS "status chat empty-state output is deterministic"
+
+HEAD "5: empty-state option does not combine with pccx-lab backend"
+if "$STUB" --include-chat-empty-state --backend pccx-lab >/dev/null 2>&1; then
+    FAIL "expected combined chat-empty-state/backend mode to fail"
+    exit 1
+fi
+PASS "chat empty state remains separate from backend execution"
+
+HEAD "6: output avoids known overclaims and chat content"
+FORBIDDEN_PREFIX="KV260 inference"
+FORBIDDEN_CLAIM="${FORBIDDEN_PREFIX} works"
+require_not_contains "$OUTPUT" "$FORBIDDEN_CLAIM"
+THROUGHPUT_PREFIX="20 tok/s"
+THROUGHPUT_CLAIM="${THROUGHPUT_PREFIX} achieved"
+require_not_contains "$OUTPUT" "$THROUGHPUT_CLAIM"
+require_not_contains "$OUTPUT" "hello"
+require_not_contains "$OUTPUT" "assistant response:"
+require_not_contains "$OUTPUT" "session title:"
+PASS "no empty-state overclaim or chat content in status output"
+
+printf '\n[DONE]  all status-chat-empty-state tests passed\n'


### PR DESCRIPTION
## Summary
- add a checked `pccx.chatEmptyState.v0` fixture for display-only standalone chat empty-state metadata
- wire the new stub into status output, docs, README, and CI coverage
- keep prompt, response, transcript, session store, model asset, runtime, provider, target, pccx-lab, IDE, command dispatch, and artifact paths disabled or absent

Refs #9

## Validation
- `python3 scripts/tests/chat_empty_state_contract_test.py`
- `bash scripts/tests/status-chat-empty-state.sh scripts/status-stub.sh`
- `python3 -m py_compile contracts/*.py scripts/tests/*.py`
- `find scripts -type f -name '*.sh' -not -name '*.snapshot' -exec bash -n {} +`
- `for test_file in scripts/tests/*_test.py; do python3 "$test_file"; done`
- `for test_file in scripts/tests/status-*.sh; do bash "$test_file" scripts/status-stub.sh; done`
- local forbidden-claim scan
- `git diff --check`

Local note: `shellcheck` is not installed on this workstation; CI installs and runs it.
