### PR TITLE
Add chat clipboard policy boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,7 @@ jobs:
                    scripts/chat-response-stream-stub.sh \
                    scripts/chat-message-list-stub.sh \
                    scripts/chat-action-bar-stub.sh \
+                   scripts/chat-clipboard-policy-stub.sh \
                    scripts/chat-attachment-policy-stub.sh \
                    scripts/chat-shortcut-map-stub.sh \
                    scripts/chat-surface-preview.sh \
@@ -260,6 +261,10 @@ jobs:
         run: ./scripts/status-stub.sh --include-chat-action-bar
       - name: run scripts/chat-action-bar-stub.sh
         run: ./scripts/chat-action-bar-stub.sh --model gemma3n-e4b --target kv260
+      - name: run scripts/status-stub.sh with chat clipboard policy
+        run: ./scripts/status-stub.sh --include-chat-clipboard-policy
+      - name: run scripts/chat-clipboard-policy-stub.sh
+        run: ./scripts/chat-clipboard-policy-stub.sh --model gemma3n-e4b --target kv260
       - name: run scripts/status-stub.sh with chat attachment policy
         run: ./scripts/status-stub.sh --include-chat-attachment-policy
       - name: run scripts/chat-attachment-policy-stub.sh
@@ -334,6 +339,8 @@ jobs:
         run: python3 scripts/tests/chat_message_list_contract_test.py
       - name: run chat action-bar contract tests
         run: python3 scripts/tests/chat_action_bar_contract_test.py
+      - name: run chat clipboard-policy contract tests
+        run: python3 scripts/tests/chat_clipboard_policy_contract_test.py
       - name: run chat attachment-policy contract tests
         run: python3 scripts/tests/chat_attachment_policy_contract_test.py
       - name: run chat shortcut-map contract tests
@@ -372,6 +379,7 @@ jobs:
           chmod +x scripts/chat-response-stream-stub.sh
           chmod +x scripts/chat-message-list-stub.sh
           chmod +x scripts/chat-action-bar-stub.sh
+          chmod +x scripts/chat-clipboard-policy-stub.sh
           chmod +x scripts/chat-attachment-policy-stub.sh
           chmod +x scripts/chat-shortcut-map-stub.sh
           chmod +x scripts/launch-stub.sh
@@ -399,6 +407,7 @@ jobs:
           chmod +x scripts/tests/status-chat-response-stream.sh
           chmod +x scripts/tests/status-chat-message-list.sh
           chmod +x scripts/tests/status-chat-action-bar.sh
+          chmod +x scripts/tests/status-chat-clipboard-policy.sh
           chmod +x scripts/tests/status-chat-attachment-policy.sh
           chmod +x scripts/tests/status-chat-shortcut-map.sh
       - name: shellcheck status-stub and test script
@@ -429,6 +438,7 @@ jobs:
           shellcheck scripts/tests/status-chat-response-stream.sh
           shellcheck scripts/tests/status-chat-message-list.sh
           shellcheck scripts/tests/status-chat-action-bar.sh
+          shellcheck scripts/tests/status-chat-clipboard-policy.sh
           shellcheck scripts/tests/status-chat-attachment-policy.sh
           shellcheck scripts/tests/status-chat-shortcut-map.sh
       - name: run status-backend tests
@@ -479,6 +489,8 @@ jobs:
         run: bash scripts/tests/status-chat-message-list.sh scripts/status-stub.sh
       - name: run status-chat-action-bar tests
         run: bash scripts/tests/status-chat-action-bar.sh scripts/status-stub.sh
+      - name: run status-chat-clipboard-policy tests
+        run: bash scripts/tests/status-chat-clipboard-policy.sh scripts/status-stub.sh
       - name: run status-chat-attachment-policy tests
         run: bash scripts/tests/status-chat-attachment-policy.sh scripts/status-stub.sh
       - name: run status-chat-shortcut-map tests

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ and verify host-side prerequisites before the real engine lands.
 | [`scripts/check.sh`](./scripts/check.sh) | Probe host info, tooling availability, edge-device hints. Always exits 0. |
 | [`scripts/check-device-stub.sh`](./scripts/check-device-stub.sh) | Narrowly scoped device-tree / FPGA-node probe (KV260 / Kria detection only). Always exits 0. |
 | [`scripts/install-stub.sh`](./scripts/install-stub.sh) | Preview of the planned install flow; reports which host runtime pieces are present, lists device-side pieces as future deliverables. Always exits 0. |
-| [`scripts/status-stub.sh`](./scripts/status-stub.sh) | Launcher state summary. Default mode: local scaffold output, always exits 0. With `--include-chat-action-bar`, adds read-only disabled chat action-bar data. With `--include-chat-attachment-policy`, adds read-only disabled chat attachment-policy data. With `--include-chat-shortcut-map`, adds read-only disabled chat shortcut-map data. With `--include-chat-message-list`, adds read-only empty chat message-list data. With `--include-chat-response-stream`, adds read-only blocked chat response stream data. With `--include-chat-error-taxonomy`, adds read-only chat error taxonomy data. With `--include-chat-audit-event`, adds read-only blocked chat audit-event metadata. With `--include-chat-surface-layout`, adds read-only chat surface layout data. With `--include-chat-empty-state`, adds read-only display-only chat empty-state data. With `--include-chat-local-only-policy`, adds read-only local-only/cloud-block policy data. With `--include-chat-preferences`, adds read-only chat preferences/settings data. With `--include-chat-session-index`, adds read-only empty chat session index data. With `--include-chat-session-store-policy`, adds read-only disabled chat session-store policy data. With `--include-chat-session-title-policy`, adds read-only placeholder session-title policy data. With `--include-chat-transcript-policy`, adds read-only chat transcript retention/export policy data. With `--include-chat-send-result`, adds read-only blocked chat send-result data. With `--include-chat-composer`, adds read-only chat composer/input-control data. With `--include-chat-model-status`, adds read-only blocked chat model-status display data. With `--include-chat-model-selection-policy`, adds read-only disabled chat model-selection data. With `--include-chat-context-policy`, adds read-only disabled chat context-window/tokenization policy data. With `--include-chat-model-load-request`, adds read-only disabled chat model-load request data. With `--include-chat-session`, adds read-only blocked chat/session and lifecycle summaries. With `--include-chat-readiness`, adds read-only chat readiness checks and recovery actions. With `--include-device-session`, adds a read-only device/session status panel. With `--include-runtime-readiness`, adds a read-only runtime readiness summary. With `--backend pccx-lab`, calls `pccx-lab status --format json` and forwards the run-status envelope (exits non-zero if binary is missing or output is invalid). |
+| [`scripts/status-stub.sh`](./scripts/status-stub.sh) | Launcher state summary. Default mode: local scaffold output, always exits 0. With `--include-chat-action-bar`, adds read-only disabled chat action-bar data. With `--include-chat-clipboard-policy`, adds read-only disabled chat clipboard-policy data. With `--include-chat-attachment-policy`, adds read-only disabled chat attachment-policy data. With `--include-chat-shortcut-map`, adds read-only disabled chat shortcut-map data. With `--include-chat-message-list`, adds read-only empty chat message-list data. With `--include-chat-response-stream`, adds read-only blocked chat response stream data. With `--include-chat-error-taxonomy`, adds read-only chat error taxonomy data. With `--include-chat-audit-event`, adds read-only blocked chat audit-event metadata. With `--include-chat-surface-layout`, adds read-only chat surface layout data. With `--include-chat-empty-state`, adds read-only display-only chat empty-state data. With `--include-chat-local-only-policy`, adds read-only local-only/cloud-block policy data. With `--include-chat-preferences`, adds read-only chat preferences/settings data. With `--include-chat-session-index`, adds read-only empty chat session index data. With `--include-chat-session-store-policy`, adds read-only disabled chat session-store policy data. With `--include-chat-session-title-policy`, adds read-only placeholder session-title policy data. With `--include-chat-transcript-policy`, adds read-only chat transcript retention/export policy data. With `--include-chat-send-result`, adds read-only blocked chat send-result data. With `--include-chat-composer`, adds read-only chat composer/input-control data. With `--include-chat-model-status`, adds read-only blocked chat model-status display data. With `--include-chat-model-selection-policy`, adds read-only disabled chat model-selection data. With `--include-chat-context-policy`, adds read-only disabled chat context-window/tokenization policy data. With `--include-chat-model-load-request`, adds read-only disabled chat model-load request data. With `--include-chat-session`, adds read-only blocked chat/session and lifecycle summaries. With `--include-chat-readiness`, adds read-only chat readiness checks and recovery actions. With `--include-device-session`, adds a read-only device/session status panel. With `--include-runtime-readiness`, adds a read-only runtime readiness summary. With `--backend pccx-lab`, calls `pccx-lab status --format json` and forwards the run-status envelope (exits non-zero if binary is missing or output is invalid). |
 | [`scripts/device-session-status-stub.sh`](./scripts/device-session-status-stub.sh) | Data-only device/session status JSON for the Gemma 3N E4B + KV260 target. Reports connection, model load, session, diagnostics, readiness, discovery paths, flow steps, and error taxonomy as placeholder / blocked. |
 | [`scripts/runtime-readiness-stub.sh`](./scripts/runtime-readiness-stub.sh) | Data-only runtime readiness JSON for the Gemma 3N E4B + KV260 target. Reports blocked / not yet evidence-backed. |
 | [`scripts/chat-session-stub.sh`](./scripts/chat-session-stub.sh) | Data-only standalone chat/session JSON for the Gemma 3N E4B + KV260 target. Reports disabled send controls, inactive session state, no prompt/response persistence, and readiness handoff references. |
@@ -109,6 +109,7 @@ and verify host-side prerequisites before the real engine lands.
 | [`scripts/chat-response-stream-stub.sh`](./scripts/chat-response-stream-stub.sh) | Data-only blocked chat response stream JSON for the Gemma 3N E4B + KV260 target. Reports disabled response streaming, progress, token counter, and stop-control state without opening transport, generating chunks, counting tokens, or writing transcripts. |
 | [`scripts/chat-message-list-stub.sh`](./scripts/chat-message-list-stub.sh) | Data-only empty chat message-list JSON for the Gemma 3N E4B + KV260 target. Reports an empty conversation viewport without reading a session store, transcript, prompt, response, summary, model path, runtime log, or artifact. |
 | [`scripts/chat-action-bar-stub.sh`](./scripts/chat-action-bar-stub.sh) | Data-only disabled chat action-bar JSON for the Gemma 3N E4B + KV260 target. Reports new, clear, export, retry, copy, stop, and attach controls without reading stores, transcripts, message bodies, files, clipboard data, model paths, runtime logs, or artifacts. |
+| [`scripts/chat-clipboard-policy-stub.sh`](./scripts/chat-clipboard-policy-stub.sh) | Data-only disabled chat clipboard-policy JSON for the Gemma 3N E4B + KV260 target. Reports clipboard read, write, paste, copy, import, export, transcript-copy, message-copy, and clipboard-backed attachment gates without reading or writing clipboard, prompt, response, transcript, message, file, model, runtime, or artifact data. |
 | [`scripts/chat-attachment-policy-stub.sh`](./scripts/chat-attachment-policy-stub.sh) | Data-only disabled chat attachment-policy JSON for the Gemma 3N E4B + KV260 target. Reports disabled file picker, file read, upload, import, preview, and persistence gates without reading file names, paths, metadata, contents, clipboard data, transcripts, generated artifacts, model paths, runtime logs, or artifacts. |
 | [`scripts/chat-shortcut-map-stub.sh`](./scripts/chat-shortcut-map-stub.sh) | Data-only disabled chat shortcut-map JSON for the Gemma 3N E4B + KV260 target. Reports planned keyboard accelerator and focus metadata without installing listeners, capturing key events, dispatching commands, changing focus, reading prompts, sessions, transcripts, messages, files, or clipboard data, or starting runtime paths. |
 | [`scripts/chat-transcript-policy-stub.sh`](./scripts/chat-transcript-policy-stub.sh) | Data-only chat transcript policy JSON for the Gemma 3N E4B + KV260 target. Reports retention, export, storage, and privacy policy state without reading, generating, storing, persisting, summarizing, or exporting prompt/response/transcript content. |
@@ -144,6 +145,7 @@ bash scripts/status-stub.sh --include-chat-error-taxonomy
 bash scripts/status-stub.sh --include-chat-response-stream
 bash scripts/status-stub.sh --include-chat-message-list
 bash scripts/status-stub.sh --include-chat-action-bar
+bash scripts/status-stub.sh --include-chat-clipboard-policy
 bash scripts/status-stub.sh --include-chat-attachment-policy
 bash scripts/status-stub.sh --include-chat-shortcut-map
 bash scripts/status-stub.sh --include-device-session
@@ -172,6 +174,7 @@ bash scripts/chat-error-taxonomy-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-response-stream-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-message-list-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-action-bar-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/chat-clipboard-policy-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-attachment-policy-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-shortcut-map-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-surface-preview.sh --model gemma3n-e4b --target kv260
@@ -365,6 +368,7 @@ bash scripts/chat-audit-event-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-error-taxonomy-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-response-stream-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-action-bar-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/chat-clipboard-policy-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-attachment-policy-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-shortcut-map-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-surface-preview.sh --model gemma3n-e4b --target kv260
@@ -377,6 +381,7 @@ bash scripts/status-stub.sh --include-chat-audit-event
 bash scripts/status-stub.sh --include-chat-error-taxonomy
 bash scripts/status-stub.sh --include-chat-response-stream
 bash scripts/status-stub.sh --include-chat-action-bar
+bash scripts/status-stub.sh --include-chat-clipboard-policy
 bash scripts/status-stub.sh --include-chat-attachment-policy
 bash scripts/status-stub.sh --include-chat-session-store-policy
 bash scripts/status-stub.sh --include-chat-shortcut-map
@@ -407,6 +412,7 @@ bash scripts/tests/status-chat-audit-event.sh
 bash scripts/tests/status-chat-error-taxonomy.sh
 bash scripts/tests/status-chat-response-stream.sh
 bash scripts/tests/status-chat-action-bar.sh
+bash scripts/tests/status-chat-clipboard-policy.sh
 bash scripts/tests/status-chat-attachment-policy.sh
 bash scripts/tests/status-chat-session-store-policy.sh
 bash scripts/tests/status-chat-shortcut-map.sh
@@ -471,6 +477,13 @@ controls for the planned chat surface. It records new chat, clear,
 export, retry, copy, stop, and attach controls without reading session
 stores, transcripts, message bodies, files, clipboard data, model paths,
 runtime logs, or artifacts.
+
+The chat clipboard-policy fixture defines the disabled clipboard
+boundary for the planned chat surface. It records copy, paste, import,
+export, transcript-copy, message-copy, and clipboard-backed attachment
+gates without reading or writing clipboard data, prompt text, response
+text, transcripts, message bodies, files, model paths, runtime logs, or
+artifacts.
 
 The chat attachment-policy fixture defines the disabled local attachment
 boundary for the planned chat surface. It records file picker, file

--- a/contracts/chat_clipboard_policy_contract.py
+++ b/contracts/chat_clipboard_policy_contract.py
@@ -1,0 +1,466 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Data-only chat clipboard policy contract for the planned launcher UI.
+
+The contract describes disabled clipboard gates for the standalone chat
+surface. It does not read from or write to the clipboard, paste prompt
+content, copy messages, import clipboard payloads, export transcripts,
+read session stores, read transcripts, load models, touch KV260 hardware,
+call providers, invoke pccx-lab, or start runtime code.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import sys
+
+
+SCHEMA_VERSION = "pccx.chatClipboardPolicy.v0"
+
+CHAT_CLIPBOARD_POLICY_FIELDS = (
+    "schemaVersion",
+    "clipboardPolicyId",
+    "fixtureVersion",
+    "lastUpdatedSource",
+    "targetDevice",
+    "targetBoard",
+    "targetModel",
+    "clipboardPolicyState",
+    "clipboardReadState",
+    "clipboardWriteState",
+    "copyActionState",
+    "pasteActionState",
+    "clipboardImportState",
+    "clipboardExportState",
+    "selectionState",
+    "messageContentState",
+    "transcriptState",
+    "privacyState",
+    "chatComposerRef",
+    "chatActionBarRef",
+    "chatMessageListRef",
+    "chatAttachmentPolicyRef",
+    "chatTranscriptPolicyRef",
+    "chatLocalOnlyPolicyRef",
+    "clipboardPolicy",
+    "clipboardSurfaces",
+    "clipboardControls",
+    "blockedReasons",
+    "handoffRefs",
+    "safetyFlags",
+    "limitations",
+    "issueRefs",
+)
+
+CLIPBOARD_POLICY_FIELDS = (
+    "state",
+    "mode",
+    "sourcePolicy",
+    "contentPolicy",
+    "readEnabled",
+    "writeEnabled",
+    "copyEnabled",
+    "pasteEnabled",
+    "importEnabled",
+    "exportEnabled",
+    "selectionRequired",
+    "userConsentRequired",
+    "sideEffectPolicy",
+    "persistencePolicy",
+)
+
+CLIPBOARD_SURFACE_FIELDS = (
+    "surfaceId",
+    "label",
+    "state",
+    "enabled",
+    "summary",
+    "sideEffectPolicy",
+)
+
+CLIPBOARD_CONTROL_FIELDS = (
+    "controlId",
+    "label",
+    "state",
+    "enabled",
+    "userAction",
+    "launcherAction",
+    "sideEffectPolicy",
+    "contentPolicy",
+    "blockedReasonRef",
+)
+
+BLOCKED_REASON_FIELDS = (
+    "reasonId",
+    "state",
+    "summary",
+    "requiredBefore",
+)
+
+HANDOFF_REF_FIELDS = (
+    "refId",
+    "schemaVersion",
+    "fixturePath",
+    "state",
+    "summary",
+)
+
+CHAT_CLIPBOARD_POLICY_STATE_VALUES = (
+    "available_as_data",
+    "blocked",
+    "disabled",
+    "empty_not_captured",
+    "inactive",
+    "not_configured",
+    "not_loaded",
+    "not_started",
+    "placeholder",
+    "planned",
+    "requires_evidence",
+    "summary_only",
+    "target_selected",
+    "unavailable",
+)
+
+_CHAT_CLIPBOARD_POLICY = {
+    "schemaVersion": SCHEMA_VERSION,
+    "clipboardPolicyId": "chat_clipboard_policy_gemma3n_e4b_kv260_placeholder",
+    "fixtureVersion": "chat-clipboard-policy.gemma3n-e4b-kv260.2026-05-05",
+    "lastUpdatedSource": "pccx_launcher_issue_9_chat_clipboard_policy_boundary_2026-05-05",
+    "targetDevice": "kv260",
+    "targetBoard": "xilinx_kria_kv260",
+    "targetModel": "gemma3n-e4b",
+    "clipboardPolicyState": "blocked",
+    "clipboardReadState": "disabled",
+    "clipboardWriteState": "disabled",
+    "copyActionState": "disabled",
+    "pasteActionState": "disabled",
+    "clipboardImportState": "disabled",
+    "clipboardExportState": "disabled",
+    "selectionState": "empty_not_captured",
+    "messageContentState": "empty_not_captured",
+    "transcriptState": "not_started",
+    "privacyState": "summary_only",
+    "chatComposerRef": "chat_composer_gemma3n_e4b_kv260_placeholder",
+    "chatActionBarRef": "chat_action_bar_gemma3n_e4b_kv260_placeholder",
+    "chatMessageListRef": "chat_message_list_gemma3n_e4b_kv260_placeholder",
+    "chatAttachmentPolicyRef": "chat_attachment_policy_gemma3n_e4b_kv260_placeholder",
+    "chatTranscriptPolicyRef": "chat_transcript_policy_gemma3n_e4b_kv260_placeholder",
+    "chatLocalOnlyPolicyRef": "chat_local_only_policy_gemma3n_e4b_kv260_placeholder",
+    "clipboardPolicy": {
+        "state": "blocked",
+        "mode": "disabled_until_reviewed_clipboard_boundary_exists",
+        "sourcePolicy": "checked fixture only; no clipboard API, selection, message, transcript, prompt, attachment, file, artifact, session store, model path, or runtime log is read",
+        "contentPolicy": "clipboard policy metadata only; no clipboard text, prompt text, response text, transcript text, selection text, file names, paths, bytes, or artifacts are included",
+        "readEnabled": False,
+        "writeEnabled": False,
+        "copyEnabled": False,
+        "pasteEnabled": False,
+        "importEnabled": False,
+        "exportEnabled": False,
+        "selectionRequired": False,
+        "userConsentRequired": True,
+        "sideEffectPolicy": "local_render_only",
+        "persistencePolicy": "no clipboard read, write, paste, copy, import, export, attachment, transcript, session, or artifact persistence",
+    },
+    "clipboardSurfaces": [
+        {
+            "surfaceId": "message_actions",
+            "label": "message actions",
+            "state": "disabled",
+            "enabled": False,
+            "summary": "Copy message controls remain disabled because no message content is captured.",
+            "sideEffectPolicy": "no_clipboard_write",
+        },
+        {
+            "surfaceId": "composer_input",
+            "label": "composer input",
+            "state": "blocked",
+            "enabled": False,
+            "summary": "Paste into the composer remains disabled until an explicit clipboard read boundary exists.",
+            "sideEffectPolicy": "no_clipboard_read",
+        },
+        {
+            "surfaceId": "attachment_input",
+            "label": "attachment input",
+            "state": "disabled",
+            "enabled": False,
+            "summary": "Clipboard-backed attachments remain disabled until attachment ingestion and redaction rules exist.",
+            "sideEffectPolicy": "no_clipboard_attachment_read",
+        },
+        {
+            "surfaceId": "transcript_export",
+            "label": "transcript export",
+            "state": "not_configured",
+            "enabled": False,
+            "summary": "Transcript copy/export remains disabled until retention and redaction boundaries are reviewed.",
+            "sideEffectPolicy": "no_transcript_export_no_clipboard_write",
+        },
+    ],
+    "clipboardControls": [
+        {
+            "controlId": "copy_message",
+            "label": "copy message",
+            "state": "disabled",
+            "enabled": False,
+            "userAction": "Copy only after message content, selection, redaction, and clipboard write boundaries are reviewed.",
+            "launcherAction": "Keep copy disabled and do not request clipboard write permission.",
+            "sideEffectPolicy": "no_clipboard_write",
+            "contentPolicy": "no message body, selection text, response text, or prompt text",
+            "blockedReasonRef": "message_content_absent",
+        },
+        {
+            "controlId": "copy_transcript",
+            "label": "copy transcript",
+            "state": "disabled",
+            "enabled": False,
+            "userAction": "Copy transcripts only after storage, retention, and redaction policy exists.",
+            "launcherAction": "Keep transcript copy disabled and do not read transcript data.",
+            "sideEffectPolicy": "no_transcript_read_no_clipboard_write",
+            "contentPolicy": "no transcript, prompt, response, session title, or summary content",
+            "blockedReasonRef": "transcript_export_not_reviewed",
+        },
+        {
+            "controlId": "paste_prompt",
+            "label": "paste prompt",
+            "state": "disabled",
+            "enabled": False,
+            "userAction": "Paste only after an explicit local clipboard read and prompt redaction boundary exists.",
+            "launcherAction": "Keep paste disabled and do not inspect clipboard contents.",
+            "sideEffectPolicy": "no_clipboard_read",
+            "contentPolicy": "no clipboard text or prompt text",
+            "blockedReasonRef": "clipboard_api_boundary_absent",
+        },
+        {
+            "controlId": "paste_attachment",
+            "label": "paste attachment",
+            "state": "disabled",
+            "enabled": False,
+            "userAction": "Paste attachments only after local attachment and clipboard payload policies are reviewed.",
+            "launcherAction": "Keep clipboard attachments disabled and do not read clipboard payloads.",
+            "sideEffectPolicy": "no_clipboard_attachment_read",
+            "contentPolicy": "no clipboard payload, file name, path, metadata, preview, or bytes",
+            "blockedReasonRef": "attachment_clipboard_boundary_absent",
+        },
+        {
+            "controlId": "import_clipboard_payload",
+            "label": "import clipboard payload",
+            "state": "disabled",
+            "enabled": False,
+            "userAction": "Import clipboard data only after type limits, redaction, and persistence review.",
+            "launcherAction": "Do not import, parse, index, or persist clipboard data.",
+            "sideEffectPolicy": "no_clipboard_import",
+            "contentPolicy": "no clipboard text, image, file, path, metadata, preview, or bytes",
+            "blockedReasonRef": "privacy_redaction_not_reviewed",
+        },
+        {
+            "controlId": "export_to_clipboard",
+            "label": "export to clipboard",
+            "state": "disabled",
+            "enabled": False,
+            "userAction": "Export to clipboard only after explicit user action and redaction policy exists.",
+            "launcherAction": "Do not write transcript, message, error, file, or artifact data to the clipboard.",
+            "sideEffectPolicy": "no_clipboard_export",
+            "contentPolicy": "no transcript, message, error detail, file, path, model, runtime, or artifact content",
+            "blockedReasonRef": "privacy_redaction_not_reviewed",
+        },
+    ],
+    "blockedReasons": [
+        {
+            "reasonId": "clipboard_api_boundary_absent",
+            "state": "blocked",
+            "summary": "No reviewed clipboard API permission, read, write, or paste boundary exists.",
+            "requiredBefore": "clipboard_read_or_write_enabled",
+        },
+        {
+            "reasonId": "message_content_absent",
+            "state": "empty_not_captured",
+            "summary": "No prompt, response, transcript, or message body content is present.",
+            "requiredBefore": "copy_message_enabled",
+        },
+        {
+            "reasonId": "transcript_export_not_reviewed",
+            "state": "not_configured",
+            "summary": "Transcript export needs explicit storage, retention, and redaction boundaries.",
+            "requiredBefore": "copy_transcript_enabled",
+        },
+        {
+            "reasonId": "attachment_clipboard_boundary_absent",
+            "state": "disabled",
+            "summary": "Clipboard-backed attachments require a reviewed attachment payload boundary.",
+            "requiredBefore": "paste_attachment_enabled",
+        },
+        {
+            "reasonId": "privacy_redaction_not_reviewed",
+            "state": "not_configured",
+            "summary": "Clipboard import and export need explicit redaction and persistence review.",
+            "requiredBefore": "clipboard_import_or_export_enabled",
+        },
+    ],
+    "handoffRefs": [
+        {
+            "refId": "chat_composer",
+            "schemaVersion": "pccx.chatComposer.v0",
+            "fixturePath": "contracts/fixtures/chat-composer.gemma3n-e4b-kv260-placeholder.json",
+            "state": "blocked",
+            "summary": "Composer data keeps paste controls disabled.",
+        },
+        {
+            "refId": "chat_action_bar",
+            "schemaVersion": "pccx.chatActionBar.v0",
+            "fixturePath": "contracts/fixtures/chat-action-bar.gemma3n-e4b-kv260-placeholder.json",
+            "state": "blocked",
+            "summary": "Action bar data keeps copy/export controls disabled.",
+        },
+        {
+            "refId": "chat_message_list",
+            "schemaVersion": "pccx.chatMessageList.v0",
+            "fixturePath": "contracts/fixtures/chat-message-list.gemma3n-e4b-kv260-placeholder.json",
+            "state": "empty_not_captured",
+            "summary": "Empty message-list data prevents message copy actions.",
+        },
+        {
+            "refId": "chat_attachment_policy",
+            "schemaVersion": "pccx.chatAttachmentPolicy.v0",
+            "fixturePath": "contracts/fixtures/chat-attachment-policy.gemma3n-e4b-kv260-placeholder.json",
+            "state": "blocked",
+            "summary": "Attachment policy data keeps clipboard-backed attachment reads disabled.",
+        },
+        {
+            "refId": "chat_transcript_policy",
+            "schemaVersion": "pccx.chatTranscriptPolicy.v0",
+            "fixturePath": "contracts/fixtures/chat-transcript-policy.gemma3n-e4b-kv260-placeholder.json",
+            "state": "disabled",
+            "summary": "Transcript persistence and export remain unavailable.",
+        },
+        {
+            "refId": "chat_local_only_policy",
+            "schemaVersion": "pccx.chatLocalOnlyPolicy.v0",
+            "fixturePath": "contracts/fixtures/chat-local-only-policy.gemma3n-e4b-kv260-placeholder.json",
+            "state": "blocked",
+            "summary": "Local-only policy keeps provider, cloud, network, and upload paths unavailable.",
+        },
+    ],
+    "safetyFlags": {
+        "dataOnly": True,
+        "readOnly": True,
+        "deterministic": True,
+        "clipboardPolicyDisplayOnly": True,
+        "clipboardMetadataOnly": True,
+        "clipboardRead": False,
+        "clipboardWrite": False,
+        "clipboardCopy": False,
+        "clipboardPaste": False,
+        "clipboardImport": False,
+        "clipboardExport": False,
+        "clipboardAttachmentRead": False,
+        "clipboardEventListenerInstalled": False,
+        "selectionRead": False,
+        "messageBodiesIncluded": False,
+        "promptCapture": False,
+        "promptRead": False,
+        "promptContentIncluded": False,
+        "responseContentIncluded": False,
+        "transcriptContentIncluded": False,
+        "readsTranscript": False,
+        "transcriptExport": False,
+        "readsSessionStore": False,
+        "sessionStoreRead": False,
+        "sessionStoreWrite": False,
+        "attachmentReads": False,
+        "fileUpload": False,
+        "fileImport": False,
+        "filePreview": False,
+        "writesArtifacts": False,
+        "readsArtifacts": False,
+        "modelAssetRead": False,
+        "modelAssetPathsIncluded": False,
+        "modelWeightPathsIncluded": False,
+        "modelLoadAttempted": False,
+        "modelExecution": False,
+        "runtimeExecution": False,
+        "touchesHardware": False,
+        "hardwareAccess": False,
+        "kv260Access": False,
+        "networkCalls": False,
+        "networkScan": False,
+        "sshExecution": False,
+        "providerCalls": False,
+        "cloudCalls": False,
+        "configRead": False,
+        "environmentRead": False,
+        "providerConfigRead": False,
+        "privatePathsIncluded": False,
+        "secretsIncluded": False,
+        "tokensIncluded": False,
+        "generatedBlobsIncluded": False,
+        "hardwareDumpsIncluded": False,
+        "runtimeLogsIncluded": False,
+        "telemetry": False,
+        "automaticUpload": False,
+        "writeBack": False,
+        "executesPccxLab": False,
+        "executesSystemverilogIde": False,
+        "mcpServerImplemented": False,
+        "lspImplemented": False,
+        "stableApiAbiClaim": False,
+    },
+    "limitations": [
+        "Data-only chat clipboard-policy fixture; no clipboard content, selection, prompt, response, transcript, message body, file, artifact, model path, runtime log, or private path is read or written.",
+        "Clipboard read, write, paste, copy, import, export, transcript-copy, message-copy, and clipboard-backed attachment controls remain disabled or blocked.",
+        "No session store, transcript, message body, attachment, artifact, private path, secret, token, log, or hardware dump is read or written.",
+        "No clipboard API request, prompt capture, transcript export, upload, import, model load, runtime execution, provider call, network call, or KV260 hardware access is performed.",
+        "This is not a release, tag, compatibility commitment, MCP, LSP, IDE, marketplace, telemetry, or runtime implementation.",
+    ],
+    "issueRefs": [
+        "pccxai/pccx-llm-launcher#9",
+    ],
+}
+
+
+def create_gemma3n_e4b_kv260_chat_clipboard_policy() -> dict:
+    """Return the checked Gemma 3N E4B plus KV260 chat clipboard fixture."""
+    return copy.deepcopy(_CHAT_CLIPBOARD_POLICY)
+
+
+def chat_clipboard_policy_json(clipboard_policy: dict | None = None) -> str:
+    """Render a deterministic JSON representation."""
+    return json.dumps(
+        clipboard_policy
+        if clipboard_policy is not None
+        else create_gemma3n_e4b_kv260_chat_clipboard_policy(),
+        indent=2,
+        sort_keys=True,
+    ) + "\n"
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Print data-only chat clipboard-policy JSON.",
+    )
+    parser.add_argument(
+        "--model",
+        default="gemma3n-e4b",
+        choices=("gemma3n-e4b",),
+        help="model descriptor target",
+    )
+    parser.add_argument(
+        "--target",
+        default="kv260",
+        choices=("kv260",),
+        help="target board/device",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parse_args(sys.argv[1:] if argv is None else argv)
+    sys.stdout.write(chat_clipboard_policy_json())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contracts/fixtures/chat-clipboard-policy.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-clipboard-policy.gemma3n-e4b-kv260-placeholder.json
@@ -1,0 +1,294 @@
+{
+  "blockedReasons": [
+    {
+      "reasonId": "clipboard_api_boundary_absent",
+      "requiredBefore": "clipboard_read_or_write_enabled",
+      "state": "blocked",
+      "summary": "No reviewed clipboard API permission, read, write, or paste boundary exists."
+    },
+    {
+      "reasonId": "message_content_absent",
+      "requiredBefore": "copy_message_enabled",
+      "state": "empty_not_captured",
+      "summary": "No prompt, response, transcript, or message body content is present."
+    },
+    {
+      "reasonId": "transcript_export_not_reviewed",
+      "requiredBefore": "copy_transcript_enabled",
+      "state": "not_configured",
+      "summary": "Transcript export needs explicit storage, retention, and redaction boundaries."
+    },
+    {
+      "reasonId": "attachment_clipboard_boundary_absent",
+      "requiredBefore": "paste_attachment_enabled",
+      "state": "disabled",
+      "summary": "Clipboard-backed attachments require a reviewed attachment payload boundary."
+    },
+    {
+      "reasonId": "privacy_redaction_not_reviewed",
+      "requiredBefore": "clipboard_import_or_export_enabled",
+      "state": "not_configured",
+      "summary": "Clipboard import and export need explicit redaction and persistence review."
+    }
+  ],
+  "chatActionBarRef": "chat_action_bar_gemma3n_e4b_kv260_placeholder",
+  "chatAttachmentPolicyRef": "chat_attachment_policy_gemma3n_e4b_kv260_placeholder",
+  "chatComposerRef": "chat_composer_gemma3n_e4b_kv260_placeholder",
+  "chatLocalOnlyPolicyRef": "chat_local_only_policy_gemma3n_e4b_kv260_placeholder",
+  "chatMessageListRef": "chat_message_list_gemma3n_e4b_kv260_placeholder",
+  "chatTranscriptPolicyRef": "chat_transcript_policy_gemma3n_e4b_kv260_placeholder",
+  "clipboardControls": [
+    {
+      "blockedReasonRef": "message_content_absent",
+      "contentPolicy": "no message body, selection text, response text, or prompt text",
+      "controlId": "copy_message",
+      "enabled": false,
+      "label": "copy message",
+      "launcherAction": "Keep copy disabled and do not request clipboard write permission.",
+      "sideEffectPolicy": "no_clipboard_write",
+      "state": "disabled",
+      "userAction": "Copy only after message content, selection, redaction, and clipboard write boundaries are reviewed."
+    },
+    {
+      "blockedReasonRef": "transcript_export_not_reviewed",
+      "contentPolicy": "no transcript, prompt, response, session title, or summary content",
+      "controlId": "copy_transcript",
+      "enabled": false,
+      "label": "copy transcript",
+      "launcherAction": "Keep transcript copy disabled and do not read transcript data.",
+      "sideEffectPolicy": "no_transcript_read_no_clipboard_write",
+      "state": "disabled",
+      "userAction": "Copy transcripts only after storage, retention, and redaction policy exists."
+    },
+    {
+      "blockedReasonRef": "clipboard_api_boundary_absent",
+      "contentPolicy": "no clipboard text or prompt text",
+      "controlId": "paste_prompt",
+      "enabled": false,
+      "label": "paste prompt",
+      "launcherAction": "Keep paste disabled and do not inspect clipboard contents.",
+      "sideEffectPolicy": "no_clipboard_read",
+      "state": "disabled",
+      "userAction": "Paste only after an explicit local clipboard read and prompt redaction boundary exists."
+    },
+    {
+      "blockedReasonRef": "attachment_clipboard_boundary_absent",
+      "contentPolicy": "no clipboard payload, file name, path, metadata, preview, or bytes",
+      "controlId": "paste_attachment",
+      "enabled": false,
+      "label": "paste attachment",
+      "launcherAction": "Keep clipboard attachments disabled and do not read clipboard payloads.",
+      "sideEffectPolicy": "no_clipboard_attachment_read",
+      "state": "disabled",
+      "userAction": "Paste attachments only after local attachment and clipboard payload policies are reviewed."
+    },
+    {
+      "blockedReasonRef": "privacy_redaction_not_reviewed",
+      "contentPolicy": "no clipboard text, image, file, path, metadata, preview, or bytes",
+      "controlId": "import_clipboard_payload",
+      "enabled": false,
+      "label": "import clipboard payload",
+      "launcherAction": "Do not import, parse, index, or persist clipboard data.",
+      "sideEffectPolicy": "no_clipboard_import",
+      "state": "disabled",
+      "userAction": "Import clipboard data only after type limits, redaction, and persistence review."
+    },
+    {
+      "blockedReasonRef": "privacy_redaction_not_reviewed",
+      "contentPolicy": "no transcript, message, error detail, file, path, model, runtime, or artifact content",
+      "controlId": "export_to_clipboard",
+      "enabled": false,
+      "label": "export to clipboard",
+      "launcherAction": "Do not write transcript, message, error, file, or artifact data to the clipboard.",
+      "sideEffectPolicy": "no_clipboard_export",
+      "state": "disabled",
+      "userAction": "Export to clipboard only after explicit user action and redaction policy exists."
+    }
+  ],
+  "clipboardExportState": "disabled",
+  "clipboardImportState": "disabled",
+  "clipboardPolicy": {
+    "contentPolicy": "clipboard policy metadata only; no clipboard text, prompt text, response text, transcript text, selection text, file names, paths, bytes, or artifacts are included",
+    "copyEnabled": false,
+    "exportEnabled": false,
+    "importEnabled": false,
+    "mode": "disabled_until_reviewed_clipboard_boundary_exists",
+    "pasteEnabled": false,
+    "persistencePolicy": "no clipboard read, write, paste, copy, import, export, attachment, transcript, session, or artifact persistence",
+    "readEnabled": false,
+    "selectionRequired": false,
+    "sideEffectPolicy": "local_render_only",
+    "sourcePolicy": "checked fixture only; no clipboard API, selection, message, transcript, prompt, attachment, file, artifact, session store, model path, or runtime log is read",
+    "state": "blocked",
+    "userConsentRequired": true,
+    "writeEnabled": false
+  },
+  "clipboardPolicyId": "chat_clipboard_policy_gemma3n_e4b_kv260_placeholder",
+  "clipboardPolicyState": "blocked",
+  "clipboardReadState": "disabled",
+  "clipboardSurfaces": [
+    {
+      "enabled": false,
+      "label": "message actions",
+      "sideEffectPolicy": "no_clipboard_write",
+      "state": "disabled",
+      "summary": "Copy message controls remain disabled because no message content is captured.",
+      "surfaceId": "message_actions"
+    },
+    {
+      "enabled": false,
+      "label": "composer input",
+      "sideEffectPolicy": "no_clipboard_read",
+      "state": "blocked",
+      "summary": "Paste into the composer remains disabled until an explicit clipboard read boundary exists.",
+      "surfaceId": "composer_input"
+    },
+    {
+      "enabled": false,
+      "label": "attachment input",
+      "sideEffectPolicy": "no_clipboard_attachment_read",
+      "state": "disabled",
+      "summary": "Clipboard-backed attachments remain disabled until attachment ingestion and redaction rules exist.",
+      "surfaceId": "attachment_input"
+    },
+    {
+      "enabled": false,
+      "label": "transcript export",
+      "sideEffectPolicy": "no_transcript_export_no_clipboard_write",
+      "state": "not_configured",
+      "summary": "Transcript copy/export remains disabled until retention and redaction boundaries are reviewed.",
+      "surfaceId": "transcript_export"
+    }
+  ],
+  "clipboardWriteState": "disabled",
+  "copyActionState": "disabled",
+  "fixtureVersion": "chat-clipboard-policy.gemma3n-e4b-kv260.2026-05-05",
+  "handoffRefs": [
+    {
+      "fixturePath": "contracts/fixtures/chat-composer.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_composer",
+      "schemaVersion": "pccx.chatComposer.v0",
+      "state": "blocked",
+      "summary": "Composer data keeps paste controls disabled."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-action-bar.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_action_bar",
+      "schemaVersion": "pccx.chatActionBar.v0",
+      "state": "blocked",
+      "summary": "Action bar data keeps copy/export controls disabled."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-message-list.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_message_list",
+      "schemaVersion": "pccx.chatMessageList.v0",
+      "state": "empty_not_captured",
+      "summary": "Empty message-list data prevents message copy actions."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-attachment-policy.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_attachment_policy",
+      "schemaVersion": "pccx.chatAttachmentPolicy.v0",
+      "state": "blocked",
+      "summary": "Attachment policy data keeps clipboard-backed attachment reads disabled."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-transcript-policy.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_transcript_policy",
+      "schemaVersion": "pccx.chatTranscriptPolicy.v0",
+      "state": "disabled",
+      "summary": "Transcript persistence and export remain unavailable."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-local-only-policy.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_local_only_policy",
+      "schemaVersion": "pccx.chatLocalOnlyPolicy.v0",
+      "state": "blocked",
+      "summary": "Local-only policy keeps provider, cloud, network, and upload paths unavailable."
+    }
+  ],
+  "issueRefs": [
+    "pccxai/pccx-llm-launcher#9"
+  ],
+  "lastUpdatedSource": "pccx_launcher_issue_9_chat_clipboard_policy_boundary_2026-05-05",
+  "limitations": [
+    "Data-only chat clipboard-policy fixture; no clipboard content, selection, prompt, response, transcript, message body, file, artifact, model path, runtime log, or private path is read or written.",
+    "Clipboard read, write, paste, copy, import, export, transcript-copy, message-copy, and clipboard-backed attachment controls remain disabled or blocked.",
+    "No session store, transcript, message body, attachment, artifact, private path, secret, token, log, or hardware dump is read or written.",
+    "No clipboard API request, prompt capture, transcript export, upload, import, model load, runtime execution, provider call, network call, or KV260 hardware access is performed.",
+    "This is not a release, tag, compatibility commitment, MCP, LSP, IDE, marketplace, telemetry, or runtime implementation."
+  ],
+  "messageContentState": "empty_not_captured",
+  "pasteActionState": "disabled",
+  "privacyState": "summary_only",
+  "safetyFlags": {
+    "attachmentReads": false,
+    "automaticUpload": false,
+    "clipboardAttachmentRead": false,
+    "clipboardCopy": false,
+    "clipboardEventListenerInstalled": false,
+    "clipboardExport": false,
+    "clipboardImport": false,
+    "clipboardMetadataOnly": true,
+    "clipboardPaste": false,
+    "clipboardPolicyDisplayOnly": true,
+    "clipboardRead": false,
+    "clipboardWrite": false,
+    "cloudCalls": false,
+    "configRead": false,
+    "dataOnly": true,
+    "deterministic": true,
+    "environmentRead": false,
+    "executesPccxLab": false,
+    "executesSystemverilogIde": false,
+    "fileImport": false,
+    "filePreview": false,
+    "fileUpload": false,
+    "generatedBlobsIncluded": false,
+    "hardwareAccess": false,
+    "hardwareDumpsIncluded": false,
+    "kv260Access": false,
+    "lspImplemented": false,
+    "mcpServerImplemented": false,
+    "messageBodiesIncluded": false,
+    "modelAssetPathsIncluded": false,
+    "modelAssetRead": false,
+    "modelExecution": false,
+    "modelLoadAttempted": false,
+    "modelWeightPathsIncluded": false,
+    "networkCalls": false,
+    "networkScan": false,
+    "privatePathsIncluded": false,
+    "promptCapture": false,
+    "promptContentIncluded": false,
+    "promptRead": false,
+    "providerCalls": false,
+    "providerConfigRead": false,
+    "readOnly": true,
+    "readsArtifacts": false,
+    "readsSessionStore": false,
+    "readsTranscript": false,
+    "responseContentIncluded": false,
+    "runtimeExecution": false,
+    "runtimeLogsIncluded": false,
+    "secretsIncluded": false,
+    "selectionRead": false,
+    "sessionStoreRead": false,
+    "sessionStoreWrite": false,
+    "sshExecution": false,
+    "stableApiAbiClaim": false,
+    "telemetry": false,
+    "tokensIncluded": false,
+    "touchesHardware": false,
+    "transcriptContentIncluded": false,
+    "transcriptExport": false,
+    "writeBack": false,
+    "writesArtifacts": false
+  },
+  "schemaVersion": "pccx.chatClipboardPolicy.v0",
+  "selectionState": "empty_not_captured",
+  "targetBoard": "xilinx_kria_kv260",
+  "targetDevice": "kv260",
+  "targetModel": "gemma3n-e4b",
+  "transcriptState": "not_started"
+}

--- a/docs/STANDALONE_CHAT_SESSION_CONTRACT.md
+++ b/docs/STANDALONE_CHAT_SESSION_CONTRACT.md
@@ -29,6 +29,7 @@ The implementation lives in:
 - `contracts/chat_error_taxonomy_contract.py`
 - `contracts/chat_message_list_contract.py`
 - `contracts/chat_action_bar_contract.py`
+- `contracts/chat_clipboard_policy_contract.py`
 - `contracts/chat_attachment_policy_contract.py`
 - `contracts/chat_shortcut_map_contract.py`
 - `contracts/fixtures/chat-session.gemma3n-e4b-kv260-placeholder.json`
@@ -52,6 +53,7 @@ The implementation lives in:
 - `contracts/fixtures/chat-error-taxonomy.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-message-list.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-action-bar.gemma3n-e4b-kv260-placeholder.json`
+- `contracts/fixtures/chat-clipboard-policy.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-attachment-policy.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-shortcut-map.gemma3n-e4b-kv260-placeholder.json`
 - `scripts/chat-session-stub.sh`
@@ -75,6 +77,7 @@ The implementation lives in:
 - `scripts/chat-error-taxonomy-stub.sh`
 - `scripts/chat-message-list-stub.sh`
 - `scripts/chat-action-bar-stub.sh`
+- `scripts/chat-clipboard-policy-stub.sh`
 - `scripts/chat-attachment-policy-stub.sh`
 - `scripts/chat-shortcut-map-stub.sh`
 - `scripts/chat-surface-preview.sh`
@@ -99,6 +102,7 @@ The implementation lives in:
 - `scripts/tests/chat_error_taxonomy_contract_test.py`
 - `scripts/tests/chat_message_list_contract_test.py`
 - `scripts/tests/chat_action_bar_contract_test.py`
+- `scripts/tests/chat_clipboard_policy_contract_test.py`
 - `scripts/tests/chat_attachment_policy_contract_test.py`
 - `scripts/tests/chat_shortcut_map_contract_test.py`
 - `scripts/tests/chat_surface_preview_test.py`
@@ -122,6 +126,7 @@ The implementation lives in:
 - `scripts/tests/status-chat-response-stream.sh`
 - `scripts/tests/status-chat-message-list.sh`
 - `scripts/tests/status-chat-action-bar.sh`
+- `scripts/tests/status-chat-clipboard-policy.sh`
 - `scripts/tests/status-chat-attachment-policy.sh`
 - `scripts/tests/status-chat-shortcut-map.sh`
 
@@ -449,6 +454,22 @@ unavailable, or planned. No session store or transcript is read, no
 message body is included, no transcript is exported, no clipboard or file
 operation is performed, no stop signal is sent, no model or runtime path
 is started, and no artifact is written.
+
+The chat clipboard-policy fixture records the disabled clipboard boundary
+used by the planned standalone chat surface:
+
+```bash
+bash scripts/chat-clipboard-policy-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/status-stub.sh --include-chat-clipboard-policy
+```
+
+It keeps clipboard handling as local metadata: read, write, paste, copy,
+import, export, transcript-copy, message-copy, and clipboard-backed
+attachment gates remain disabled or blocked. No clipboard data, prompt
+text, response text, transcript, message body, file data, model path,
+runtime log, or artifact is read or written, no clipboard permission is
+requested, no upload or import runs, no model/runtime path is started,
+and no target access occurs.
 
 The chat attachment-policy fixture records the disabled local attachment
 boundary used by the planned standalone chat surface:

--- a/scripts/chat-clipboard-policy-stub.sh
+++ b/scripts/chat-clipboard-policy-stub.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+# Print the data-only chat clipboard-policy contract.
+
+set -eu
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+
+python3 "$ROOT_DIR/contracts/chat_clipboard_policy_contract.py" "$@"

--- a/scripts/status-stub.sh
+++ b/scripts/status-stub.sh
@@ -73,6 +73,9 @@
 # Chat action-bar controls boundary (explicit opt-in, read-only local data):
 #   --include-chat-action-bar
 #
+# Chat clipboard-policy boundary (explicit opt-in, read-only local data):
+#   --include-chat-clipboard-policy
+#
 # Chat attachment-policy boundary (explicit opt-in, read-only local data):
 #   --include-chat-attachment-policy
 #
@@ -117,6 +120,7 @@ INCLUDE_CHAT_ERROR_TAXONOMY="0"
 INCLUDE_CHAT_RESPONSE_STREAM="0"
 INCLUDE_CHAT_MESSAGE_LIST="0"
 INCLUDE_CHAT_ACTION_BAR="0"
+INCLUDE_CHAT_CLIPBOARD_POLICY="0"
 INCLUDE_CHAT_ATTACHMENT_POLICY="0"
 INCLUDE_CHAT_SHORTCUT_MAP="0"
 
@@ -534,6 +538,148 @@ print(
 
     HEAD "chat action bar"
     printf '%s\n' "$CHAT_ACTION_BAR_SUMMARY"
+}
+
+print_chat_clipboard_policy_summary() {
+    SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+    ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+    CHAT_CLIPBOARD_POLICY_STUB="$ROOT_DIR/scripts/chat-clipboard-policy-stub.sh"
+
+    if [ ! -f "$CHAT_CLIPBOARD_POLICY_STUB" ]; then
+        ERROR "chat clipboard-policy stub not found: $CHAT_CLIPBOARD_POLICY_STUB"
+        return 1
+    fi
+
+    if ! CHAT_CLIPBOARD_POLICY_JSON="$(bash "$CHAT_CLIPBOARD_POLICY_STUB" --model gemma3n-e4b --target kv260 2>&1)"; then
+        ERROR "chat clipboard-policy stub failed"
+        printf '%s\n' "$CHAT_CLIPBOARD_POLICY_JSON" >&2
+        return 1
+    fi
+
+    if ! CHAT_CLIPBOARD_POLICY_SUMMARY="$(
+        printf '%s\n' "$CHAT_CLIPBOARD_POLICY_JSON" | python3 -c '
+import json
+import sys
+
+data = json.load(sys.stdin)
+flags = data["safetyFlags"]
+policy = data["clipboardPolicy"]
+
+def b(value):
+    return "true" if value else "false"
+
+surfaces = " ".join(
+    "{}={}:{}".format(surface["surfaceId"], surface["state"], b(surface["enabled"]))
+    for surface in data["clipboardSurfaces"]
+)
+controls = " ".join(
+    "{}={}:{}".format(control["controlId"], control["state"], b(control["enabled"]))
+    for control in data["clipboardControls"]
+)
+blocked = " ".join(
+    "{}={}".format(reason["reasonId"], reason["state"])
+    for reason in data["blockedReasons"]
+)
+
+print("[INFO]  source     : scripts/chat-clipboard-policy-stub.sh --model gemma3n-e4b --target kv260")
+print("[INFO]  boundary   : read-only data; no clipboard read/write/paste/copy/import/export/session-store/transcript/message/file/model/runtime/hardware/lab/IDE execution")
+print("[INFO]  target     : {}".format(data["targetDevice"]))
+print("[INFO]  model      : {}".format(data["targetModel"]))
+print("[INFO]  policy     : {}".format(data["clipboardPolicyState"]))
+print("[INFO]  read       : {}".format(data["clipboardReadState"]))
+print("[INFO]  write      : {}".format(data["clipboardWriteState"]))
+print("[INFO]  copy       : {}".format(data["copyActionState"]))
+print("[INFO]  paste      : {}".format(data["pasteActionState"]))
+print("[INFO]  import     : {}".format(data["clipboardImportState"]))
+print("[INFO]  export     : {}".format(data["clipboardExportState"]))
+print("[INFO]  selection  : {}".format(data["selectionState"]))
+print("[INFO]  message    : {}".format(data["messageContentState"]))
+print("[INFO]  transcript : {}".format(data["transcriptState"]))
+print("[INFO]  privacy    : {}".format(data["privacyState"]))
+print(
+    "[INFO]  clipboard-policy : {} mode={} readEnabled={} "
+    "writeEnabled={} copyEnabled={} pasteEnabled={} "
+    "importEnabled={} exportEnabled={} userConsentRequired={}".format(
+        policy["state"],
+        policy["mode"],
+        b(policy["readEnabled"]),
+        b(policy["writeEnabled"]),
+        b(policy["copyEnabled"]),
+        b(policy["pasteEnabled"]),
+        b(policy["importEnabled"]),
+        b(policy["exportEnabled"]),
+        b(policy["userConsentRequired"]),
+    )
+)
+print("[INFO]  surfaces   : {}".format(surfaces))
+print("[INFO]  controls   : {}".format(controls))
+print("[INFO]  blocked    : {}".format(blocked))
+print(
+    "[INFO]  flags      : readOnly={} dataOnly={} deterministic={} "
+    "clipboardPolicyDisplayOnly={} clipboardMetadataOnly={} "
+    "clipboardRead={} clipboardWrite={} clipboardCopy={} "
+    "clipboardPaste={} clipboardImport={} clipboardExport={} "
+    "clipboardAttachmentRead={} clipboardEventListenerInstalled={} "
+    "selectionRead={} messageBodiesIncluded={} promptCapture={} "
+    "promptRead={} promptContentIncluded={} responseContentIncluded={} "
+    "transcriptContentIncluded={} readsTranscript={} "
+    "transcriptExport={} readsSessionStore={} sessionStoreRead={} "
+    "sessionStoreWrite={} attachmentReads={} fileUpload={} "
+    "fileImport={} filePreview={} writesArtifacts={} "
+    "readsArtifacts={} modelAssetRead={} modelExecution={} "
+    "runtimeExecution={} kv260Access={} hardwareAccess={} "
+    "networkCalls={} providerCalls={} cloudCalls={} "
+    "executesPccxLab={}".format(
+        b(flags["readOnly"]),
+        b(flags["dataOnly"]),
+        b(flags["deterministic"]),
+        b(flags["clipboardPolicyDisplayOnly"]),
+        b(flags["clipboardMetadataOnly"]),
+        b(flags["clipboardRead"]),
+        b(flags["clipboardWrite"]),
+        b(flags["clipboardCopy"]),
+        b(flags["clipboardPaste"]),
+        b(flags["clipboardImport"]),
+        b(flags["clipboardExport"]),
+        b(flags["clipboardAttachmentRead"]),
+        b(flags["clipboardEventListenerInstalled"]),
+        b(flags["selectionRead"]),
+        b(flags["messageBodiesIncluded"]),
+        b(flags["promptCapture"]),
+        b(flags["promptRead"]),
+        b(flags["promptContentIncluded"]),
+        b(flags["responseContentIncluded"]),
+        b(flags["transcriptContentIncluded"]),
+        b(flags["readsTranscript"]),
+        b(flags["transcriptExport"]),
+        b(flags["readsSessionStore"]),
+        b(flags["sessionStoreRead"]),
+        b(flags["sessionStoreWrite"]),
+        b(flags["attachmentReads"]),
+        b(flags["fileUpload"]),
+        b(flags["fileImport"]),
+        b(flags["filePreview"]),
+        b(flags["writesArtifacts"]),
+        b(flags["readsArtifacts"]),
+        b(flags["modelAssetRead"]),
+        b(flags["modelExecution"]),
+        b(flags["runtimeExecution"]),
+        b(flags["kv260Access"]),
+        b(flags["hardwareAccess"]),
+        b(flags["networkCalls"]),
+        b(flags["providerCalls"]),
+        b(flags["cloudCalls"]),
+        b(flags["executesPccxLab"]),
+    )
+)
+'
+    )"; then
+        ERROR "chat clipboard-policy JSON could not be summarized"
+        return 1
+    fi
+
+    HEAD "chat clipboard policy"
+    printf '%s\n' "$CHAT_CLIPBOARD_POLICY_SUMMARY"
 }
 
 print_chat_attachment_policy_summary() {
@@ -2967,6 +3113,10 @@ while [ $# -gt 0 ]; do
             INCLUDE_CHAT_ACTION_BAR="1"
             shift
             ;;
+        --include-chat-clipboard-policy)
+            INCLUDE_CHAT_CLIPBOARD_POLICY="1"
+            shift
+            ;;
         --include-chat-attachment-policy)
             INCLUDE_CHAT_ATTACHMENT_POLICY="1"
             shift
@@ -2990,8 +3140,8 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-if [ -n "$BACKEND" ] && { [ "$INCLUDE_RUNTIME_READINESS" = "1" ] || [ "$INCLUDE_DEVICE_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SURFACE_LAYOUT" = "1" ] || [ "$INCLUDE_CHAT_EMPTY_STATE" = "1" ] || [ "$INCLUDE_CHAT_LOCAL_ONLY_POLICY" = "1" ] || [ "$INCLUDE_CHAT_PREFERENCES" = "1" ] || [ "$INCLUDE_CHAT_SESSION_INDEX" = "1" ] || [ "$INCLUDE_CHAT_SESSION_STORE_POLICY" = "1" ] || [ "$INCLUDE_CHAT_SESSION_TITLE_POLICY" = "1" ] || [ "$INCLUDE_CHAT_MODEL_STATUS" = "1" ] || [ "$INCLUDE_CHAT_MODEL_SELECTION_POLICY" = "1" ] || [ "$INCLUDE_CHAT_CONTEXT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_MODEL_LOAD_REQUEST" = "1" ] || [ "$INCLUDE_CHAT_READINESS" = "1" ] || [ "$INCLUDE_CHAT_COMPOSER" = "1" ] || [ "$INCLUDE_CHAT_SEND_RESULT" = "1" ] || [ "$INCLUDE_CHAT_TRANSCRIPT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_AUDIT_EVENT" = "1" ] || [ "$INCLUDE_CHAT_ERROR_TAXONOMY" = "1" ] || [ "$INCLUDE_CHAT_RESPONSE_STREAM" = "1" ] || [ "$INCLUDE_CHAT_MESSAGE_LIST" = "1" ] || [ "$INCLUDE_CHAT_ACTION_BAR" = "1" ] || [ "$INCLUDE_CHAT_ATTACHMENT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_SHORTCUT_MAP" = "1" ]; }; then
-    ERROR "--include-runtime-readiness, --include-device-session, --include-chat-session, --include-chat-surface-layout, --include-chat-empty-state, --include-chat-local-only-policy, --include-chat-preferences, --include-chat-session-index, --include-chat-session-store-policy, --include-chat-session-title-policy, --include-chat-model-status, --include-chat-model-selection-policy, --include-chat-context-policy, --include-chat-model-load-request, --include-chat-readiness, --include-chat-composer, --include-chat-send-result, --include-chat-transcript-policy, --include-chat-audit-event, --include-chat-error-taxonomy, --include-chat-response-stream, --include-chat-message-list, --include-chat-action-bar, --include-chat-attachment-policy, and --include-chat-shortcut-map are only supported in local scaffold mode"
+if [ -n "$BACKEND" ] && { [ "$INCLUDE_RUNTIME_READINESS" = "1" ] || [ "$INCLUDE_DEVICE_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SURFACE_LAYOUT" = "1" ] || [ "$INCLUDE_CHAT_EMPTY_STATE" = "1" ] || [ "$INCLUDE_CHAT_LOCAL_ONLY_POLICY" = "1" ] || [ "$INCLUDE_CHAT_PREFERENCES" = "1" ] || [ "$INCLUDE_CHAT_SESSION_INDEX" = "1" ] || [ "$INCLUDE_CHAT_SESSION_STORE_POLICY" = "1" ] || [ "$INCLUDE_CHAT_SESSION_TITLE_POLICY" = "1" ] || [ "$INCLUDE_CHAT_MODEL_STATUS" = "1" ] || [ "$INCLUDE_CHAT_MODEL_SELECTION_POLICY" = "1" ] || [ "$INCLUDE_CHAT_CONTEXT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_MODEL_LOAD_REQUEST" = "1" ] || [ "$INCLUDE_CHAT_READINESS" = "1" ] || [ "$INCLUDE_CHAT_COMPOSER" = "1" ] || [ "$INCLUDE_CHAT_SEND_RESULT" = "1" ] || [ "$INCLUDE_CHAT_TRANSCRIPT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_AUDIT_EVENT" = "1" ] || [ "$INCLUDE_CHAT_ERROR_TAXONOMY" = "1" ] || [ "$INCLUDE_CHAT_RESPONSE_STREAM" = "1" ] || [ "$INCLUDE_CHAT_MESSAGE_LIST" = "1" ] || [ "$INCLUDE_CHAT_ACTION_BAR" = "1" ] || [ "$INCLUDE_CHAT_CLIPBOARD_POLICY" = "1" ] || [ "$INCLUDE_CHAT_ATTACHMENT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_SHORTCUT_MAP" = "1" ]; }; then
+    ERROR "--include-runtime-readiness, --include-device-session, --include-chat-session, --include-chat-surface-layout, --include-chat-empty-state, --include-chat-local-only-policy, --include-chat-preferences, --include-chat-session-index, --include-chat-session-store-policy, --include-chat-session-title-policy, --include-chat-model-status, --include-chat-model-selection-policy, --include-chat-context-policy, --include-chat-model-load-request, --include-chat-readiness, --include-chat-composer, --include-chat-send-result, --include-chat-transcript-policy, --include-chat-audit-event, --include-chat-error-taxonomy, --include-chat-response-stream, --include-chat-message-list, --include-chat-action-bar, --include-chat-clipboard-policy, --include-chat-attachment-policy, and --include-chat-shortcut-map are only supported in local scaffold mode"
     exit 1
 fi
 
@@ -3027,6 +3177,7 @@ if [ -z "$BACKEND" ]; then
     NOTE "chat stream   : opt-in via --include-chat-response-stream (read-only response stream data)"
     NOTE "chat messages : opt-in via --include-chat-message-list (read-only empty message-list data)"
     NOTE "chat actions  : opt-in via --include-chat-action-bar (read-only disabled action-bar data)"
+    NOTE "chat clipboard: opt-in via --include-chat-clipboard-policy (read-only disabled clipboard-policy data)"
     NOTE "chat attach   : opt-in via --include-chat-attachment-policy (read-only disabled attachment-policy data)"
     NOTE "chat shortcuts: opt-in via --include-chat-shortcut-map (read-only disabled shortcut-map data)"
     NOTE "editor bridge  : planned (VS Code / other IDEs)"
@@ -3051,6 +3202,12 @@ if [ -z "$BACKEND" ]; then
 
     if [ "$INCLUDE_CHAT_ACTION_BAR" = "1" ]; then
         if ! print_chat_action_bar_summary; then
+            exit 1
+        fi
+    fi
+
+    if [ "$INCLUDE_CHAT_CLIPBOARD_POLICY" = "1" ]; then
+        if ! print_chat_clipboard_policy_summary; then
             exit 1
         fi
     fi

--- a/scripts/tests/chat_clipboard_policy_contract_test.py
+++ b/scripts/tests/chat_clipboard_policy_contract_test.py
@@ -1,0 +1,404 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Fixture tests for the standalone chat clipboard-policy contract."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "contracts" / "chat_clipboard_policy_contract.py"
+FIXTURE_PATH = (
+    ROOT
+    / "contracts"
+    / "fixtures"
+    / "chat-clipboard-policy.gemma3n-e4b-kv260-placeholder.json"
+)
+SCRIPT_PATH = ROOT / "scripts" / "chat-clipboard-policy-stub.sh"
+STATUS_TEST_PATH = ROOT / "scripts" / "tests" / "status-chat-clipboard-policy.sh"
+DOC_PATH = ROOT / "docs" / "STANDALONE_CHAT_SESSION_CONTRACT.md"
+README_PATH = ROOT / "README.md"
+TEST_PATH = Path(__file__).resolve()
+CI_PATH = ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location(
+        "chat_clipboard_policy_contract",
+        MODULE_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def iter_state_values(value):
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            if (
+                key == "state"
+                or key.endswith("State")
+                or key.endswith("Status")
+            ) and isinstance(nested, str):
+                yield nested
+            yield from iter_state_values(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            yield from iter_state_values(nested)
+
+
+def iter_keys(value):
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            yield key
+            yield from iter_keys(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            yield from iter_keys(nested)
+
+
+def assert_no_private_or_generated_data(text: str) -> None:
+    forbidden_patterns = [
+        r"/home/[^\s\"']+",
+        r"/Users/[^\s\"']+",
+        r"[A-Za-z]:\\Users\\",
+        r"\b(?:api[_-]?key|authorization|bearer|client[_-]?secret|password|private[_-]?key|secret|token)\b\s*[:=]",
+        r"\.(?:gguf|safetensors|ckpt|pt|pth|onnx)\b",
+        r"(?:weights|model_weights|model-cache)/(?:[^\"'\s]+)",
+        r"(?:raw[_-]?full[_-]?logs|hardware[_-]?dump|generated[_-]?blob)\s*[:=]",
+    ]
+    for pattern in forbidden_patterns:
+        assert not re.search(pattern, text, re.IGNORECASE), pattern
+
+
+def assert_no_runtime_implementation_terms(source: str) -> None:
+    forbidden = [
+        "subprocess",
+        "os.system",
+        "popen",
+        "socket",
+        "urllib",
+        "requests",
+        "http.client",
+        "openai",
+        "anthropic",
+        "gem" + "ini",
+        "modelcontextprotocol",
+        "websocket",
+        "xmutil",
+        "xrt-smi",
+        "lsusb",
+        "dmesg",
+    ]
+    lowered = source.lower()
+    for term in forbidden:
+        assert term not in lowered, term
+
+
+def assert_no_provider_configs(value) -> None:
+    forbidden_keys = {
+        "apiKey",
+        "accessToken",
+        "refreshToken",
+        "authorization",
+        "bearerToken",
+        "provider",
+        "providers",
+        "providerConfig",
+        "providerConfigs",
+    }
+    for key in iter_keys(value):
+        assert key not in forbidden_keys, key
+
+
+def assert_no_unsupported_claims(text: str) -> None:
+    literal_claims = [
+        "production" + "-ready",
+        "marketplace" + "-ready",
+        "stable " + "API",
+        "stable " + "ABI",
+        "KV260 inference " + "works",
+        "Gemma 3N E4B " + "runs on KV260",
+        "20 tok/s " + "achieved",
+        "timing " + "closed",
+        "bitstream " + "ready",
+        "launcher executes " + "pccx-lab",
+        "IDE controls " + "launcher",
+        "AI provider integration " + "is live",
+    ]
+    lowered = text.lower()
+    for claim in literal_claims:
+        assert claim.lower() not in lowered, claim
+
+
+def test_chat_clipboard_policy_matches_fixture_and_is_deterministic() -> None:
+    module = load_module()
+    generated = module.create_gemma3n_e4b_kv260_chat_clipboard_policy()
+    fixture = json.loads(read_text(FIXTURE_PATH))
+
+    assert generated == fixture
+    assert module.chat_clipboard_policy_json(generated) == (
+        module.chat_clipboard_policy_json(generated)
+    )
+    assert module.chat_clipboard_policy_json(generated).endswith("\n")
+    assert json.loads(module.chat_clipboard_policy_json(generated)) == fixture
+
+
+def test_cli_stub_outputs_deterministic_json() -> None:
+    fixture = json.loads(read_text(FIXTURE_PATH))
+    command = [
+        "bash",
+        str(SCRIPT_PATH),
+        "--model",
+        "gemma3n-e4b",
+        "--target",
+        "kv260",
+    ]
+    first = subprocess.run(command, check=True, capture_output=True, text=True)
+    second = subprocess.run(command, check=True, capture_output=True, text=True)
+
+    assert first.stderr == ""
+    assert first.stdout == second.stdout
+    assert first.stdout.endswith("\n")
+    assert json.loads(first.stdout) == fixture
+
+
+def test_required_fields_and_allowed_states() -> None:
+    module = load_module()
+    clipboard_policy = module.create_gemma3n_e4b_kv260_chat_clipboard_policy()
+    allowed = set(module.CHAT_CLIPBOARD_POLICY_STATE_VALUES)
+
+    assert tuple(clipboard_policy.keys()) == module.CHAT_CLIPBOARD_POLICY_FIELDS
+    assert clipboard_policy["schemaVersion"] == "pccx.chatClipboardPolicy.v0"
+    assert (
+        tuple(clipboard_policy["clipboardPolicy"].keys())
+        == module.CLIPBOARD_POLICY_FIELDS
+    )
+
+    states = list(iter_state_values(clipboard_policy))
+    assert states
+    for state in states:
+        assert state in allowed, state
+
+    for surface in clipboard_policy["clipboardSurfaces"]:
+        assert tuple(surface.keys()) == module.CLIPBOARD_SURFACE_FIELDS
+    for control in clipboard_policy["clipboardControls"]:
+        assert tuple(control.keys()) == module.CLIPBOARD_CONTROL_FIELDS
+    for reason in clipboard_policy["blockedReasons"]:
+        assert tuple(reason.keys()) == module.BLOCKED_REASON_FIELDS
+    for ref in clipboard_policy["handoffRefs"]:
+        assert tuple(ref.keys()) == module.HANDOFF_REF_FIELDS
+
+
+def test_chat_clipboard_policy_keeps_clipboard_disabled() -> None:
+    clipboard_policy = load_module().create_gemma3n_e4b_kv260_chat_clipboard_policy()
+    policy = clipboard_policy["clipboardPolicy"]
+    flags = clipboard_policy["safetyFlags"]
+    surfaces = {
+        surface["surfaceId"]: surface
+        for surface in clipboard_policy["clipboardSurfaces"]
+    }
+    controls = {
+        control["controlId"]: control
+        for control in clipboard_policy["clipboardControls"]
+    }
+    reasons = {
+        reason["reasonId"]: reason for reason in clipboard_policy["blockedReasons"]
+    }
+    refs = {ref["refId"]: ref for ref in clipboard_policy["handoffRefs"]}
+
+    assert clipboard_policy["clipboardPolicyState"] == "blocked"
+    assert clipboard_policy["clipboardReadState"] == "disabled"
+    assert clipboard_policy["clipboardWriteState"] == "disabled"
+    assert clipboard_policy["copyActionState"] == "disabled"
+    assert clipboard_policy["pasteActionState"] == "disabled"
+    assert clipboard_policy["clipboardImportState"] == "disabled"
+    assert clipboard_policy["clipboardExportState"] == "disabled"
+    assert clipboard_policy["selectionState"] == "empty_not_captured"
+    assert clipboard_policy["messageContentState"] == "empty_not_captured"
+    assert policy["sideEffectPolicy"] == "local_render_only"
+    assert policy["readEnabled"] is False
+    assert policy["writeEnabled"] is False
+    assert policy["copyEnabled"] is False
+    assert policy["pasteEnabled"] is False
+    assert policy["importEnabled"] is False
+    assert policy["exportEnabled"] is False
+    assert set(surfaces) == {
+        "message_actions",
+        "composer_input",
+        "attachment_input",
+        "transcript_export",
+    }
+    assert all(surface["enabled"] is False for surface in surfaces.values())
+    assert set(controls) == {
+        "copy_message",
+        "copy_transcript",
+        "paste_prompt",
+        "paste_attachment",
+        "import_clipboard_payload",
+        "export_to_clipboard",
+    }
+    assert all(control["enabled"] is False for control in controls.values())
+    assert controls["copy_message"]["sideEffectPolicy"] == "no_clipboard_write"
+    assert controls["copy_transcript"]["sideEffectPolicy"] == (
+        "no_transcript_read_no_clipboard_write"
+    )
+    assert controls["paste_prompt"]["sideEffectPolicy"] == "no_clipboard_read"
+    assert controls["paste_attachment"]["sideEffectPolicy"] == (
+        "no_clipboard_attachment_read"
+    )
+    assert controls["import_clipboard_payload"]["sideEffectPolicy"] == (
+        "no_clipboard_import"
+    )
+    assert controls["export_to_clipboard"]["sideEffectPolicy"] == (
+        "no_clipboard_export"
+    )
+    assert set(reasons) == {
+        "clipboard_api_boundary_absent",
+        "message_content_absent",
+        "transcript_export_not_reviewed",
+        "attachment_clipboard_boundary_absent",
+        "privacy_redaction_not_reviewed",
+    }
+    assert set(refs) == {
+        "chat_composer",
+        "chat_action_bar",
+        "chat_message_list",
+        "chat_attachment_policy",
+        "chat_transcript_policy",
+        "chat_local_only_policy",
+    }
+    assert flags["readOnly"] is True
+    assert flags["dataOnly"] is True
+    assert flags["clipboardPolicyDisplayOnly"] is True
+    assert flags["clipboardMetadataOnly"] is True
+    assert flags["clipboardRead"] is False
+    assert flags["clipboardWrite"] is False
+    assert flags["clipboardCopy"] is False
+    assert flags["clipboardPaste"] is False
+    assert flags["clipboardImport"] is False
+    assert flags["clipboardExport"] is False
+    assert flags["clipboardAttachmentRead"] is False
+    assert flags["clipboardEventListenerInstalled"] is False
+    assert flags["selectionRead"] is False
+    assert flags["messageBodiesIncluded"] is False
+    assert flags["promptCapture"] is False
+    assert flags["promptRead"] is False
+    assert flags["promptContentIncluded"] is False
+    assert flags["responseContentIncluded"] is False
+    assert flags["transcriptContentIncluded"] is False
+    assert flags["readsTranscript"] is False
+    assert flags["transcriptExport"] is False
+    assert flags["readsSessionStore"] is False
+    assert flags["sessionStoreRead"] is False
+    assert flags["sessionStoreWrite"] is False
+    assert flags["attachmentReads"] is False
+    assert flags["fileUpload"] is False
+    assert flags["fileImport"] is False
+    assert flags["filePreview"] is False
+    assert flags["writesArtifacts"] is False
+    assert flags["readsArtifacts"] is False
+    assert flags["modelAssetRead"] is False
+    assert flags["modelExecution"] is False
+    assert flags["runtimeExecution"] is False
+    assert flags["kv260Access"] is False
+    assert flags["hardwareAccess"] is False
+    assert flags["networkCalls"] is False
+    assert flags["providerCalls"] is False
+    assert flags["cloudCalls"] is False
+    assert flags["executesPccxLab"] is False
+
+
+def test_chat_clipboard_policy_docs_and_ci_are_wired() -> None:
+    doc = read_text(DOC_PATH)
+    readme = read_text(README_PATH)
+    status_test = read_text(STATUS_TEST_PATH)
+    ci = read_text(CI_PATH)
+
+    assert "contracts/chat_clipboard_policy_contract.py" in doc
+    assert (
+        "contracts/fixtures/chat-clipboard-policy.gemma3n-e4b-kv260-placeholder.json"
+        in doc
+    )
+    assert "scripts/chat-clipboard-policy-stub.sh" in doc
+    assert "scripts/tests/chat_clipboard_policy_contract_test.py" in doc
+    assert "scripts/tests/status-chat-clipboard-policy.sh" in doc
+    assert "chat-clipboard-policy-stub.sh" in readme
+    assert "--include-chat-clipboard-policy" in readme
+    assert "chat_clipboard_policy_contract_test.py" in ci
+    assert "status-chat-clipboard-policy.sh" in ci
+    assert "--include-chat-clipboard-policy" in status_test
+
+
+def test_chat_clipboard_policy_has_no_runtime_or_private_surface() -> None:
+    module = load_module()
+    clipboard_policy = module.create_gemma3n_e4b_kv260_chat_clipboard_policy()
+    fixture_text = read_text(FIXTURE_PATH)
+    contract_source = read_text(MODULE_PATH)
+    stub_source = read_text(SCRIPT_PATH)
+    docs = "\n".join(
+        [
+            fixture_text,
+            contract_source,
+            stub_source,
+            read_text(DOC_PATH),
+            read_text(README_PATH),
+            read_text(STATUS_TEST_PATH),
+        ]
+    )
+
+    assert_no_provider_configs(clipboard_policy)
+    assert_no_private_or_generated_data(docs)
+    assert_no_unsupported_claims(docs)
+    assert_no_runtime_implementation_terms(contract_source)
+    assert_no_runtime_implementation_terms(stub_source)
+
+
+def test_source_headers_for_touched_code_files() -> None:
+    expected_headers = {
+        MODULE_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        SCRIPT_PATH: [
+            "#!/usr/bin/env bash",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        STATUS_TEST_PATH: [
+            "#!/usr/bin/env bash",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        TEST_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        CI_PATH: [
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+    }
+
+    for path, header in expected_headers.items():
+        assert read_text(path).splitlines()[: len(header)] == header, path
+
+
+if __name__ == "__main__":
+    for name, func in sorted(globals().items()):
+        if name.startswith("test_") and callable(func):
+            func()
+    print("chat clipboard-policy contract tests ok")

--- a/scripts/tests/status-chat-clipboard-policy.sh
+++ b/scripts/tests/status-chat-clipboard-policy.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+# scripts/tests/status-chat-clipboard-policy.sh - status clipboard-policy tests.
+#
+# Usage: bash scripts/tests/status-chat-clipboard-policy.sh [path/to/status-stub.sh]
+
+set -eu
+
+PASS() { printf '[PASS]  %s\n' "$*"; }
+FAIL() { printf '[FAIL] %s\n' "$*" >&2; }
+HEAD() { printf '\n=== %s ===\n' "$*"; }
+
+STUB="${1:-scripts/status-stub.sh}"
+
+if [ ! -x "$STUB" ]; then
+    chmod +x "$STUB"
+fi
+
+contains() {
+    case "$1" in
+        *"$2"*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+require_contains() {
+    local output="$1"
+    local expected="$2"
+    if ! contains "$output" "$expected"; then
+        FAIL "expected output to contain: $expected"
+        printf '%s\n' "$output" >&2
+        exit 1
+    fi
+}
+
+require_not_contains() {
+    local output="$1"
+    local forbidden="$2"
+    if contains "$output" "$forbidden"; then
+        FAIL "output contained forbidden text: $forbidden"
+        printf '%s\n' "$output" >&2
+        exit 1
+    fi
+}
+
+HEAD "1: status can include chat clipboard policy"
+OUTPUT="$("$STUB" --include-chat-clipboard-policy)"
+require_contains "$OUTPUT" "=== chat clipboard policy ==="
+require_contains "$OUTPUT" "source     : scripts/chat-clipboard-policy-stub.sh --model gemma3n-e4b --target kv260"
+require_contains "$OUTPUT" "boundary   : read-only data; no clipboard read/write/paste/copy/import/export/session-store/transcript/message/file/model/runtime/hardware/lab/IDE execution"
+require_contains "$OUTPUT" "target     : kv260"
+require_contains "$OUTPUT" "model      : gemma3n-e4b"
+require_contains "$OUTPUT" "policy     : blocked"
+require_contains "$OUTPUT" "read       : disabled"
+require_contains "$OUTPUT" "write      : disabled"
+require_contains "$OUTPUT" "copy       : disabled"
+require_contains "$OUTPUT" "paste      : disabled"
+require_contains "$OUTPUT" "import     : disabled"
+require_contains "$OUTPUT" "export     : disabled"
+require_contains "$OUTPUT" "selection  : empty_not_captured"
+require_contains "$OUTPUT" "message    : empty_not_captured"
+require_contains "$OUTPUT" "transcript : not_started"
+require_contains "$OUTPUT" "privacy    : summary_only"
+PASS "chat clipboard-policy section is present and conservative"
+
+HEAD "2: surfaces and controls stay disabled"
+require_contains "$OUTPUT" "clipboard-policy : blocked mode=disabled_until_reviewed_clipboard_boundary_exists"
+require_contains "$OUTPUT" "readEnabled=false"
+require_contains "$OUTPUT" "writeEnabled=false"
+require_contains "$OUTPUT" "copyEnabled=false"
+require_contains "$OUTPUT" "pasteEnabled=false"
+require_contains "$OUTPUT" "importEnabled=false"
+require_contains "$OUTPUT" "exportEnabled=false"
+require_contains "$OUTPUT" "userConsentRequired=true"
+require_contains "$OUTPUT" "surfaces   : message_actions=disabled:false"
+require_contains "$OUTPUT" "composer_input=blocked:false"
+require_contains "$OUTPUT" "attachment_input=disabled:false"
+require_contains "$OUTPUT" "transcript_export=not_configured:false"
+require_contains "$OUTPUT" "controls   : copy_message=disabled:false"
+require_contains "$OUTPUT" "copy_transcript=disabled:false"
+require_contains "$OUTPUT" "paste_prompt=disabled:false"
+require_contains "$OUTPUT" "paste_attachment=disabled:false"
+require_contains "$OUTPUT" "import_clipboard_payload=disabled:false"
+require_contains "$OUTPUT" "export_to_clipboard=disabled:false"
+require_contains "$OUTPUT" "blocked    : clipboard_api_boundary_absent=blocked"
+require_contains "$OUTPUT" "message_content_absent=empty_not_captured"
+require_contains "$OUTPUT" "transcript_export_not_reviewed=not_configured"
+require_contains "$OUTPUT" "attachment_clipboard_boundary_absent=disabled"
+require_contains "$OUTPUT" "privacy_redaction_not_reviewed=not_configured"
+PASS "disabled clipboard metadata is summarized"
+
+HEAD "3: safety flags stay read-only and non-executing"
+require_contains "$OUTPUT" "readOnly=true"
+require_contains "$OUTPUT" "dataOnly=true"
+require_contains "$OUTPUT" "deterministic=true"
+require_contains "$OUTPUT" "clipboardPolicyDisplayOnly=true"
+require_contains "$OUTPUT" "clipboardMetadataOnly=true"
+require_contains "$OUTPUT" "clipboardRead=false"
+require_contains "$OUTPUT" "clipboardWrite=false"
+require_contains "$OUTPUT" "clipboardCopy=false"
+require_contains "$OUTPUT" "clipboardPaste=false"
+require_contains "$OUTPUT" "clipboardImport=false"
+require_contains "$OUTPUT" "clipboardExport=false"
+require_contains "$OUTPUT" "clipboardAttachmentRead=false"
+require_contains "$OUTPUT" "clipboardEventListenerInstalled=false"
+require_contains "$OUTPUT" "selectionRead=false"
+require_contains "$OUTPUT" "messageBodiesIncluded=false"
+require_contains "$OUTPUT" "promptCapture=false"
+require_contains "$OUTPUT" "promptRead=false"
+require_contains "$OUTPUT" "promptContentIncluded=false"
+require_contains "$OUTPUT" "responseContentIncluded=false"
+require_contains "$OUTPUT" "transcriptContentIncluded=false"
+require_contains "$OUTPUT" "readsTranscript=false"
+require_contains "$OUTPUT" "transcriptExport=false"
+require_contains "$OUTPUT" "readsSessionStore=false"
+require_contains "$OUTPUT" "sessionStoreRead=false"
+require_contains "$OUTPUT" "sessionStoreWrite=false"
+require_contains "$OUTPUT" "attachmentReads=false"
+require_contains "$OUTPUT" "fileUpload=false"
+require_contains "$OUTPUT" "fileImport=false"
+require_contains "$OUTPUT" "filePreview=false"
+require_contains "$OUTPUT" "writesArtifacts=false"
+require_contains "$OUTPUT" "readsArtifacts=false"
+require_contains "$OUTPUT" "modelAssetRead=false"
+require_contains "$OUTPUT" "modelExecution=false"
+require_contains "$OUTPUT" "runtimeExecution=false"
+require_contains "$OUTPUT" "kv260Access=false"
+require_contains "$OUTPUT" "hardwareAccess=false"
+require_contains "$OUTPUT" "networkCalls=false"
+require_contains "$OUTPUT" "providerCalls=false"
+require_contains "$OUTPUT" "cloudCalls=false"
+require_contains "$OUTPUT" "executesPccxLab=false"
+PASS "execution-related flags remain false"
+
+HEAD "4: output is deterministic"
+OUTPUT_AGAIN="$("$STUB" --include-chat-clipboard-policy)"
+if [ "$OUTPUT" != "$OUTPUT_AGAIN" ]; then
+    FAIL "status chat clipboard-policy output changed between runs"
+    exit 1
+fi
+PASS "status chat clipboard-policy output is deterministic"
+
+HEAD "5: chat clipboard-policy option does not combine with pccx-lab backend"
+if "$STUB" --include-chat-clipboard-policy --backend pccx-lab >/dev/null 2>&1; then
+    FAIL "expected combined chat-clipboard-policy/backend mode to fail"
+    exit 1
+fi
+PASS "chat clipboard-policy remains separate from backend execution"
+
+HEAD "6: output avoids known overclaims"
+FORBIDDEN_PREFIX="KV260 inference"
+FORBIDDEN_CLAIM="${FORBIDDEN_PREFIX} works"
+require_not_contains "$OUTPUT" "$FORBIDDEN_CLAIM"
+THROUGHPUT_PREFIX="20 tok/s"
+THROUGHPUT_CLAIM="${THROUGHPUT_PREFIX} achieved"
+require_not_contains "$OUTPUT" "$THROUGHPUT_CLAIM"
+PASS "no chat clipboard-policy or throughput overclaim in status output"
+
+printf '\n[DONE]  all status-chat-clipboard-policy tests passed\n'


### PR DESCRIPTION
## Summary

- Add a data-only chat clipboard-policy contract, checked fixture, and stub for the standalone chat surface.
- Keep clipboard read, write, paste, copy, import, export, transcript-copy, message-copy, and clipboard-backed attachment gates disabled or blocked.
- Wire the new status opt-in, README/docs coverage, CI checks, and focused contract/status tests.

Refs #9

## Validation

- `python3 scripts/tests/chat_clipboard_policy_contract_test.py`
- `bash scripts/tests/status-chat-clipboard-policy.sh scripts/status-stub.sh`
- `python3 -m py_compile contracts/*.py scripts/tests/*.py`
- `find scripts -type f -name '*.sh' -not -name '*.snapshot' -exec bash -n {} +`
- `for test_file in scripts/tests/*_test.py; do python3 "$test_file"; done`
- `for test_file in scripts/tests/status-*.sh; do bash "$test_file" scripts/status-stub.sh; done`
- `git diff --check`
- local forbidden-claim scan: clean
- `./scripts/check.sh`
- `./scripts/check-device-stub.sh`
- `./scripts/install-stub.sh`
- `./scripts/status-stub.sh --include-chat-clipboard-policy`

Shellcheck is not installed on this host; the workflow installs and runs it.
