### PR TITLE
Add chat redaction policy boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,7 @@ jobs:
                    scripts/chat-message-list-stub.sh \
                    scripts/chat-action-bar-stub.sh \
                    scripts/chat-clipboard-policy-stub.sh \
+                   scripts/chat-redaction-policy-stub.sh \
                    scripts/chat-attachment-policy-stub.sh \
                    scripts/chat-shortcut-map-stub.sh \
                    scripts/chat-surface-preview.sh \
@@ -265,6 +266,10 @@ jobs:
         run: ./scripts/status-stub.sh --include-chat-clipboard-policy
       - name: run scripts/chat-clipboard-policy-stub.sh
         run: ./scripts/chat-clipboard-policy-stub.sh --model gemma3n-e4b --target kv260
+      - name: run scripts/status-stub.sh with chat redaction policy
+        run: ./scripts/status-stub.sh --include-chat-redaction-policy
+      - name: run scripts/chat-redaction-policy-stub.sh
+        run: ./scripts/chat-redaction-policy-stub.sh --model gemma3n-e4b --target kv260
       - name: run scripts/status-stub.sh with chat attachment policy
         run: ./scripts/status-stub.sh --include-chat-attachment-policy
       - name: run scripts/chat-attachment-policy-stub.sh
@@ -341,6 +346,8 @@ jobs:
         run: python3 scripts/tests/chat_action_bar_contract_test.py
       - name: run chat clipboard-policy contract tests
         run: python3 scripts/tests/chat_clipboard_policy_contract_test.py
+      - name: run chat redaction-policy contract tests
+        run: python3 scripts/tests/chat_redaction_policy_contract_test.py
       - name: run chat attachment-policy contract tests
         run: python3 scripts/tests/chat_attachment_policy_contract_test.py
       - name: run chat shortcut-map contract tests
@@ -380,6 +387,7 @@ jobs:
           chmod +x scripts/chat-message-list-stub.sh
           chmod +x scripts/chat-action-bar-stub.sh
           chmod +x scripts/chat-clipboard-policy-stub.sh
+          chmod +x scripts/chat-redaction-policy-stub.sh
           chmod +x scripts/chat-attachment-policy-stub.sh
           chmod +x scripts/chat-shortcut-map-stub.sh
           chmod +x scripts/launch-stub.sh
@@ -408,6 +416,7 @@ jobs:
           chmod +x scripts/tests/status-chat-message-list.sh
           chmod +x scripts/tests/status-chat-action-bar.sh
           chmod +x scripts/tests/status-chat-clipboard-policy.sh
+          chmod +x scripts/tests/status-chat-redaction-policy.sh
           chmod +x scripts/tests/status-chat-attachment-policy.sh
           chmod +x scripts/tests/status-chat-shortcut-map.sh
       - name: shellcheck status-stub and test script
@@ -439,6 +448,7 @@ jobs:
           shellcheck scripts/tests/status-chat-message-list.sh
           shellcheck scripts/tests/status-chat-action-bar.sh
           shellcheck scripts/tests/status-chat-clipboard-policy.sh
+          shellcheck scripts/tests/status-chat-redaction-policy.sh
           shellcheck scripts/tests/status-chat-attachment-policy.sh
           shellcheck scripts/tests/status-chat-shortcut-map.sh
       - name: run status-backend tests
@@ -491,6 +501,8 @@ jobs:
         run: bash scripts/tests/status-chat-action-bar.sh scripts/status-stub.sh
       - name: run status-chat-clipboard-policy tests
         run: bash scripts/tests/status-chat-clipboard-policy.sh scripts/status-stub.sh
+      - name: run status-chat-redaction-policy tests
+        run: bash scripts/tests/status-chat-redaction-policy.sh scripts/status-stub.sh
       - name: run status-chat-attachment-policy tests
         run: bash scripts/tests/status-chat-attachment-policy.sh scripts/status-stub.sh
       - name: run status-chat-shortcut-map tests

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ and verify host-side prerequisites before the real engine lands.
 | [`scripts/check.sh`](./scripts/check.sh) | Probe host info, tooling availability, edge-device hints. Always exits 0. |
 | [`scripts/check-device-stub.sh`](./scripts/check-device-stub.sh) | Narrowly scoped device-tree / FPGA-node probe (KV260 / Kria detection only). Always exits 0. |
 | [`scripts/install-stub.sh`](./scripts/install-stub.sh) | Preview of the planned install flow; reports which host runtime pieces are present, lists device-side pieces as future deliverables. Always exits 0. |
-| [`scripts/status-stub.sh`](./scripts/status-stub.sh) | Launcher state summary. Default mode: local scaffold output, always exits 0. With `--include-chat-action-bar`, adds read-only disabled chat action-bar data. With `--include-chat-clipboard-policy`, adds read-only disabled chat clipboard-policy data. With `--include-chat-attachment-policy`, adds read-only disabled chat attachment-policy data. With `--include-chat-shortcut-map`, adds read-only disabled chat shortcut-map data. With `--include-chat-message-list`, adds read-only empty chat message-list data. With `--include-chat-response-stream`, adds read-only blocked chat response stream data. With `--include-chat-error-taxonomy`, adds read-only chat error taxonomy data. With `--include-chat-audit-event`, adds read-only blocked chat audit-event metadata. With `--include-chat-surface-layout`, adds read-only chat surface layout data. With `--include-chat-empty-state`, adds read-only display-only chat empty-state data. With `--include-chat-local-only-policy`, adds read-only local-only/cloud-block policy data. With `--include-chat-preferences`, adds read-only chat preferences/settings data. With `--include-chat-session-index`, adds read-only empty chat session index data. With `--include-chat-session-store-policy`, adds read-only disabled chat session-store policy data. With `--include-chat-session-title-policy`, adds read-only placeholder session-title policy data. With `--include-chat-transcript-policy`, adds read-only chat transcript retention/export policy data. With `--include-chat-send-result`, adds read-only blocked chat send-result data. With `--include-chat-composer`, adds read-only chat composer/input-control data. With `--include-chat-model-status`, adds read-only blocked chat model-status display data. With `--include-chat-model-selection-policy`, adds read-only disabled chat model-selection data. With `--include-chat-context-policy`, adds read-only disabled chat context-window/tokenization policy data. With `--include-chat-model-load-request`, adds read-only disabled chat model-load request data. With `--include-chat-session`, adds read-only blocked chat/session and lifecycle summaries. With `--include-chat-readiness`, adds read-only chat readiness checks and recovery actions. With `--include-device-session`, adds a read-only device/session status panel. With `--include-runtime-readiness`, adds a read-only runtime readiness summary. With `--backend pccx-lab`, calls `pccx-lab status --format json` and forwards the run-status envelope (exits non-zero if binary is missing or output is invalid). |
+| [`scripts/status-stub.sh`](./scripts/status-stub.sh) | Launcher state summary. Default mode: local scaffold output, always exits 0. With `--include-chat-action-bar`, adds read-only disabled chat action-bar data. With `--include-chat-clipboard-policy`, adds read-only disabled chat clipboard-policy data. With `--include-chat-redaction-policy`, adds read-only disabled chat redaction-policy data. With `--include-chat-attachment-policy`, adds read-only disabled chat attachment-policy data. With `--include-chat-shortcut-map`, adds read-only disabled chat shortcut-map data. With `--include-chat-message-list`, adds read-only empty chat message-list data. With `--include-chat-response-stream`, adds read-only blocked chat response stream data. With `--include-chat-error-taxonomy`, adds read-only chat error taxonomy data. With `--include-chat-audit-event`, adds read-only blocked chat audit-event metadata. With `--include-chat-surface-layout`, adds read-only chat surface layout data. With `--include-chat-empty-state`, adds read-only display-only chat empty-state data. With `--include-chat-local-only-policy`, adds read-only local-only/cloud-block policy data. With `--include-chat-preferences`, adds read-only chat preferences/settings data. With `--include-chat-session-index`, adds read-only empty chat session index data. With `--include-chat-session-store-policy`, adds read-only disabled chat session-store policy data. With `--include-chat-session-title-policy`, adds read-only placeholder session-title policy data. With `--include-chat-transcript-policy`, adds read-only chat transcript retention/export policy data. With `--include-chat-send-result`, adds read-only blocked chat send-result data. With `--include-chat-composer`, adds read-only chat composer/input-control data. With `--include-chat-model-status`, adds read-only blocked chat model-status display data. With `--include-chat-model-selection-policy`, adds read-only disabled chat model-selection data. With `--include-chat-context-policy`, adds read-only disabled chat context-window/tokenization policy data. With `--include-chat-model-load-request`, adds read-only disabled chat model-load request data. With `--include-chat-session`, adds read-only blocked chat/session and lifecycle summaries. With `--include-chat-readiness`, adds read-only chat readiness checks and recovery actions. With `--include-device-session`, adds a read-only device/session status panel. With `--include-runtime-readiness`, adds a read-only runtime readiness summary. With `--backend pccx-lab`, calls `pccx-lab status --format json` and forwards the run-status envelope (exits non-zero if binary is missing or output is invalid). |
 | [`scripts/device-session-status-stub.sh`](./scripts/device-session-status-stub.sh) | Data-only device/session status JSON for the Gemma 3N E4B + KV260 target. Reports connection, model load, session, diagnostics, readiness, discovery paths, flow steps, and error taxonomy as placeholder / blocked. |
 | [`scripts/runtime-readiness-stub.sh`](./scripts/runtime-readiness-stub.sh) | Data-only runtime readiness JSON for the Gemma 3N E4B + KV260 target. Reports blocked / not yet evidence-backed. |
 | [`scripts/chat-session-stub.sh`](./scripts/chat-session-stub.sh) | Data-only standalone chat/session JSON for the Gemma 3N E4B + KV260 target. Reports disabled send controls, inactive session state, no prompt/response persistence, and readiness handoff references. |
@@ -110,6 +110,7 @@ and verify host-side prerequisites before the real engine lands.
 | [`scripts/chat-message-list-stub.sh`](./scripts/chat-message-list-stub.sh) | Data-only empty chat message-list JSON for the Gemma 3N E4B + KV260 target. Reports an empty conversation viewport without reading a session store, transcript, prompt, response, summary, model path, runtime log, or artifact. |
 | [`scripts/chat-action-bar-stub.sh`](./scripts/chat-action-bar-stub.sh) | Data-only disabled chat action-bar JSON for the Gemma 3N E4B + KV260 target. Reports new, clear, export, retry, copy, stop, and attach controls without reading stores, transcripts, message bodies, files, clipboard data, model paths, runtime logs, or artifacts. |
 | [`scripts/chat-clipboard-policy-stub.sh`](./scripts/chat-clipboard-policy-stub.sh) | Data-only disabled chat clipboard-policy JSON for the Gemma 3N E4B + KV260 target. Reports clipboard read, write, paste, copy, import, export, transcript-copy, message-copy, and clipboard-backed attachment gates without reading or writing clipboard, prompt, response, transcript, message, file, model, runtime, or artifact data. |
+| [`scripts/chat-redaction-policy-stub.sh`](./scripts/chat-redaction-policy-stub.sh) | Data-only disabled chat redaction-policy JSON for the Gemma 3N E4B + KV260 target. Reports redaction rule, content scan, PII, secret, prompt, response, transcript, message, attachment, clipboard, audit, and persistence gates without loading rules, scanning content, applying redactions, reading files, or starting model/runtime paths. |
 | [`scripts/chat-attachment-policy-stub.sh`](./scripts/chat-attachment-policy-stub.sh) | Data-only disabled chat attachment-policy JSON for the Gemma 3N E4B + KV260 target. Reports disabled file picker, file read, upload, import, preview, and persistence gates without reading file names, paths, metadata, contents, clipboard data, transcripts, generated artifacts, model paths, runtime logs, or artifacts. |
 | [`scripts/chat-shortcut-map-stub.sh`](./scripts/chat-shortcut-map-stub.sh) | Data-only disabled chat shortcut-map JSON for the Gemma 3N E4B + KV260 target. Reports planned keyboard accelerator and focus metadata without installing listeners, capturing key events, dispatching commands, changing focus, reading prompts, sessions, transcripts, messages, files, or clipboard data, or starting runtime paths. |
 | [`scripts/chat-transcript-policy-stub.sh`](./scripts/chat-transcript-policy-stub.sh) | Data-only chat transcript policy JSON for the Gemma 3N E4B + KV260 target. Reports retention, export, storage, and privacy policy state without reading, generating, storing, persisting, summarizing, or exporting prompt/response/transcript content. |
@@ -146,6 +147,7 @@ bash scripts/status-stub.sh --include-chat-response-stream
 bash scripts/status-stub.sh --include-chat-message-list
 bash scripts/status-stub.sh --include-chat-action-bar
 bash scripts/status-stub.sh --include-chat-clipboard-policy
+bash scripts/status-stub.sh --include-chat-redaction-policy
 bash scripts/status-stub.sh --include-chat-attachment-policy
 bash scripts/status-stub.sh --include-chat-shortcut-map
 bash scripts/status-stub.sh --include-device-session
@@ -175,6 +177,7 @@ bash scripts/chat-response-stream-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-message-list-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-action-bar-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-clipboard-policy-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/chat-redaction-policy-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-attachment-policy-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-shortcut-map-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-surface-preview.sh --model gemma3n-e4b --target kv260
@@ -350,6 +353,7 @@ python3 contracts/chat_audit_event_contract.py --model gemma3n-e4b --target kv26
 python3 contracts/chat_error_taxonomy_contract.py --model gemma3n-e4b --target kv260
 python3 contracts/chat_response_stream_contract.py --model gemma3n-e4b --target kv260
 python3 contracts/chat_action_bar_contract.py --model gemma3n-e4b --target kv260
+python3 contracts/chat_redaction_policy_contract.py --model gemma3n-e4b --target kv260
 python3 contracts/chat_attachment_policy_contract.py --model gemma3n-e4b --target kv260
 python3 contracts/chat_session_store_policy_contract.py --model gemma3n-e4b --target kv260
 python3 contracts/chat_shortcut_map_contract.py --model gemma3n-e4b --target kv260
@@ -369,6 +373,7 @@ bash scripts/chat-error-taxonomy-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-response-stream-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-action-bar-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-clipboard-policy-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/chat-redaction-policy-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-attachment-policy-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-shortcut-map-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-surface-preview.sh --model gemma3n-e4b --target kv260
@@ -382,6 +387,7 @@ bash scripts/status-stub.sh --include-chat-error-taxonomy
 bash scripts/status-stub.sh --include-chat-response-stream
 bash scripts/status-stub.sh --include-chat-action-bar
 bash scripts/status-stub.sh --include-chat-clipboard-policy
+bash scripts/status-stub.sh --include-chat-redaction-policy
 bash scripts/status-stub.sh --include-chat-attachment-policy
 bash scripts/status-stub.sh --include-chat-session-store-policy
 bash scripts/status-stub.sh --include-chat-shortcut-map
@@ -398,6 +404,7 @@ python3 scripts/tests/chat_audit_event_contract_test.py
 python3 scripts/tests/chat_error_taxonomy_contract_test.py
 python3 scripts/tests/chat_response_stream_contract_test.py
 python3 scripts/tests/chat_action_bar_contract_test.py
+python3 scripts/tests/chat_redaction_policy_contract_test.py
 python3 scripts/tests/chat_attachment_policy_contract_test.py
 python3 scripts/tests/chat_session_store_policy_contract_test.py
 python3 scripts/tests/chat_shortcut_map_contract_test.py
@@ -413,6 +420,7 @@ bash scripts/tests/status-chat-error-taxonomy.sh
 bash scripts/tests/status-chat-response-stream.sh
 bash scripts/tests/status-chat-action-bar.sh
 bash scripts/tests/status-chat-clipboard-policy.sh
+bash scripts/tests/status-chat-redaction-policy.sh
 bash scripts/tests/status-chat-attachment-policy.sh
 bash scripts/tests/status-chat-session-store-policy.sh
 bash scripts/tests/status-chat-shortcut-map.sh
@@ -484,6 +492,13 @@ export, transcript-copy, message-copy, and clipboard-backed attachment
 gates without reading or writing clipboard data, prompt text, response
 text, transcripts, message bodies, files, model paths, runtime logs, or
 artifacts.
+
+The chat redaction-policy fixture defines the disabled content scanning
+and redaction boundary for the planned chat surface. It records rule
+review, prompt, response, transcript, message, attachment, clipboard,
+audit, PII, secret, and result-persistence gates without loading rules,
+scanning content, applying redactions, reading stores, touching files, or
+starting model/runtime paths.
 
 The chat attachment-policy fixture defines the disabled local attachment
 boundary for the planned chat surface. It records file picker, file

--- a/contracts/chat_redaction_policy_contract.py
+++ b/contracts/chat_redaction_policy_contract.py
@@ -1,0 +1,549 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Data-only chat redaction policy contract for the planned launcher UI.
+
+The contract describes disabled redaction and content-scan gates for the
+standalone chat surface. It does not load redaction rules, scan prompts,
+responses, transcripts, messages, attachments, clipboard payloads, audit
+events, session stores, model assets, or logs; it does not detect PII or
+secrets, apply redactions, persist redaction results, touch KV260 hardware,
+call providers, invoke pccx-lab, or start runtime code.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import sys
+
+
+SCHEMA_VERSION = "pccx.chatRedactionPolicy.v0"
+
+CHAT_REDACTION_POLICY_FIELDS = (
+    "schemaVersion",
+    "redactionPolicyId",
+    "fixtureVersion",
+    "lastUpdatedSource",
+    "targetDevice",
+    "targetBoard",
+    "targetModel",
+    "redactionPolicyState",
+    "contentScanState",
+    "promptRedactionState",
+    "responseRedactionState",
+    "transcriptRedactionState",
+    "messageRedactionState",
+    "attachmentRedactionState",
+    "clipboardRedactionState",
+    "auditRedactionState",
+    "piiDetectionState",
+    "secretDetectionState",
+    "persistenceState",
+    "privacyState",
+    "chatComposerRef",
+    "chatMessageListRef",
+    "chatTranscriptPolicyRef",
+    "chatAttachmentPolicyRef",
+    "chatClipboardPolicyRef",
+    "chatAuditEventRef",
+    "chatLocalOnlyPolicyRef",
+    "redactionPolicy",
+    "redactionSurfaces",
+    "redactionControls",
+    "blockedReasons",
+    "handoffRefs",
+    "safetyFlags",
+    "limitations",
+    "issueRefs",
+)
+
+REDACTION_POLICY_FIELDS = (
+    "state",
+    "mode",
+    "sourcePolicy",
+    "contentPolicy",
+    "scannerEnabled",
+    "promptRedactionEnabled",
+    "responseRedactionEnabled",
+    "transcriptRedactionEnabled",
+    "messageRedactionEnabled",
+    "attachmentRedactionEnabled",
+    "clipboardRedactionEnabled",
+    "auditRedactionEnabled",
+    "piiDetectionEnabled",
+    "secretDetectionEnabled",
+    "persistenceEnabled",
+    "sideEffectPolicy",
+)
+
+REDACTION_SURFACE_FIELDS = (
+    "surfaceId",
+    "label",
+    "state",
+    "enabled",
+    "summary",
+    "contentPolicy",
+    "sideEffectPolicy",
+)
+
+REDACTION_CONTROL_FIELDS = (
+    "controlId",
+    "label",
+    "state",
+    "enabled",
+    "userAction",
+    "launcherAction",
+    "sideEffectPolicy",
+    "contentPolicy",
+    "blockedReasonRef",
+)
+
+BLOCKED_REASON_FIELDS = (
+    "reasonId",
+    "state",
+    "summary",
+    "requiredBefore",
+)
+
+HANDOFF_REF_FIELDS = (
+    "refId",
+    "schemaVersion",
+    "fixturePath",
+    "state",
+    "summary",
+)
+
+CHAT_REDACTION_POLICY_STATE_VALUES = (
+    "available_as_data",
+    "blocked",
+    "disabled",
+    "empty_not_captured",
+    "inactive",
+    "not_configured",
+    "not_loaded",
+    "not_started",
+    "not_used",
+    "placeholder",
+    "planned",
+    "requires_evidence",
+    "requires_review",
+    "summary_only",
+    "target_selected",
+    "unavailable",
+)
+
+_CHAT_REDACTION_POLICY = {
+    "schemaVersion": SCHEMA_VERSION,
+    "redactionPolicyId": "chat_redaction_policy_gemma3n_e4b_kv260_placeholder",
+    "fixtureVersion": "chat-redaction-policy.gemma3n-e4b-kv260.2026-05-05",
+    "lastUpdatedSource": "pccx_launcher_issue_9_chat_redaction_policy_boundary_2026-05-05",
+    "targetDevice": "kv260",
+    "targetBoard": "xilinx_kria_kv260",
+    "targetModel": "gemma3n-e4b",
+    "redactionPolicyState": "blocked",
+    "contentScanState": "disabled",
+    "promptRedactionState": "disabled",
+    "responseRedactionState": "disabled",
+    "transcriptRedactionState": "not_configured",
+    "messageRedactionState": "empty_not_captured",
+    "attachmentRedactionState": "blocked",
+    "clipboardRedactionState": "disabled",
+    "auditRedactionState": "blocked",
+    "piiDetectionState": "disabled",
+    "secretDetectionState": "disabled",
+    "persistenceState": "disabled",
+    "privacyState": "summary_only",
+    "chatComposerRef": "chat_composer_gemma3n_e4b_kv260_placeholder",
+    "chatMessageListRef": "chat_message_list_gemma3n_e4b_kv260_placeholder",
+    "chatTranscriptPolicyRef": "chat_transcript_policy_gemma3n_e4b_kv260_placeholder",
+    "chatAttachmentPolicyRef": "chat_attachment_policy_gemma3n_e4b_kv260_placeholder",
+    "chatClipboardPolicyRef": "chat_clipboard_policy_gemma3n_e4b_kv260_placeholder",
+    "chatAuditEventRef": "chat_audit_event_gemma3n_e4b_kv260_placeholder",
+    "chatLocalOnlyPolicyRef": "chat_local_only_policy_gemma3n_e4b_kv260_placeholder",
+    "redactionPolicy": {
+        "state": "blocked",
+        "mode": "disabled_until_reviewed_redaction_rules_and_content_boundaries_exist",
+        "sourcePolicy": "checked fixture only; no prompt, response, transcript, message, attachment, clipboard, audit, session-store, file, artifact, model path, or runtime log is read",
+        "contentPolicy": "redaction policy metadata only; no raw content, detector matches, replacement text, identifiers, file names, paths, bytes, prompts, responses, transcripts, or messages are included",
+        "scannerEnabled": False,
+        "promptRedactionEnabled": False,
+        "responseRedactionEnabled": False,
+        "transcriptRedactionEnabled": False,
+        "messageRedactionEnabled": False,
+        "attachmentRedactionEnabled": False,
+        "clipboardRedactionEnabled": False,
+        "auditRedactionEnabled": False,
+        "piiDetectionEnabled": False,
+        "secretDetectionEnabled": False,
+        "persistenceEnabled": False,
+        "sideEffectPolicy": "local_render_only",
+    },
+    "redactionSurfaces": [
+        {
+            "surfaceId": "composer_prompt",
+            "label": "composer prompt",
+            "state": "blocked",
+            "enabled": False,
+            "summary": "Prompt redaction remains disabled because prompt capture is not enabled.",
+            "contentPolicy": "no_prompt_text",
+            "sideEffectPolicy": "no_prompt_scan",
+        },
+        {
+            "surfaceId": "assistant_response",
+            "label": "assistant response",
+            "state": "disabled",
+            "enabled": False,
+            "summary": "Response redaction remains disabled because no generated response exists.",
+            "contentPolicy": "no_response_text",
+            "sideEffectPolicy": "no_response_scan",
+        },
+        {
+            "surfaceId": "message_list",
+            "label": "message list",
+            "state": "empty_not_captured",
+            "enabled": False,
+            "summary": "Message redaction remains unavailable because message bodies are not captured.",
+            "contentPolicy": "no_message_body",
+            "sideEffectPolicy": "no_message_scan",
+        },
+        {
+            "surfaceId": "transcript_export",
+            "label": "transcript export",
+            "state": "not_configured",
+            "enabled": False,
+            "summary": "Transcript redaction requires a reviewed store, retention, and export policy.",
+            "contentPolicy": "no_transcript_text",
+            "sideEffectPolicy": "no_transcript_scan_or_export",
+        },
+        {
+            "surfaceId": "attachment_payload",
+            "label": "attachment payload",
+            "state": "blocked",
+            "enabled": False,
+            "summary": "Attachment redaction remains blocked until file and artifact input boundaries exist.",
+            "contentPolicy": "no_file_name_path_metadata_or_bytes",
+            "sideEffectPolicy": "no_attachment_scan",
+        },
+        {
+            "surfaceId": "clipboard_payload",
+            "label": "clipboard payload",
+            "state": "disabled",
+            "enabled": False,
+            "summary": "Clipboard redaction remains disabled because clipboard reads are unavailable.",
+            "contentPolicy": "no_clipboard_content",
+            "sideEffectPolicy": "no_clipboard_scan",
+        },
+        {
+            "surfaceId": "audit_event",
+            "label": "audit event",
+            "state": "blocked",
+            "enabled": False,
+            "summary": "Audit redaction remains blocked because audit persistence is not configured.",
+            "contentPolicy": "no_actor_identifier_prompt_response_or_raw_event",
+            "sideEffectPolicy": "no_audit_scan_or_persistence",
+        },
+    ],
+    "redactionControls": [
+        {
+            "controlId": "review_redaction_rules",
+            "label": "review redaction rules",
+            "state": "not_configured",
+            "enabled": False,
+            "userAction": "Review rules only after a separate local policy source is defined.",
+            "launcherAction": "Keep rules unavailable and do not load policy files.",
+            "sideEffectPolicy": "no_rule_load",
+            "contentPolicy": "no_rule_content_or_private_path",
+            "blockedReasonRef": "redaction_rules_absent",
+        },
+        {
+            "controlId": "scan_prompt_content",
+            "label": "scan prompt content",
+            "state": "disabled",
+            "enabled": False,
+            "userAction": "Scan prompts only after prompt capture and redaction review exists.",
+            "launcherAction": "Do not capture, inspect, or scan prompt text.",
+            "sideEffectPolicy": "no_prompt_scan",
+            "contentPolicy": "no_prompt_text",
+            "blockedReasonRef": "content_boundary_absent",
+        },
+        {
+            "controlId": "scan_response_content",
+            "label": "scan response content",
+            "state": "disabled",
+            "enabled": False,
+            "userAction": "Scan responses only after a reviewed response stream exists.",
+            "launcherAction": "Do not generate, inspect, or scan response text.",
+            "sideEffectPolicy": "no_response_scan",
+            "contentPolicy": "no_response_text",
+            "blockedReasonRef": "content_boundary_absent",
+        },
+        {
+            "controlId": "scan_transcript_content",
+            "label": "scan transcript content",
+            "state": "not_configured",
+            "enabled": False,
+            "userAction": "Scan transcripts only after local storage and retention policy exists.",
+            "launcherAction": "Do not read, export, inspect, or scan transcripts.",
+            "sideEffectPolicy": "no_transcript_scan",
+            "contentPolicy": "no_transcript_text",
+            "blockedReasonRef": "transcript_policy_not_reviewed",
+        },
+        {
+            "controlId": "detect_sensitive_content",
+            "label": "detect sensitive content",
+            "state": "disabled",
+            "enabled": False,
+            "userAction": "Run detectors only after local detector scope and review rules exist.",
+            "launcherAction": "Do not run PII, secret, token, path, or identifier detection.",
+            "sideEffectPolicy": "no_detector_execution",
+            "contentPolicy": "no_detector_matches_or_raw_content",
+            "blockedReasonRef": "scanner_not_reviewed",
+        },
+        {
+            "controlId": "redact_attachment_payload",
+            "label": "redact attachment payload",
+            "state": "blocked",
+            "enabled": False,
+            "userAction": "Redact attachments only after file input, parsing, and redaction rules are reviewed.",
+            "launcherAction": "Do not open, read, parse, scan, or redact file or artifact payloads.",
+            "sideEffectPolicy": "no_attachment_read_or_redaction",
+            "contentPolicy": "no_file_name_path_metadata_preview_or_bytes",
+            "blockedReasonRef": "content_boundary_absent",
+        },
+        {
+            "controlId": "redact_clipboard_payload",
+            "label": "redact clipboard payload",
+            "state": "disabled",
+            "enabled": False,
+            "userAction": "Redact clipboard data only after clipboard read and redaction boundaries are reviewed.",
+            "launcherAction": "Do not read, scan, redact, import, or write clipboard data.",
+            "sideEffectPolicy": "no_clipboard_read_or_redaction",
+            "contentPolicy": "no_clipboard_content",
+            "blockedReasonRef": "content_boundary_absent",
+        },
+        {
+            "controlId": "persist_redaction_result",
+            "label": "persist redaction result",
+            "state": "disabled",
+            "enabled": False,
+            "userAction": "Persist redaction results only after local store and retention policy exists.",
+            "launcherAction": "Do not write redaction reports, artifacts, transcripts, or session records.",
+            "sideEffectPolicy": "no_redaction_result_persistence",
+            "contentPolicy": "no_redacted_content_or_report",
+            "blockedReasonRef": "persistence_not_configured",
+        },
+    ],
+    "blockedReasons": [
+        {
+            "reasonId": "redaction_rules_absent",
+            "state": "not_configured",
+            "summary": "No reviewed local redaction rule source exists.",
+            "requiredBefore": "redaction_rule_review_enabled",
+        },
+        {
+            "reasonId": "content_boundary_absent",
+            "state": "blocked",
+            "summary": "Prompt, response, message, attachment, and clipboard content boundaries remain unavailable.",
+            "requiredBefore": "content_scan_enabled",
+        },
+        {
+            "reasonId": "transcript_policy_not_reviewed",
+            "state": "not_configured",
+            "summary": "Transcript storage, retention, export, and redaction policy is not configured.",
+            "requiredBefore": "transcript_redaction_enabled",
+        },
+        {
+            "reasonId": "scanner_not_reviewed",
+            "state": "requires_review",
+            "summary": "Detector scope, match handling, and replacement policy require review.",
+            "requiredBefore": "sensitive_content_detection_enabled",
+        },
+        {
+            "reasonId": "persistence_not_configured",
+            "state": "disabled",
+            "summary": "Redaction results are not persisted or exported.",
+            "requiredBefore": "redaction_result_persistence_enabled",
+        },
+    ],
+    "handoffRefs": [
+        {
+            "refId": "chat_composer",
+            "schemaVersion": "pccx.chatComposer.v0",
+            "fixturePath": "contracts/fixtures/chat-composer.gemma3n-e4b-kv260-placeholder.json",
+            "state": "blocked",
+            "summary": "Composer data keeps prompt capture and prompt redaction disabled.",
+        },
+        {
+            "refId": "chat_message_list",
+            "schemaVersion": "pccx.chatMessageList.v0",
+            "fixturePath": "contracts/fixtures/chat-message-list.gemma3n-e4b-kv260-placeholder.json",
+            "state": "empty_not_captured",
+            "summary": "Empty message-list data prevents message redaction.",
+        },
+        {
+            "refId": "chat_transcript_policy",
+            "schemaVersion": "pccx.chatTranscriptPolicy.v0",
+            "fixturePath": "contracts/fixtures/chat-transcript-policy.gemma3n-e4b-kv260-placeholder.json",
+            "state": "disabled",
+            "summary": "Transcript persistence and export remain unavailable.",
+        },
+        {
+            "refId": "chat_attachment_policy",
+            "schemaVersion": "pccx.chatAttachmentPolicy.v0",
+            "fixturePath": "contracts/fixtures/chat-attachment-policy.gemma3n-e4b-kv260-placeholder.json",
+            "state": "blocked",
+            "summary": "Attachment policy keeps attachment payload reads disabled.",
+        },
+        {
+            "refId": "chat_clipboard_policy",
+            "schemaVersion": "pccx.chatClipboardPolicy.v0",
+            "fixturePath": "contracts/fixtures/chat-clipboard-policy.gemma3n-e4b-kv260-placeholder.json",
+            "state": "blocked",
+            "summary": "Clipboard policy keeps clipboard payload reads and writes disabled.",
+        },
+        {
+            "refId": "chat_audit_event",
+            "schemaVersion": "pccx.chatAuditEvent.v0",
+            "fixturePath": "contracts/fixtures/chat-audit-event.gemma3n-e4b-kv260-placeholder.json",
+            "state": "blocked",
+            "summary": "Audit-event data keeps audit redaction and persistence disabled.",
+        },
+        {
+            "refId": "chat_local_only_policy",
+            "schemaVersion": "pccx.chatLocalOnlyPolicy.v0",
+            "fixturePath": "contracts/fixtures/chat-local-only-policy.gemma3n-e4b-kv260-placeholder.json",
+            "state": "blocked",
+            "summary": "Local-only policy keeps provider, cloud, network, and upload paths unavailable.",
+        },
+    ],
+    "safetyFlags": {
+        "dataOnly": True,
+        "readOnly": True,
+        "deterministic": True,
+        "redactionPolicyDisplayOnly": True,
+        "redactionMetadataOnly": True,
+        "redactionRulesLoaded": False,
+        "redactionRulesPersisted": False,
+        "contentScan": False,
+        "piiDetection": False,
+        "secretDetection": False,
+        "identifierDetection": False,
+        "promptRedaction": False,
+        "responseRedaction": False,
+        "transcriptRedaction": False,
+        "messageRedaction": False,
+        "attachmentRedaction": False,
+        "clipboardRedaction": False,
+        "auditRedaction": False,
+        "redactionApplied": False,
+        "redactionResultPersisted": False,
+        "redactionReportGenerated": False,
+        "promptCapture": False,
+        "promptRead": False,
+        "promptContentIncluded": False,
+        "responseContentIncluded": False,
+        "transcriptContentIncluded": False,
+        "messageBodiesIncluded": False,
+        "readsTranscript": False,
+        "readsSessionStore": False,
+        "sessionStoreRead": False,
+        "sessionStoreWrite": False,
+        "clipboardRead": False,
+        "clipboardWrite": False,
+        "attachmentReads": False,
+        "fileNameIncluded": False,
+        "filePathIncluded": False,
+        "fileMetadataRead": False,
+        "fileContentRead": False,
+        "directoryScan": False,
+        "fileImport": False,
+        "fileUpload": False,
+        "writesArtifacts": False,
+        "readsArtifacts": False,
+        "modelAssetRead": False,
+        "modelAssetPathsIncluded": False,
+        "modelLoadAttempted": False,
+        "modelExecution": False,
+        "runtimeExecution": False,
+        "touchesHardware": False,
+        "hardwareAccess": False,
+        "kv260Access": False,
+        "networkCalls": False,
+        "providerCalls": False,
+        "cloudCalls": False,
+        "configRead": False,
+        "environmentRead": False,
+        "providerConfigRead": False,
+        "privatePathsIncluded": False,
+        "secretsIncluded": False,
+        "tokensIncluded": False,
+        "generatedBlobsIncluded": False,
+        "hardwareDumpsIncluded": False,
+        "runtimeLogsIncluded": False,
+        "telemetry": False,
+        "automaticUpload": False,
+        "writeBack": False,
+        "executesPccxLab": False,
+        "executesSystemverilogIde": False,
+        "mcpServerImplemented": False,
+        "lspImplemented": False,
+        "stableApiAbiClaim": False,
+    },
+    "limitations": [
+        "Data-only chat redaction-policy fixture; no redaction rules, prompt, response, transcript, message body, attachment, clipboard data, audit content, file, artifact, model path, runtime log, or private path is read or written.",
+        "Content scanning, sensitive-content detection, prompt redaction, response redaction, transcript redaction, message redaction, attachment redaction, clipboard redaction, audit redaction, and result persistence remain disabled or blocked.",
+        "No PII, secret, token, path, identifier, or detector match is produced or included.",
+        "No model load, runtime execution, provider call, network call, upload, artifact access, or KV260 hardware access is performed.",
+        "This is not a release, tag, compatibility commitment, MCP, LSP, IDE, marketplace, telemetry, or runtime implementation.",
+    ],
+    "issueRefs": [
+        "pccxai/pccx-llm-launcher#9",
+    ],
+}
+
+
+def create_gemma3n_e4b_kv260_chat_redaction_policy() -> dict:
+    """Return the checked Gemma 3N E4B plus KV260 chat redaction fixture."""
+    return copy.deepcopy(_CHAT_REDACTION_POLICY)
+
+
+def chat_redaction_policy_json(redaction_policy: dict | None = None) -> str:
+    """Render a deterministic JSON representation."""
+    return json.dumps(
+        redaction_policy
+        if redaction_policy is not None
+        else create_gemma3n_e4b_kv260_chat_redaction_policy(),
+        indent=2,
+        sort_keys=True,
+    ) + "\n"
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Print data-only chat redaction-policy JSON.",
+    )
+    parser.add_argument(
+        "--model",
+        default="gemma3n-e4b",
+        choices=("gemma3n-e4b",),
+        help="model descriptor target",
+    )
+    parser.add_argument(
+        "--target",
+        default="kv260",
+        choices=("kv260",),
+        help="target board/device",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parse_args(sys.argv[1:] if argv is None else argv)
+    sys.stdout.write(chat_redaction_policy_json())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contracts/fixtures/chat-redaction-policy.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-redaction-policy.gemma3n-e4b-kv260-placeholder.json
@@ -1,0 +1,368 @@
+{
+  "attachmentRedactionState": "blocked",
+  "auditRedactionState": "blocked",
+  "blockedReasons": [
+    {
+      "reasonId": "redaction_rules_absent",
+      "requiredBefore": "redaction_rule_review_enabled",
+      "state": "not_configured",
+      "summary": "No reviewed local redaction rule source exists."
+    },
+    {
+      "reasonId": "content_boundary_absent",
+      "requiredBefore": "content_scan_enabled",
+      "state": "blocked",
+      "summary": "Prompt, response, message, attachment, and clipboard content boundaries remain unavailable."
+    },
+    {
+      "reasonId": "transcript_policy_not_reviewed",
+      "requiredBefore": "transcript_redaction_enabled",
+      "state": "not_configured",
+      "summary": "Transcript storage, retention, export, and redaction policy is not configured."
+    },
+    {
+      "reasonId": "scanner_not_reviewed",
+      "requiredBefore": "sensitive_content_detection_enabled",
+      "state": "requires_review",
+      "summary": "Detector scope, match handling, and replacement policy require review."
+    },
+    {
+      "reasonId": "persistence_not_configured",
+      "requiredBefore": "redaction_result_persistence_enabled",
+      "state": "disabled",
+      "summary": "Redaction results are not persisted or exported."
+    }
+  ],
+  "chatAttachmentPolicyRef": "chat_attachment_policy_gemma3n_e4b_kv260_placeholder",
+  "chatAuditEventRef": "chat_audit_event_gemma3n_e4b_kv260_placeholder",
+  "chatClipboardPolicyRef": "chat_clipboard_policy_gemma3n_e4b_kv260_placeholder",
+  "chatComposerRef": "chat_composer_gemma3n_e4b_kv260_placeholder",
+  "chatLocalOnlyPolicyRef": "chat_local_only_policy_gemma3n_e4b_kv260_placeholder",
+  "chatMessageListRef": "chat_message_list_gemma3n_e4b_kv260_placeholder",
+  "chatTranscriptPolicyRef": "chat_transcript_policy_gemma3n_e4b_kv260_placeholder",
+  "clipboardRedactionState": "disabled",
+  "contentScanState": "disabled",
+  "fixtureVersion": "chat-redaction-policy.gemma3n-e4b-kv260.2026-05-05",
+  "handoffRefs": [
+    {
+      "fixturePath": "contracts/fixtures/chat-composer.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_composer",
+      "schemaVersion": "pccx.chatComposer.v0",
+      "state": "blocked",
+      "summary": "Composer data keeps prompt capture and prompt redaction disabled."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-message-list.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_message_list",
+      "schemaVersion": "pccx.chatMessageList.v0",
+      "state": "empty_not_captured",
+      "summary": "Empty message-list data prevents message redaction."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-transcript-policy.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_transcript_policy",
+      "schemaVersion": "pccx.chatTranscriptPolicy.v0",
+      "state": "disabled",
+      "summary": "Transcript persistence and export remain unavailable."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-attachment-policy.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_attachment_policy",
+      "schemaVersion": "pccx.chatAttachmentPolicy.v0",
+      "state": "blocked",
+      "summary": "Attachment policy keeps attachment payload reads disabled."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-clipboard-policy.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_clipboard_policy",
+      "schemaVersion": "pccx.chatClipboardPolicy.v0",
+      "state": "blocked",
+      "summary": "Clipboard policy keeps clipboard payload reads and writes disabled."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-audit-event.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_audit_event",
+      "schemaVersion": "pccx.chatAuditEvent.v0",
+      "state": "blocked",
+      "summary": "Audit-event data keeps audit redaction and persistence disabled."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-local-only-policy.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_local_only_policy",
+      "schemaVersion": "pccx.chatLocalOnlyPolicy.v0",
+      "state": "blocked",
+      "summary": "Local-only policy keeps provider, cloud, network, and upload paths unavailable."
+    }
+  ],
+  "issueRefs": [
+    "pccxai/pccx-llm-launcher#9"
+  ],
+  "lastUpdatedSource": "pccx_launcher_issue_9_chat_redaction_policy_boundary_2026-05-05",
+  "limitations": [
+    "Data-only chat redaction-policy fixture; no redaction rules, prompt, response, transcript, message body, attachment, clipboard data, audit content, file, artifact, model path, runtime log, or private path is read or written.",
+    "Content scanning, sensitive-content detection, prompt redaction, response redaction, transcript redaction, message redaction, attachment redaction, clipboard redaction, audit redaction, and result persistence remain disabled or blocked.",
+    "No PII, secret, token, path, identifier, or detector match is produced or included.",
+    "No model load, runtime execution, provider call, network call, upload, artifact access, or KV260 hardware access is performed.",
+    "This is not a release, tag, compatibility commitment, MCP, LSP, IDE, marketplace, telemetry, or runtime implementation."
+  ],
+  "messageRedactionState": "empty_not_captured",
+  "persistenceState": "disabled",
+  "piiDetectionState": "disabled",
+  "privacyState": "summary_only",
+  "promptRedactionState": "disabled",
+  "redactionControls": [
+    {
+      "blockedReasonRef": "redaction_rules_absent",
+      "contentPolicy": "no_rule_content_or_private_path",
+      "controlId": "review_redaction_rules",
+      "enabled": false,
+      "label": "review redaction rules",
+      "launcherAction": "Keep rules unavailable and do not load policy files.",
+      "sideEffectPolicy": "no_rule_load",
+      "state": "not_configured",
+      "userAction": "Review rules only after a separate local policy source is defined."
+    },
+    {
+      "blockedReasonRef": "content_boundary_absent",
+      "contentPolicy": "no_prompt_text",
+      "controlId": "scan_prompt_content",
+      "enabled": false,
+      "label": "scan prompt content",
+      "launcherAction": "Do not capture, inspect, or scan prompt text.",
+      "sideEffectPolicy": "no_prompt_scan",
+      "state": "disabled",
+      "userAction": "Scan prompts only after prompt capture and redaction review exists."
+    },
+    {
+      "blockedReasonRef": "content_boundary_absent",
+      "contentPolicy": "no_response_text",
+      "controlId": "scan_response_content",
+      "enabled": false,
+      "label": "scan response content",
+      "launcherAction": "Do not generate, inspect, or scan response text.",
+      "sideEffectPolicy": "no_response_scan",
+      "state": "disabled",
+      "userAction": "Scan responses only after a reviewed response stream exists."
+    },
+    {
+      "blockedReasonRef": "transcript_policy_not_reviewed",
+      "contentPolicy": "no_transcript_text",
+      "controlId": "scan_transcript_content",
+      "enabled": false,
+      "label": "scan transcript content",
+      "launcherAction": "Do not read, export, inspect, or scan transcripts.",
+      "sideEffectPolicy": "no_transcript_scan",
+      "state": "not_configured",
+      "userAction": "Scan transcripts only after local storage and retention policy exists."
+    },
+    {
+      "blockedReasonRef": "scanner_not_reviewed",
+      "contentPolicy": "no_detector_matches_or_raw_content",
+      "controlId": "detect_sensitive_content",
+      "enabled": false,
+      "label": "detect sensitive content",
+      "launcherAction": "Do not run PII, secret, token, path, or identifier detection.",
+      "sideEffectPolicy": "no_detector_execution",
+      "state": "disabled",
+      "userAction": "Run detectors only after local detector scope and review rules exist."
+    },
+    {
+      "blockedReasonRef": "content_boundary_absent",
+      "contentPolicy": "no_file_name_path_metadata_preview_or_bytes",
+      "controlId": "redact_attachment_payload",
+      "enabled": false,
+      "label": "redact attachment payload",
+      "launcherAction": "Do not open, read, parse, scan, or redact file or artifact payloads.",
+      "sideEffectPolicy": "no_attachment_read_or_redaction",
+      "state": "blocked",
+      "userAction": "Redact attachments only after file input, parsing, and redaction rules are reviewed."
+    },
+    {
+      "blockedReasonRef": "content_boundary_absent",
+      "contentPolicy": "no_clipboard_content",
+      "controlId": "redact_clipboard_payload",
+      "enabled": false,
+      "label": "redact clipboard payload",
+      "launcherAction": "Do not read, scan, redact, import, or write clipboard data.",
+      "sideEffectPolicy": "no_clipboard_read_or_redaction",
+      "state": "disabled",
+      "userAction": "Redact clipboard data only after clipboard read and redaction boundaries are reviewed."
+    },
+    {
+      "blockedReasonRef": "persistence_not_configured",
+      "contentPolicy": "no_redacted_content_or_report",
+      "controlId": "persist_redaction_result",
+      "enabled": false,
+      "label": "persist redaction result",
+      "launcherAction": "Do not write redaction reports, artifacts, transcripts, or session records.",
+      "sideEffectPolicy": "no_redaction_result_persistence",
+      "state": "disabled",
+      "userAction": "Persist redaction results only after local store and retention policy exists."
+    }
+  ],
+  "redactionPolicy": {
+    "attachmentRedactionEnabled": false,
+    "auditRedactionEnabled": false,
+    "clipboardRedactionEnabled": false,
+    "contentPolicy": "redaction policy metadata only; no raw content, detector matches, replacement text, identifiers, file names, paths, bytes, prompts, responses, transcripts, or messages are included",
+    "messageRedactionEnabled": false,
+    "mode": "disabled_until_reviewed_redaction_rules_and_content_boundaries_exist",
+    "persistenceEnabled": false,
+    "piiDetectionEnabled": false,
+    "promptRedactionEnabled": false,
+    "responseRedactionEnabled": false,
+    "scannerEnabled": false,
+    "secretDetectionEnabled": false,
+    "sideEffectPolicy": "local_render_only",
+    "sourcePolicy": "checked fixture only; no prompt, response, transcript, message, attachment, clipboard, audit, session-store, file, artifact, model path, or runtime log is read",
+    "state": "blocked",
+    "transcriptRedactionEnabled": false
+  },
+  "redactionPolicyId": "chat_redaction_policy_gemma3n_e4b_kv260_placeholder",
+  "redactionPolicyState": "blocked",
+  "redactionSurfaces": [
+    {
+      "contentPolicy": "no_prompt_text",
+      "enabled": false,
+      "label": "composer prompt",
+      "sideEffectPolicy": "no_prompt_scan",
+      "state": "blocked",
+      "summary": "Prompt redaction remains disabled because prompt capture is not enabled.",
+      "surfaceId": "composer_prompt"
+    },
+    {
+      "contentPolicy": "no_response_text",
+      "enabled": false,
+      "label": "assistant response",
+      "sideEffectPolicy": "no_response_scan",
+      "state": "disabled",
+      "summary": "Response redaction remains disabled because no generated response exists.",
+      "surfaceId": "assistant_response"
+    },
+    {
+      "contentPolicy": "no_message_body",
+      "enabled": false,
+      "label": "message list",
+      "sideEffectPolicy": "no_message_scan",
+      "state": "empty_not_captured",
+      "summary": "Message redaction remains unavailable because message bodies are not captured.",
+      "surfaceId": "message_list"
+    },
+    {
+      "contentPolicy": "no_transcript_text",
+      "enabled": false,
+      "label": "transcript export",
+      "sideEffectPolicy": "no_transcript_scan_or_export",
+      "state": "not_configured",
+      "summary": "Transcript redaction requires a reviewed store, retention, and export policy.",
+      "surfaceId": "transcript_export"
+    },
+    {
+      "contentPolicy": "no_file_name_path_metadata_or_bytes",
+      "enabled": false,
+      "label": "attachment payload",
+      "sideEffectPolicy": "no_attachment_scan",
+      "state": "blocked",
+      "summary": "Attachment redaction remains blocked until file and artifact input boundaries exist.",
+      "surfaceId": "attachment_payload"
+    },
+    {
+      "contentPolicy": "no_clipboard_content",
+      "enabled": false,
+      "label": "clipboard payload",
+      "sideEffectPolicy": "no_clipboard_scan",
+      "state": "disabled",
+      "summary": "Clipboard redaction remains disabled because clipboard reads are unavailable.",
+      "surfaceId": "clipboard_payload"
+    },
+    {
+      "contentPolicy": "no_actor_identifier_prompt_response_or_raw_event",
+      "enabled": false,
+      "label": "audit event",
+      "sideEffectPolicy": "no_audit_scan_or_persistence",
+      "state": "blocked",
+      "summary": "Audit redaction remains blocked because audit persistence is not configured.",
+      "surfaceId": "audit_event"
+    }
+  ],
+  "responseRedactionState": "disabled",
+  "safetyFlags": {
+    "attachmentReads": false,
+    "attachmentRedaction": false,
+    "auditRedaction": false,
+    "automaticUpload": false,
+    "clipboardRead": false,
+    "clipboardRedaction": false,
+    "clipboardWrite": false,
+    "cloudCalls": false,
+    "configRead": false,
+    "contentScan": false,
+    "dataOnly": true,
+    "deterministic": true,
+    "directoryScan": false,
+    "environmentRead": false,
+    "executesPccxLab": false,
+    "executesSystemverilogIde": false,
+    "fileContentRead": false,
+    "fileImport": false,
+    "fileMetadataRead": false,
+    "fileNameIncluded": false,
+    "filePathIncluded": false,
+    "fileUpload": false,
+    "generatedBlobsIncluded": false,
+    "hardwareAccess": false,
+    "hardwareDumpsIncluded": false,
+    "identifierDetection": false,
+    "kv260Access": false,
+    "lspImplemented": false,
+    "mcpServerImplemented": false,
+    "messageBodiesIncluded": false,
+    "messageRedaction": false,
+    "modelAssetPathsIncluded": false,
+    "modelAssetRead": false,
+    "modelExecution": false,
+    "modelLoadAttempted": false,
+    "networkCalls": false,
+    "piiDetection": false,
+    "privatePathsIncluded": false,
+    "promptCapture": false,
+    "promptContentIncluded": false,
+    "promptRead": false,
+    "promptRedaction": false,
+    "providerCalls": false,
+    "providerConfigRead": false,
+    "readOnly": true,
+    "readsArtifacts": false,
+    "readsSessionStore": false,
+    "readsTranscript": false,
+    "redactionApplied": false,
+    "redactionMetadataOnly": true,
+    "redactionPolicyDisplayOnly": true,
+    "redactionReportGenerated": false,
+    "redactionResultPersisted": false,
+    "redactionRulesLoaded": false,
+    "redactionRulesPersisted": false,
+    "responseContentIncluded": false,
+    "responseRedaction": false,
+    "runtimeExecution": false,
+    "runtimeLogsIncluded": false,
+    "secretDetection": false,
+    "secretsIncluded": false,
+    "sessionStoreRead": false,
+    "sessionStoreWrite": false,
+    "stableApiAbiClaim": false,
+    "telemetry": false,
+    "tokensIncluded": false,
+    "touchesHardware": false,
+    "transcriptContentIncluded": false,
+    "transcriptRedaction": false,
+    "writeBack": false,
+    "writesArtifacts": false
+  },
+  "schemaVersion": "pccx.chatRedactionPolicy.v0",
+  "secretDetectionState": "disabled",
+  "targetBoard": "xilinx_kria_kv260",
+  "targetDevice": "kv260",
+  "targetModel": "gemma3n-e4b",
+  "transcriptRedactionState": "not_configured"
+}

--- a/docs/STANDALONE_CHAT_SESSION_CONTRACT.md
+++ b/docs/STANDALONE_CHAT_SESSION_CONTRACT.md
@@ -30,6 +30,7 @@ The implementation lives in:
 - `contracts/chat_message_list_contract.py`
 - `contracts/chat_action_bar_contract.py`
 - `contracts/chat_clipboard_policy_contract.py`
+- `contracts/chat_redaction_policy_contract.py`
 - `contracts/chat_attachment_policy_contract.py`
 - `contracts/chat_shortcut_map_contract.py`
 - `contracts/fixtures/chat-session.gemma3n-e4b-kv260-placeholder.json`
@@ -54,6 +55,7 @@ The implementation lives in:
 - `contracts/fixtures/chat-message-list.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-action-bar.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-clipboard-policy.gemma3n-e4b-kv260-placeholder.json`
+- `contracts/fixtures/chat-redaction-policy.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-attachment-policy.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-shortcut-map.gemma3n-e4b-kv260-placeholder.json`
 - `scripts/chat-session-stub.sh`
@@ -78,6 +80,7 @@ The implementation lives in:
 - `scripts/chat-message-list-stub.sh`
 - `scripts/chat-action-bar-stub.sh`
 - `scripts/chat-clipboard-policy-stub.sh`
+- `scripts/chat-redaction-policy-stub.sh`
 - `scripts/chat-attachment-policy-stub.sh`
 - `scripts/chat-shortcut-map-stub.sh`
 - `scripts/chat-surface-preview.sh`
@@ -103,6 +106,7 @@ The implementation lives in:
 - `scripts/tests/chat_message_list_contract_test.py`
 - `scripts/tests/chat_action_bar_contract_test.py`
 - `scripts/tests/chat_clipboard_policy_contract_test.py`
+- `scripts/tests/chat_redaction_policy_contract_test.py`
 - `scripts/tests/chat_attachment_policy_contract_test.py`
 - `scripts/tests/chat_shortcut_map_contract_test.py`
 - `scripts/tests/chat_surface_preview_test.py`
@@ -127,6 +131,7 @@ The implementation lives in:
 - `scripts/tests/status-chat-message-list.sh`
 - `scripts/tests/status-chat-action-bar.sh`
 - `scripts/tests/status-chat-clipboard-policy.sh`
+- `scripts/tests/status-chat-redaction-policy.sh`
 - `scripts/tests/status-chat-attachment-policy.sh`
 - `scripts/tests/status-chat-shortcut-map.sh`
 
@@ -174,6 +179,9 @@ The chat/session contract records:
   message bodies or transcript reads
 - disabled action-bar metadata for new, clear, export, retry, copy, stop,
   and attach controls without side effects
+- disabled redaction-policy metadata for redaction rules, content scan,
+  PII, secret, prompt, response, transcript, message, attachment,
+  clipboard, audit, and result-persistence gates without side effects
 - disabled attachment-policy metadata for file picker, file read, upload,
   import, preview, and persistence gates without side effects
 - disabled shortcut-map metadata for planned keyboard accelerators,
@@ -470,6 +478,25 @@ text, response text, transcript, message body, file data, model path,
 runtime log, or artifact is read or written, no clipboard permission is
 requested, no upload or import runs, no model/runtime path is started,
 and no target access occurs.
+
+The chat redaction-policy fixture records the disabled redaction and
+content-scanning boundary used by the planned standalone chat surface:
+
+```bash
+bash scripts/chat-redaction-policy-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/status-stub.sh --include-chat-redaction-policy
+```
+
+It keeps redaction handling as local metadata: redaction rule review,
+content scan, PII detection, secret detection, prompt redaction, response
+redaction, transcript redaction, message redaction, attachment redaction,
+clipboard redaction, audit redaction, and result persistence remain
+disabled, blocked, or not configured. No redaction rules, prompt text,
+response text, transcript, message body, clipboard data, file data, audit
+content, store content, model path, runtime log, private path, or artifact
+is read or written, no detector runs, no redaction is applied, no result
+is persisted, no model/runtime path is started, and no target access
+occurs.
 
 The chat attachment-policy fixture records the disabled local attachment
 boundary used by the planned standalone chat surface:

--- a/scripts/chat-redaction-policy-stub.sh
+++ b/scripts/chat-redaction-policy-stub.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+# Print the data-only chat redaction-policy contract.
+
+set -eu
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+
+python3 "$ROOT_DIR/contracts/chat_redaction_policy_contract.py" "$@"

--- a/scripts/status-stub.sh
+++ b/scripts/status-stub.sh
@@ -76,6 +76,9 @@
 # Chat clipboard-policy boundary (explicit opt-in, read-only local data):
 #   --include-chat-clipboard-policy
 #
+# Chat redaction-policy boundary (explicit opt-in, read-only local data):
+#   --include-chat-redaction-policy
+#
 # Chat attachment-policy boundary (explicit opt-in, read-only local data):
 #   --include-chat-attachment-policy
 #
@@ -121,6 +124,7 @@ INCLUDE_CHAT_RESPONSE_STREAM="0"
 INCLUDE_CHAT_MESSAGE_LIST="0"
 INCLUDE_CHAT_ACTION_BAR="0"
 INCLUDE_CHAT_CLIPBOARD_POLICY="0"
+INCLUDE_CHAT_REDACTION_POLICY="0"
 INCLUDE_CHAT_ATTACHMENT_POLICY="0"
 INCLUDE_CHAT_SHORTCUT_MAP="0"
 
@@ -680,6 +684,171 @@ print(
 
     HEAD "chat clipboard policy"
     printf '%s\n' "$CHAT_CLIPBOARD_POLICY_SUMMARY"
+}
+
+print_chat_redaction_policy_summary() {
+    SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+    ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+    CHAT_REDACTION_POLICY_STUB="$ROOT_DIR/scripts/chat-redaction-policy-stub.sh"
+
+    if [ ! -f "$CHAT_REDACTION_POLICY_STUB" ]; then
+        ERROR "chat redaction-policy stub not found: $CHAT_REDACTION_POLICY_STUB"
+        return 1
+    fi
+
+    if ! CHAT_REDACTION_POLICY_JSON="$(bash "$CHAT_REDACTION_POLICY_STUB" --model gemma3n-e4b --target kv260 2>&1)"; then
+        ERROR "chat redaction-policy stub failed"
+        printf '%s\n' "$CHAT_REDACTION_POLICY_JSON" >&2
+        return 1
+    fi
+
+    if ! CHAT_REDACTION_POLICY_SUMMARY="$(
+        printf '%s\n' "$CHAT_REDACTION_POLICY_JSON" | python3 -c '
+import json
+import sys
+
+data = json.load(sys.stdin)
+flags = data["safetyFlags"]
+policy = data["redactionPolicy"]
+
+def b(value):
+    return "true" if value else "false"
+
+surfaces = " ".join(
+    "{}={}:{}".format(surface["surfaceId"], surface["state"], b(surface["enabled"]))
+    for surface in data["redactionSurfaces"]
+)
+controls = " ".join(
+    "{}={}:{}".format(control["controlId"], control["state"], b(control["enabled"]))
+    for control in data["redactionControls"]
+)
+blocked = " ".join(
+    "{}={}".format(reason["reasonId"], reason["state"])
+    for reason in data["blockedReasons"]
+)
+
+print("[INFO]  source     : scripts/chat-redaction-policy-stub.sh --model gemma3n-e4b --target kv260")
+print("[INFO]  boundary   : read-only data; no redaction rule load/content scan/PII detection/secret detection/prompt/message/transcript/clipboard/file/model/runtime/hardware/lab/IDE execution")
+print("[INFO]  target     : {}".format(data["targetDevice"]))
+print("[INFO]  model      : {}".format(data["targetModel"]))
+print("[INFO]  policy     : {}".format(data["redactionPolicyState"]))
+print("[INFO]  scan       : {}".format(data["contentScanState"]))
+print("[INFO]  prompt    : {}".format(data["promptRedactionState"]))
+print("[INFO]  response  : {}".format(data["responseRedactionState"]))
+print("[INFO]  transcript: {}".format(data["transcriptRedactionState"]))
+print("[INFO]  message   : {}".format(data["messageRedactionState"]))
+print("[INFO]  attachment: {}".format(data["attachmentRedactionState"]))
+print("[INFO]  clipboard : {}".format(data["clipboardRedactionState"]))
+print("[INFO]  audit     : {}".format(data["auditRedactionState"]))
+print("[INFO]  pii       : {}".format(data["piiDetectionState"]))
+print("[INFO]  secrets   : {}".format(data["secretDetectionState"]))
+print("[INFO]  persistence: {}".format(data["persistenceState"]))
+print("[INFO]  privacy   : {}".format(data["privacyState"]))
+print(
+    "[INFO]  redaction-policy : {} mode={} scannerEnabled={} "
+    "promptRedactionEnabled={} responseRedactionEnabled={} "
+    "transcriptRedactionEnabled={} messageRedactionEnabled={} "
+    "attachmentRedactionEnabled={} clipboardRedactionEnabled={} "
+    "auditRedactionEnabled={} piiDetectionEnabled={} "
+    "secretDetectionEnabled={} persistenceEnabled={}".format(
+        policy["state"],
+        policy["mode"],
+        b(policy["scannerEnabled"]),
+        b(policy["promptRedactionEnabled"]),
+        b(policy["responseRedactionEnabled"]),
+        b(policy["transcriptRedactionEnabled"]),
+        b(policy["messageRedactionEnabled"]),
+        b(policy["attachmentRedactionEnabled"]),
+        b(policy["clipboardRedactionEnabled"]),
+        b(policy["auditRedactionEnabled"]),
+        b(policy["piiDetectionEnabled"]),
+        b(policy["secretDetectionEnabled"]),
+        b(policy["persistenceEnabled"]),
+    )
+)
+print("[INFO]  surfaces   : {}".format(surfaces))
+print("[INFO]  controls   : {}".format(controls))
+print("[INFO]  blocked    : {}".format(blocked))
+print(
+    "[INFO]  flags      : readOnly={} dataOnly={} deterministic={} "
+    "redactionPolicyDisplayOnly={} redactionMetadataOnly={} "
+    "redactionRulesLoaded={} redactionRulesPersisted={} "
+    "contentScan={} piiDetection={} secretDetection={} "
+    "identifierDetection={} promptRedaction={} responseRedaction={} "
+    "transcriptRedaction={} messageRedaction={} attachmentRedaction={} "
+    "clipboardRedaction={} auditRedaction={} redactionApplied={} "
+    "redactionResultPersisted={} redactionReportGenerated={} "
+    "promptCapture={} promptRead={} promptContentIncluded={} "
+    "responseContentIncluded={} transcriptContentIncluded={} "
+    "messageBodiesIncluded={} readsTranscript={} sessionStoreRead={} "
+    "sessionStoreWrite={} clipboardRead={} clipboardWrite={} "
+    "attachmentReads={} fileMetadataRead={} fileContentRead={} "
+    "directoryScan={} fileImport={} fileUpload={} writesArtifacts={} "
+    "readsArtifacts={} modelAssetRead={} modelLoadAttempted={} "
+    "modelExecution={} runtimeExecution={} kv260Access={} "
+    "hardwareAccess={} networkCalls={} providerCalls={} cloudCalls={} "
+    "executesPccxLab={} executesSystemverilogIde={}".format(
+        b(flags["readOnly"]),
+        b(flags["dataOnly"]),
+        b(flags["deterministic"]),
+        b(flags["redactionPolicyDisplayOnly"]),
+        b(flags["redactionMetadataOnly"]),
+        b(flags["redactionRulesLoaded"]),
+        b(flags["redactionRulesPersisted"]),
+        b(flags["contentScan"]),
+        b(flags["piiDetection"]),
+        b(flags["secretDetection"]),
+        b(flags["identifierDetection"]),
+        b(flags["promptRedaction"]),
+        b(flags["responseRedaction"]),
+        b(flags["transcriptRedaction"]),
+        b(flags["messageRedaction"]),
+        b(flags["attachmentRedaction"]),
+        b(flags["clipboardRedaction"]),
+        b(flags["auditRedaction"]),
+        b(flags["redactionApplied"]),
+        b(flags["redactionResultPersisted"]),
+        b(flags["redactionReportGenerated"]),
+        b(flags["promptCapture"]),
+        b(flags["promptRead"]),
+        b(flags["promptContentIncluded"]),
+        b(flags["responseContentIncluded"]),
+        b(flags["transcriptContentIncluded"]),
+        b(flags["messageBodiesIncluded"]),
+        b(flags["readsTranscript"]),
+        b(flags["sessionStoreRead"]),
+        b(flags["sessionStoreWrite"]),
+        b(flags["clipboardRead"]),
+        b(flags["clipboardWrite"]),
+        b(flags["attachmentReads"]),
+        b(flags["fileMetadataRead"]),
+        b(flags["fileContentRead"]),
+        b(flags["directoryScan"]),
+        b(flags["fileImport"]),
+        b(flags["fileUpload"]),
+        b(flags["writesArtifacts"]),
+        b(flags["readsArtifacts"]),
+        b(flags["modelAssetRead"]),
+        b(flags["modelLoadAttempted"]),
+        b(flags["modelExecution"]),
+        b(flags["runtimeExecution"]),
+        b(flags["kv260Access"]),
+        b(flags["hardwareAccess"]),
+        b(flags["networkCalls"]),
+        b(flags["providerCalls"]),
+        b(flags["cloudCalls"]),
+        b(flags["executesPccxLab"]),
+        b(flags["executesSystemverilogIde"]),
+    )
+)
+'
+    )"; then
+        ERROR "chat redaction-policy JSON could not be summarized"
+        return 1
+    fi
+
+    HEAD "chat redaction policy"
+    printf '%s\n' "$CHAT_REDACTION_POLICY_SUMMARY"
 }
 
 print_chat_attachment_policy_summary() {
@@ -3117,6 +3286,10 @@ while [ $# -gt 0 ]; do
             INCLUDE_CHAT_CLIPBOARD_POLICY="1"
             shift
             ;;
+        --include-chat-redaction-policy)
+            INCLUDE_CHAT_REDACTION_POLICY="1"
+            shift
+            ;;
         --include-chat-attachment-policy)
             INCLUDE_CHAT_ATTACHMENT_POLICY="1"
             shift
@@ -3140,8 +3313,8 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-if [ -n "$BACKEND" ] && { [ "$INCLUDE_RUNTIME_READINESS" = "1" ] || [ "$INCLUDE_DEVICE_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SURFACE_LAYOUT" = "1" ] || [ "$INCLUDE_CHAT_EMPTY_STATE" = "1" ] || [ "$INCLUDE_CHAT_LOCAL_ONLY_POLICY" = "1" ] || [ "$INCLUDE_CHAT_PREFERENCES" = "1" ] || [ "$INCLUDE_CHAT_SESSION_INDEX" = "1" ] || [ "$INCLUDE_CHAT_SESSION_STORE_POLICY" = "1" ] || [ "$INCLUDE_CHAT_SESSION_TITLE_POLICY" = "1" ] || [ "$INCLUDE_CHAT_MODEL_STATUS" = "1" ] || [ "$INCLUDE_CHAT_MODEL_SELECTION_POLICY" = "1" ] || [ "$INCLUDE_CHAT_CONTEXT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_MODEL_LOAD_REQUEST" = "1" ] || [ "$INCLUDE_CHAT_READINESS" = "1" ] || [ "$INCLUDE_CHAT_COMPOSER" = "1" ] || [ "$INCLUDE_CHAT_SEND_RESULT" = "1" ] || [ "$INCLUDE_CHAT_TRANSCRIPT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_AUDIT_EVENT" = "1" ] || [ "$INCLUDE_CHAT_ERROR_TAXONOMY" = "1" ] || [ "$INCLUDE_CHAT_RESPONSE_STREAM" = "1" ] || [ "$INCLUDE_CHAT_MESSAGE_LIST" = "1" ] || [ "$INCLUDE_CHAT_ACTION_BAR" = "1" ] || [ "$INCLUDE_CHAT_CLIPBOARD_POLICY" = "1" ] || [ "$INCLUDE_CHAT_ATTACHMENT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_SHORTCUT_MAP" = "1" ]; }; then
-    ERROR "--include-runtime-readiness, --include-device-session, --include-chat-session, --include-chat-surface-layout, --include-chat-empty-state, --include-chat-local-only-policy, --include-chat-preferences, --include-chat-session-index, --include-chat-session-store-policy, --include-chat-session-title-policy, --include-chat-model-status, --include-chat-model-selection-policy, --include-chat-context-policy, --include-chat-model-load-request, --include-chat-readiness, --include-chat-composer, --include-chat-send-result, --include-chat-transcript-policy, --include-chat-audit-event, --include-chat-error-taxonomy, --include-chat-response-stream, --include-chat-message-list, --include-chat-action-bar, --include-chat-clipboard-policy, --include-chat-attachment-policy, and --include-chat-shortcut-map are only supported in local scaffold mode"
+if [ -n "$BACKEND" ] && { [ "$INCLUDE_RUNTIME_READINESS" = "1" ] || [ "$INCLUDE_DEVICE_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SURFACE_LAYOUT" = "1" ] || [ "$INCLUDE_CHAT_EMPTY_STATE" = "1" ] || [ "$INCLUDE_CHAT_LOCAL_ONLY_POLICY" = "1" ] || [ "$INCLUDE_CHAT_PREFERENCES" = "1" ] || [ "$INCLUDE_CHAT_SESSION_INDEX" = "1" ] || [ "$INCLUDE_CHAT_SESSION_STORE_POLICY" = "1" ] || [ "$INCLUDE_CHAT_SESSION_TITLE_POLICY" = "1" ] || [ "$INCLUDE_CHAT_MODEL_STATUS" = "1" ] || [ "$INCLUDE_CHAT_MODEL_SELECTION_POLICY" = "1" ] || [ "$INCLUDE_CHAT_CONTEXT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_MODEL_LOAD_REQUEST" = "1" ] || [ "$INCLUDE_CHAT_READINESS" = "1" ] || [ "$INCLUDE_CHAT_COMPOSER" = "1" ] || [ "$INCLUDE_CHAT_SEND_RESULT" = "1" ] || [ "$INCLUDE_CHAT_TRANSCRIPT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_AUDIT_EVENT" = "1" ] || [ "$INCLUDE_CHAT_ERROR_TAXONOMY" = "1" ] || [ "$INCLUDE_CHAT_RESPONSE_STREAM" = "1" ] || [ "$INCLUDE_CHAT_MESSAGE_LIST" = "1" ] || [ "$INCLUDE_CHAT_ACTION_BAR" = "1" ] || [ "$INCLUDE_CHAT_CLIPBOARD_POLICY" = "1" ] || [ "$INCLUDE_CHAT_REDACTION_POLICY" = "1" ] || [ "$INCLUDE_CHAT_ATTACHMENT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_SHORTCUT_MAP" = "1" ]; }; then
+    ERROR "--include-runtime-readiness, --include-device-session, --include-chat-session, --include-chat-surface-layout, --include-chat-empty-state, --include-chat-local-only-policy, --include-chat-preferences, --include-chat-session-index, --include-chat-session-store-policy, --include-chat-session-title-policy, --include-chat-model-status, --include-chat-model-selection-policy, --include-chat-context-policy, --include-chat-model-load-request, --include-chat-readiness, --include-chat-composer, --include-chat-send-result, --include-chat-transcript-policy, --include-chat-audit-event, --include-chat-error-taxonomy, --include-chat-response-stream, --include-chat-message-list, --include-chat-action-bar, --include-chat-clipboard-policy, --include-chat-redaction-policy, --include-chat-attachment-policy, and --include-chat-shortcut-map are only supported in local scaffold mode"
     exit 1
 fi
 
@@ -3178,6 +3351,7 @@ if [ -z "$BACKEND" ]; then
     NOTE "chat messages : opt-in via --include-chat-message-list (read-only empty message-list data)"
     NOTE "chat actions  : opt-in via --include-chat-action-bar (read-only disabled action-bar data)"
     NOTE "chat clipboard: opt-in via --include-chat-clipboard-policy (read-only disabled clipboard-policy data)"
+    NOTE "chat redact   : opt-in via --include-chat-redaction-policy (read-only disabled redaction-policy data)"
     NOTE "chat attach   : opt-in via --include-chat-attachment-policy (read-only disabled attachment-policy data)"
     NOTE "chat shortcuts: opt-in via --include-chat-shortcut-map (read-only disabled shortcut-map data)"
     NOTE "editor bridge  : planned (VS Code / other IDEs)"
@@ -3208,6 +3382,12 @@ if [ -z "$BACKEND" ]; then
 
     if [ "$INCLUDE_CHAT_CLIPBOARD_POLICY" = "1" ]; then
         if ! print_chat_clipboard_policy_summary; then
+            exit 1
+        fi
+    fi
+
+    if [ "$INCLUDE_CHAT_REDACTION_POLICY" = "1" ]; then
+        if ! print_chat_redaction_policy_summary; then
             exit 1
         fi
     fi

--- a/scripts/tests/chat_redaction_policy_contract_test.py
+++ b/scripts/tests/chat_redaction_policy_contract_test.py
@@ -1,0 +1,434 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Fixture tests for the standalone chat redaction-policy contract."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "contracts" / "chat_redaction_policy_contract.py"
+FIXTURE_PATH = (
+    ROOT
+    / "contracts"
+    / "fixtures"
+    / "chat-redaction-policy.gemma3n-e4b-kv260-placeholder.json"
+)
+SCRIPT_PATH = ROOT / "scripts" / "chat-redaction-policy-stub.sh"
+STATUS_TEST_PATH = ROOT / "scripts" / "tests" / "status-chat-redaction-policy.sh"
+DOC_PATH = ROOT / "docs" / "STANDALONE_CHAT_SESSION_CONTRACT.md"
+README_PATH = ROOT / "README.md"
+TEST_PATH = Path(__file__).resolve()
+CI_PATH = ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location(
+        "chat_redaction_policy_contract",
+        MODULE_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def iter_state_values(value):
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            if (
+                key == "state"
+                or key.endswith("State")
+                or key.endswith("Status")
+            ) and isinstance(nested, str):
+                yield nested
+            yield from iter_state_values(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            yield from iter_state_values(nested)
+
+
+def iter_keys(value):
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            yield key
+            yield from iter_keys(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            yield from iter_keys(nested)
+
+
+def assert_no_private_or_generated_data(text: str) -> None:
+    forbidden_patterns = [
+        r"/home/[^\s\"']+",
+        r"/Users/[^\s\"']+",
+        r"[A-Za-z]:\\Users\\",
+        r"\b(?:api[_-]?key|authorization|bearer|client[_-]?secret|password|private[_-]?key|secret|token)\b\s*[:=]",
+        r"\.(?:gguf|safetensors|ckpt|pt|pth|onnx)\b",
+        r"(?:weights|model_weights|model-cache)/(?:[^\"'\s]+)",
+        r"(?:raw[_-]?full[_-]?logs|hardware[_-]?dump|generated[_-]?blob)\s*[:=]",
+    ]
+    for pattern in forbidden_patterns:
+        assert not re.search(pattern, text, re.IGNORECASE), pattern
+
+
+def assert_no_runtime_implementation_terms(source: str) -> None:
+    forbidden = [
+        "subprocess",
+        "os.system",
+        "popen",
+        "socket",
+        "urllib",
+        "requests",
+        "http.client",
+        "openai",
+        "anthropic",
+        "gem" + "ini",
+        "modelcontextprotocol",
+        "websocket",
+        "xmutil",
+        "xrt-smi",
+        "lsusb",
+        "dmesg",
+    ]
+    lowered = source.lower()
+    for term in forbidden:
+        assert term not in lowered, term
+
+
+def assert_no_provider_configs(value) -> None:
+    forbidden_keys = {
+        "apiKey",
+        "accessToken",
+        "refreshToken",
+        "authorization",
+        "bearerToken",
+        "provider",
+        "providers",
+        "providerConfig",
+        "providerConfigs",
+    }
+    for key in iter_keys(value):
+        assert key not in forbidden_keys, key
+
+
+def assert_no_unsupported_claims(text: str) -> None:
+    literal_claims = [
+        "production" + "-ready",
+        "marketplace" + "-ready",
+        "stable " + "API",
+        "stable " + "ABI",
+        "KV260 inference " + "works",
+        "Gemma 3N E4B " + "runs on KV260",
+        "20 tok/s " + "achieved",
+        "timing " + "closed",
+        "bitstream " + "ready",
+        "launcher executes " + "pccx-lab",
+        "IDE controls " + "launcher",
+        "AI provider integration " + "is live",
+    ]
+    lowered = text.lower()
+    for claim in literal_claims:
+        assert claim.lower() not in lowered, claim
+
+
+def test_chat_redaction_policy_matches_fixture_and_is_deterministic() -> None:
+    module = load_module()
+    generated = module.create_gemma3n_e4b_kv260_chat_redaction_policy()
+    fixture = json.loads(read_text(FIXTURE_PATH))
+
+    assert generated == fixture
+    assert module.chat_redaction_policy_json(generated) == (
+        module.chat_redaction_policy_json(generated)
+    )
+    assert module.chat_redaction_policy_json(generated).endswith("\n")
+    assert json.loads(module.chat_redaction_policy_json(generated)) == fixture
+
+
+def test_cli_stub_outputs_deterministic_json() -> None:
+    fixture = json.loads(read_text(FIXTURE_PATH))
+    command = [
+        "bash",
+        str(SCRIPT_PATH),
+        "--model",
+        "gemma3n-e4b",
+        "--target",
+        "kv260",
+    ]
+    first = subprocess.run(command, check=True, capture_output=True, text=True)
+    second = subprocess.run(command, check=True, capture_output=True, text=True)
+
+    assert first.stderr == ""
+    assert first.stdout == second.stdout
+    assert first.stdout.endswith("\n")
+    assert json.loads(first.stdout) == fixture
+
+
+def test_required_fields_and_allowed_states() -> None:
+    module = load_module()
+    redaction_policy = module.create_gemma3n_e4b_kv260_chat_redaction_policy()
+    allowed = set(module.CHAT_REDACTION_POLICY_STATE_VALUES)
+
+    assert tuple(redaction_policy.keys()) == module.CHAT_REDACTION_POLICY_FIELDS
+    assert redaction_policy["schemaVersion"] == "pccx.chatRedactionPolicy.v0"
+    assert (
+        tuple(redaction_policy["redactionPolicy"].keys())
+        == module.REDACTION_POLICY_FIELDS
+    )
+
+    states = list(iter_state_values(redaction_policy))
+    assert states
+    for state in states:
+        assert state in allowed, state
+
+    for surface in redaction_policy["redactionSurfaces"]:
+        assert tuple(surface.keys()) == module.REDACTION_SURFACE_FIELDS
+    for control in redaction_policy["redactionControls"]:
+        assert tuple(control.keys()) == module.REDACTION_CONTROL_FIELDS
+    for reason in redaction_policy["blockedReasons"]:
+        assert tuple(reason.keys()) == module.BLOCKED_REASON_FIELDS
+    for ref in redaction_policy["handoffRefs"]:
+        assert tuple(ref.keys()) == module.HANDOFF_REF_FIELDS
+
+
+def test_chat_redaction_policy_keeps_scanning_and_redaction_disabled() -> None:
+    redaction_policy = load_module().create_gemma3n_e4b_kv260_chat_redaction_policy()
+    policy = redaction_policy["redactionPolicy"]
+    flags = redaction_policy["safetyFlags"]
+    surfaces = {
+        surface["surfaceId"]: surface
+        for surface in redaction_policy["redactionSurfaces"]
+    }
+    controls = {
+        control["controlId"]: control
+        for control in redaction_policy["redactionControls"]
+    }
+    reasons = {
+        reason["reasonId"]: reason for reason in redaction_policy["blockedReasons"]
+    }
+    refs = {ref["refId"]: ref for ref in redaction_policy["handoffRefs"]}
+
+    assert redaction_policy["redactionPolicyState"] == "blocked"
+    assert redaction_policy["contentScanState"] == "disabled"
+    assert redaction_policy["promptRedactionState"] == "disabled"
+    assert redaction_policy["responseRedactionState"] == "disabled"
+    assert redaction_policy["transcriptRedactionState"] == "not_configured"
+    assert redaction_policy["messageRedactionState"] == "empty_not_captured"
+    assert redaction_policy["attachmentRedactionState"] == "blocked"
+    assert redaction_policy["clipboardRedactionState"] == "disabled"
+    assert redaction_policy["auditRedactionState"] == "blocked"
+    assert redaction_policy["piiDetectionState"] == "disabled"
+    assert redaction_policy["secretDetectionState"] == "disabled"
+    assert redaction_policy["persistenceState"] == "disabled"
+    assert redaction_policy["privacyState"] == "summary_only"
+    assert policy["sideEffectPolicy"] == "local_render_only"
+    assert policy["scannerEnabled"] is False
+    assert policy["promptRedactionEnabled"] is False
+    assert policy["responseRedactionEnabled"] is False
+    assert policy["transcriptRedactionEnabled"] is False
+    assert policy["messageRedactionEnabled"] is False
+    assert policy["attachmentRedactionEnabled"] is False
+    assert policy["clipboardRedactionEnabled"] is False
+    assert policy["auditRedactionEnabled"] is False
+    assert policy["piiDetectionEnabled"] is False
+    assert policy["secretDetectionEnabled"] is False
+    assert policy["persistenceEnabled"] is False
+    assert set(surfaces) == {
+        "composer_prompt",
+        "assistant_response",
+        "message_list",
+        "transcript_export",
+        "attachment_payload",
+        "clipboard_payload",
+        "audit_event",
+    }
+    assert all(surface["enabled"] is False for surface in surfaces.values())
+    assert set(controls) == {
+        "review_redaction_rules",
+        "scan_prompt_content",
+        "scan_response_content",
+        "scan_transcript_content",
+        "detect_sensitive_content",
+        "redact_attachment_payload",
+        "redact_clipboard_payload",
+        "persist_redaction_result",
+    }
+    assert all(control["enabled"] is False for control in controls.values())
+    assert controls["review_redaction_rules"]["sideEffectPolicy"] == "no_rule_load"
+    assert controls["scan_prompt_content"]["sideEffectPolicy"] == "no_prompt_scan"
+    assert controls["scan_response_content"]["sideEffectPolicy"] == "no_response_scan"
+    assert controls["scan_transcript_content"]["sideEffectPolicy"] == (
+        "no_transcript_scan"
+    )
+    assert controls["detect_sensitive_content"]["sideEffectPolicy"] == (
+        "no_detector_execution"
+    )
+    assert controls["redact_attachment_payload"]["sideEffectPolicy"] == (
+        "no_attachment_read_or_redaction"
+    )
+    assert controls["redact_clipboard_payload"]["sideEffectPolicy"] == (
+        "no_clipboard_read_or_redaction"
+    )
+    assert controls["persist_redaction_result"]["sideEffectPolicy"] == (
+        "no_redaction_result_persistence"
+    )
+    assert set(reasons) == {
+        "redaction_rules_absent",
+        "content_boundary_absent",
+        "transcript_policy_not_reviewed",
+        "scanner_not_reviewed",
+        "persistence_not_configured",
+    }
+    assert set(refs) == {
+        "chat_composer",
+        "chat_message_list",
+        "chat_transcript_policy",
+        "chat_attachment_policy",
+        "chat_clipboard_policy",
+        "chat_audit_event",
+        "chat_local_only_policy",
+    }
+    assert flags["readOnly"] is True
+    assert flags["dataOnly"] is True
+    assert flags["redactionPolicyDisplayOnly"] is True
+    assert flags["redactionMetadataOnly"] is True
+    assert flags["redactionRulesLoaded"] is False
+    assert flags["redactionRulesPersisted"] is False
+    assert flags["contentScan"] is False
+    assert flags["piiDetection"] is False
+    assert flags["secretDetection"] is False
+    assert flags["identifierDetection"] is False
+    assert flags["promptRedaction"] is False
+    assert flags["responseRedaction"] is False
+    assert flags["transcriptRedaction"] is False
+    assert flags["messageRedaction"] is False
+    assert flags["attachmentRedaction"] is False
+    assert flags["clipboardRedaction"] is False
+    assert flags["auditRedaction"] is False
+    assert flags["redactionApplied"] is False
+    assert flags["redactionResultPersisted"] is False
+    assert flags["redactionReportGenerated"] is False
+    assert flags["promptCapture"] is False
+    assert flags["promptRead"] is False
+    assert flags["promptContentIncluded"] is False
+    assert flags["responseContentIncluded"] is False
+    assert flags["transcriptContentIncluded"] is False
+    assert flags["messageBodiesIncluded"] is False
+    assert flags["readsTranscript"] is False
+    assert flags["sessionStoreRead"] is False
+    assert flags["sessionStoreWrite"] is False
+    assert flags["clipboardRead"] is False
+    assert flags["clipboardWrite"] is False
+    assert flags["attachmentReads"] is False
+    assert flags["fileMetadataRead"] is False
+    assert flags["fileContentRead"] is False
+    assert flags["directoryScan"] is False
+    assert flags["fileImport"] is False
+    assert flags["fileUpload"] is False
+    assert flags["writesArtifacts"] is False
+    assert flags["readsArtifacts"] is False
+    assert flags["modelAssetRead"] is False
+    assert flags["modelLoadAttempted"] is False
+    assert flags["modelExecution"] is False
+    assert flags["runtimeExecution"] is False
+    assert flags["kv260Access"] is False
+    assert flags["hardwareAccess"] is False
+    assert flags["networkCalls"] is False
+    assert flags["providerCalls"] is False
+    assert flags["cloudCalls"] is False
+    assert flags["executesPccxLab"] is False
+    assert flags["executesSystemverilogIde"] is False
+
+
+def test_chat_redaction_policy_docs_and_ci_are_wired() -> None:
+    doc = read_text(DOC_PATH)
+    readme = read_text(README_PATH)
+    status_test = read_text(STATUS_TEST_PATH)
+    ci = read_text(CI_PATH)
+
+    assert "contracts/chat_redaction_policy_contract.py" in doc
+    assert (
+        "contracts/fixtures/chat-redaction-policy.gemma3n-e4b-kv260-placeholder.json"
+        in doc
+    )
+    assert "scripts/chat-redaction-policy-stub.sh" in doc
+    assert "scripts/tests/chat_redaction_policy_contract_test.py" in doc
+    assert "scripts/tests/status-chat-redaction-policy.sh" in doc
+    assert "chat-redaction-policy-stub.sh" in readme
+    assert "--include-chat-redaction-policy" in readme
+    assert "chat_redaction_policy_contract_test.py" in ci
+    assert "status-chat-redaction-policy.sh" in ci
+    assert "--include-chat-redaction-policy" in status_test
+
+
+def test_chat_redaction_policy_has_no_runtime_or_private_surface() -> None:
+    module = load_module()
+    redaction_policy = module.create_gemma3n_e4b_kv260_chat_redaction_policy()
+    fixture_text = read_text(FIXTURE_PATH)
+    contract_source = read_text(MODULE_PATH)
+    stub_source = read_text(SCRIPT_PATH)
+    docs = "\n".join(
+        [
+            fixture_text,
+            contract_source,
+            stub_source,
+            read_text(DOC_PATH),
+            read_text(README_PATH),
+            read_text(STATUS_TEST_PATH),
+        ]
+    )
+
+    assert_no_provider_configs(redaction_policy)
+    assert_no_private_or_generated_data(docs)
+    assert_no_unsupported_claims(docs)
+    assert_no_runtime_implementation_terms(contract_source)
+    assert_no_runtime_implementation_terms(stub_source)
+
+
+def test_source_headers_for_touched_code_files() -> None:
+    expected_headers = {
+        MODULE_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        SCRIPT_PATH: [
+            "#!/usr/bin/env bash",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        STATUS_TEST_PATH: [
+            "#!/usr/bin/env bash",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        TEST_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        CI_PATH: [
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+    }
+
+    for path, header in expected_headers.items():
+        assert read_text(path).splitlines()[: len(header)] == header, path
+
+
+if __name__ == "__main__":
+    for name, func in sorted(globals().items()):
+        if name.startswith("test_") and callable(func):
+            func()
+    print("chat redaction-policy contract tests ok")

--- a/scripts/tests/status-chat-redaction-policy.sh
+++ b/scripts/tests/status-chat-redaction-policy.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+# scripts/tests/status-chat-redaction-policy.sh - status redaction-policy tests.
+#
+# Usage: bash scripts/tests/status-chat-redaction-policy.sh [path/to/status-stub.sh]
+
+set -eu
+
+PASS() { printf '[PASS]  %s\n' "$*"; }
+FAIL() { printf '[FAIL] %s\n' "$*" >&2; }
+HEAD() { printf '\n=== %s ===\n' "$*"; }
+
+STUB="${1:-scripts/status-stub.sh}"
+
+if [ ! -x "$STUB" ]; then
+    chmod +x "$STUB"
+fi
+
+contains() {
+    case "$1" in
+        *"$2"*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+require_contains() {
+    local output="$1"
+    local expected="$2"
+    if ! contains "$output" "$expected"; then
+        FAIL "expected output to contain: $expected"
+        printf '%s\n' "$output" >&2
+        exit 1
+    fi
+}
+
+require_not_contains() {
+    local output="$1"
+    local forbidden="$2"
+    if contains "$output" "$forbidden"; then
+        FAIL "output contained forbidden text: $forbidden"
+        printf '%s\n' "$output" >&2
+        exit 1
+    fi
+}
+
+HEAD "1: status can include chat redaction policy"
+OUTPUT="$("$STUB" --include-chat-redaction-policy)"
+require_contains "$OUTPUT" "=== chat redaction policy ==="
+require_contains "$OUTPUT" "source     : scripts/chat-redaction-policy-stub.sh --model gemma3n-e4b --target kv260"
+require_contains "$OUTPUT" "boundary   : read-only data; no redaction rule load/content scan/PII detection/secret detection/prompt/message/transcript/clipboard/file/model/runtime/hardware/lab/IDE execution"
+require_contains "$OUTPUT" "target     : kv260"
+require_contains "$OUTPUT" "model      : gemma3n-e4b"
+require_contains "$OUTPUT" "policy     : blocked"
+require_contains "$OUTPUT" "scan       : disabled"
+require_contains "$OUTPUT" "prompt    : disabled"
+require_contains "$OUTPUT" "response  : disabled"
+require_contains "$OUTPUT" "transcript: not_configured"
+require_contains "$OUTPUT" "message   : empty_not_captured"
+require_contains "$OUTPUT" "attachment: blocked"
+require_contains "$OUTPUT" "clipboard : disabled"
+require_contains "$OUTPUT" "audit     : blocked"
+require_contains "$OUTPUT" "pii       : disabled"
+require_contains "$OUTPUT" "secrets   : disabled"
+require_contains "$OUTPUT" "persistence: disabled"
+require_contains "$OUTPUT" "privacy   : summary_only"
+PASS "chat redaction-policy section is present and conservative"
+
+HEAD "2: surfaces and controls stay disabled"
+require_contains "$OUTPUT" "redaction-policy : blocked mode=disabled_until_reviewed_redaction_rules_and_content_boundaries_exist"
+require_contains "$OUTPUT" "scannerEnabled=false"
+require_contains "$OUTPUT" "promptRedactionEnabled=false"
+require_contains "$OUTPUT" "responseRedactionEnabled=false"
+require_contains "$OUTPUT" "transcriptRedactionEnabled=false"
+require_contains "$OUTPUT" "messageRedactionEnabled=false"
+require_contains "$OUTPUT" "attachmentRedactionEnabled=false"
+require_contains "$OUTPUT" "clipboardRedactionEnabled=false"
+require_contains "$OUTPUT" "auditRedactionEnabled=false"
+require_contains "$OUTPUT" "piiDetectionEnabled=false"
+require_contains "$OUTPUT" "secretDetectionEnabled=false"
+require_contains "$OUTPUT" "persistenceEnabled=false"
+require_contains "$OUTPUT" "surfaces   : composer_prompt=blocked:false"
+require_contains "$OUTPUT" "assistant_response=disabled:false"
+require_contains "$OUTPUT" "message_list=empty_not_captured:false"
+require_contains "$OUTPUT" "transcript_export=not_configured:false"
+require_contains "$OUTPUT" "attachment_payload=blocked:false"
+require_contains "$OUTPUT" "clipboard_payload=disabled:false"
+require_contains "$OUTPUT" "audit_event=blocked:false"
+require_contains "$OUTPUT" "controls   : review_redaction_rules=not_configured:false"
+require_contains "$OUTPUT" "scan_prompt_content=disabled:false"
+require_contains "$OUTPUT" "scan_response_content=disabled:false"
+require_contains "$OUTPUT" "scan_transcript_content=not_configured:false"
+require_contains "$OUTPUT" "detect_sensitive_content=disabled:false"
+require_contains "$OUTPUT" "redact_attachment_payload=blocked:false"
+require_contains "$OUTPUT" "redact_clipboard_payload=disabled:false"
+require_contains "$OUTPUT" "persist_redaction_result=disabled:false"
+require_contains "$OUTPUT" "blocked    : redaction_rules_absent=not_configured"
+require_contains "$OUTPUT" "content_boundary_absent=blocked"
+require_contains "$OUTPUT" "transcript_policy_not_reviewed=not_configured"
+require_contains "$OUTPUT" "scanner_not_reviewed=requires_review"
+require_contains "$OUTPUT" "persistence_not_configured=disabled"
+PASS "disabled redaction metadata is summarized"
+
+HEAD "3: safety flags stay read-only and non-executing"
+require_contains "$OUTPUT" "readOnly=true"
+require_contains "$OUTPUT" "dataOnly=true"
+require_contains "$OUTPUT" "deterministic=true"
+require_contains "$OUTPUT" "redactionPolicyDisplayOnly=true"
+require_contains "$OUTPUT" "redactionMetadataOnly=true"
+require_contains "$OUTPUT" "redactionRulesLoaded=false"
+require_contains "$OUTPUT" "redactionRulesPersisted=false"
+require_contains "$OUTPUT" "contentScan=false"
+require_contains "$OUTPUT" "piiDetection=false"
+require_contains "$OUTPUT" "secretDetection=false"
+require_contains "$OUTPUT" "identifierDetection=false"
+require_contains "$OUTPUT" "promptRedaction=false"
+require_contains "$OUTPUT" "responseRedaction=false"
+require_contains "$OUTPUT" "transcriptRedaction=false"
+require_contains "$OUTPUT" "messageRedaction=false"
+require_contains "$OUTPUT" "attachmentRedaction=false"
+require_contains "$OUTPUT" "clipboardRedaction=false"
+require_contains "$OUTPUT" "auditRedaction=false"
+require_contains "$OUTPUT" "redactionApplied=false"
+require_contains "$OUTPUT" "redactionResultPersisted=false"
+require_contains "$OUTPUT" "redactionReportGenerated=false"
+require_contains "$OUTPUT" "promptCapture=false"
+require_contains "$OUTPUT" "promptRead=false"
+require_contains "$OUTPUT" "promptContentIncluded=false"
+require_contains "$OUTPUT" "responseContentIncluded=false"
+require_contains "$OUTPUT" "transcriptContentIncluded=false"
+require_contains "$OUTPUT" "messageBodiesIncluded=false"
+require_contains "$OUTPUT" "readsTranscript=false"
+require_contains "$OUTPUT" "sessionStoreRead=false"
+require_contains "$OUTPUT" "clipboardRead=false"
+require_contains "$OUTPUT" "clipboardWrite=false"
+require_contains "$OUTPUT" "attachmentReads=false"
+require_contains "$OUTPUT" "fileMetadataRead=false"
+require_contains "$OUTPUT" "fileContentRead=false"
+require_contains "$OUTPUT" "directoryScan=false"
+require_contains "$OUTPUT" "fileImport=false"
+require_contains "$OUTPUT" "fileUpload=false"
+require_contains "$OUTPUT" "writesArtifacts=false"
+require_contains "$OUTPUT" "readsArtifacts=false"
+require_contains "$OUTPUT" "modelAssetRead=false"
+require_contains "$OUTPUT" "modelLoadAttempted=false"
+require_contains "$OUTPUT" "modelExecution=false"
+require_contains "$OUTPUT" "runtimeExecution=false"
+require_contains "$OUTPUT" "kv260Access=false"
+require_contains "$OUTPUT" "hardwareAccess=false"
+require_contains "$OUTPUT" "networkCalls=false"
+require_contains "$OUTPUT" "providerCalls=false"
+require_contains "$OUTPUT" "cloudCalls=false"
+require_contains "$OUTPUT" "executesPccxLab=false"
+require_contains "$OUTPUT" "executesSystemverilogIde=false"
+PASS "execution-related flags remain false"
+
+HEAD "4: output is deterministic"
+OUTPUT_AGAIN="$("$STUB" --include-chat-redaction-policy)"
+if [ "$OUTPUT" != "$OUTPUT_AGAIN" ]; then
+    FAIL "status chat redaction-policy output changed between runs"
+    exit 1
+fi
+PASS "status chat redaction-policy output is deterministic"
+
+HEAD "5: chat redaction-policy option does not combine with pccx-lab backend"
+if "$STUB" --include-chat-redaction-policy --backend pccx-lab >/dev/null 2>&1; then
+    FAIL "expected combined chat-redaction-policy/backend mode to fail"
+    exit 1
+fi
+PASS "chat redaction-policy remains separate from backend execution"
+
+HEAD "6: output avoids known overclaims"
+FORBIDDEN_PREFIX="KV260 inference"
+FORBIDDEN_CLAIM="${FORBIDDEN_PREFIX} works"
+require_not_contains "$OUTPUT" "$FORBIDDEN_CLAIM"
+THROUGHPUT_PREFIX="20 tok/s"
+THROUGHPUT_CLAIM="${THROUGHPUT_PREFIX} achieved"
+require_not_contains "$OUTPUT" "$THROUGHPUT_CLAIM"
+PASS "no chat redaction-policy or throughput overclaim in status output"
+
+printf '\n[DONE]  all status-chat-redaction-policy tests passed\n'


### PR DESCRIPTION
## Summary
- Add a data-only `pccx.chatRedactionPolicy.v0` contract, fixture, and stub for the planned chat surface.
- Wire the redaction-policy summary behind `--include-chat-redaction-policy` with disabled rule, scan, detector, redaction, persistence, file, clipboard, model, runtime, hardware, lab, and IDE gates.
- Document the boundary and add focused contract/status tests plus CI coverage.

Refs #9

## Validation
- `python3 scripts/tests/chat_redaction_policy_contract_test.py`
- `bash scripts/tests/status-chat-redaction-policy.sh scripts/status-stub.sh`
- `python3 -m py_compile contracts/*.py scripts/tests/*.py`
- `find scripts -type f -name '*.sh' -not -name '*.snapshot' -exec bash -n {} +`
- `for test_file in scripts/tests/*_test.py; do python3 "$test_file"; done`
- `for test_file in scripts/tests/status-*.sh; do bash "$test_file" scripts/status-stub.sh; done`
- `git diff --check`
- local forbidden-claim scan
- `./scripts/check.sh`
- `./scripts/check-device-stub.sh`
- `./scripts/install-stub.sh`
- `./scripts/status-stub.sh --include-chat-redaction-policy`
- `./scripts/chat-redaction-policy-stub.sh --model gemma3n-e4b --target kv260`
