### PR TITLE
Add chat status summary boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,7 @@ jobs:
                    scripts/chat-redaction-policy-stub.sh \
                    scripts/chat-attachment-policy-stub.sh \
                    scripts/chat-shortcut-map-stub.sh \
+                   scripts/chat-status-summary-stub.sh \
                    scripts/chat-surface-preview.sh \
                    scripts/chat-stub.sh; do
             [ -f "$f" ] && chmod +x "$f" || true
@@ -278,6 +279,10 @@ jobs:
         run: ./scripts/status-stub.sh --include-chat-shortcut-map
       - name: run scripts/chat-shortcut-map-stub.sh
         run: ./scripts/chat-shortcut-map-stub.sh --model gemma3n-e4b --target kv260
+      - name: run scripts/status-stub.sh with chat status summary
+        run: ./scripts/status-stub.sh --include-chat-status-summary
+      - name: run scripts/chat-status-summary-stub.sh
+        run: ./scripts/chat-status-summary-stub.sh --model gemma3n-e4b --target kv260
       - name: run scripts/chat-surface-preview.sh
         run: ./scripts/chat-surface-preview.sh --model gemma3n-e4b --target kv260
       - name: run scripts/chat-stub.sh --dry-run
@@ -352,6 +357,8 @@ jobs:
         run: python3 scripts/tests/chat_attachment_policy_contract_test.py
       - name: run chat shortcut-map contract tests
         run: python3 scripts/tests/chat_shortcut_map_contract_test.py
+      - name: run chat status-summary contract tests
+        run: python3 scripts/tests/chat_status_summary_contract_test.py
       - name: run chat surface preview tests
         run: python3 scripts/tests/chat_surface_preview_test.py
 
@@ -390,6 +397,7 @@ jobs:
           chmod +x scripts/chat-redaction-policy-stub.sh
           chmod +x scripts/chat-attachment-policy-stub.sh
           chmod +x scripts/chat-shortcut-map-stub.sh
+          chmod +x scripts/chat-status-summary-stub.sh
           chmod +x scripts/launch-stub.sh
           chmod +x scripts/tests/status-backend.sh
           chmod +x scripts/tests/status-device-session.sh
@@ -419,6 +427,7 @@ jobs:
           chmod +x scripts/tests/status-chat-redaction-policy.sh
           chmod +x scripts/tests/status-chat-attachment-policy.sh
           chmod +x scripts/tests/status-chat-shortcut-map.sh
+          chmod +x scripts/tests/status-chat-status-summary.sh
       - name: shellcheck status-stub and test script
         run: |
           sudo apt-get update -q && sudo apt-get install -y -q shellcheck
@@ -451,6 +460,7 @@ jobs:
           shellcheck scripts/tests/status-chat-redaction-policy.sh
           shellcheck scripts/tests/status-chat-attachment-policy.sh
           shellcheck scripts/tests/status-chat-shortcut-map.sh
+          shellcheck scripts/tests/status-chat-status-summary.sh
       - name: run status-backend tests
         run: bash scripts/tests/status-backend.sh scripts/status-stub.sh
       - name: run status-device-session tests
@@ -507,3 +517,5 @@ jobs:
         run: bash scripts/tests/status-chat-attachment-policy.sh scripts/status-stub.sh
       - name: run status-chat-shortcut-map tests
         run: bash scripts/tests/status-chat-shortcut-map.sh scripts/status-stub.sh
+      - name: run status-chat-status-summary tests
+        run: bash scripts/tests/status-chat-status-summary.sh scripts/status-stub.sh

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ and verify host-side prerequisites before the real engine lands.
 | [`scripts/check.sh`](./scripts/check.sh) | Probe host info, tooling availability, edge-device hints. Always exits 0. |
 | [`scripts/check-device-stub.sh`](./scripts/check-device-stub.sh) | Narrowly scoped device-tree / FPGA-node probe (KV260 / Kria detection only). Always exits 0. |
 | [`scripts/install-stub.sh`](./scripts/install-stub.sh) | Preview of the planned install flow; reports which host runtime pieces are present, lists device-side pieces as future deliverables. Always exits 0. |
-| [`scripts/status-stub.sh`](./scripts/status-stub.sh) | Launcher state summary. Default mode: local scaffold output, always exits 0. With `--include-chat-action-bar`, adds read-only disabled chat action-bar data. With `--include-chat-clipboard-policy`, adds read-only disabled chat clipboard-policy data. With `--include-chat-redaction-policy`, adds read-only disabled chat redaction-policy data. With `--include-chat-attachment-policy`, adds read-only disabled chat attachment-policy data. With `--include-chat-shortcut-map`, adds read-only disabled chat shortcut-map data. With `--include-chat-message-list`, adds read-only empty chat message-list data. With `--include-chat-response-stream`, adds read-only blocked chat response stream data. With `--include-chat-error-taxonomy`, adds read-only chat error taxonomy data. With `--include-chat-audit-event`, adds read-only blocked chat audit-event metadata. With `--include-chat-surface-layout`, adds read-only chat surface layout data. With `--include-chat-empty-state`, adds read-only display-only chat empty-state data. With `--include-chat-local-only-policy`, adds read-only local-only/cloud-block policy data. With `--include-chat-preferences`, adds read-only chat preferences/settings data. With `--include-chat-session-index`, adds read-only empty chat session index data. With `--include-chat-session-store-policy`, adds read-only disabled chat session-store policy data. With `--include-chat-session-title-policy`, adds read-only placeholder session-title policy data. With `--include-chat-transcript-policy`, adds read-only chat transcript retention/export policy data. With `--include-chat-send-result`, adds read-only blocked chat send-result data. With `--include-chat-composer`, adds read-only chat composer/input-control data. With `--include-chat-model-status`, adds read-only blocked chat model-status display data. With `--include-chat-model-selection-policy`, adds read-only disabled chat model-selection data. With `--include-chat-context-policy`, adds read-only disabled chat context-window/tokenization policy data. With `--include-chat-model-load-request`, adds read-only disabled chat model-load request data. With `--include-chat-session`, adds read-only blocked chat/session and lifecycle summaries. With `--include-chat-readiness`, adds read-only chat readiness checks and recovery actions. With `--include-device-session`, adds a read-only device/session status panel. With `--include-runtime-readiness`, adds a read-only runtime readiness summary. With `--backend pccx-lab`, calls `pccx-lab status --format json` and forwards the run-status envelope (exits non-zero if binary is missing or output is invalid). |
+| [`scripts/status-stub.sh`](./scripts/status-stub.sh) | Launcher state summary. Default mode: local scaffold output, always exits 0. With `--include-chat-action-bar`, adds read-only disabled chat action-bar data. With `--include-chat-clipboard-policy`, adds read-only disabled chat clipboard-policy data. With `--include-chat-redaction-policy`, adds read-only disabled chat redaction-policy data. With `--include-chat-attachment-policy`, adds read-only disabled chat attachment-policy data. With `--include-chat-shortcut-map`, adds read-only disabled chat shortcut-map data. With `--include-chat-status-summary`, adds read-only aggregate chat status-summary data. With `--include-chat-message-list`, adds read-only empty chat message-list data. With `--include-chat-response-stream`, adds read-only blocked chat response stream data. With `--include-chat-error-taxonomy`, adds read-only chat error taxonomy data. With `--include-chat-audit-event`, adds read-only blocked chat audit-event metadata. With `--include-chat-surface-layout`, adds read-only chat surface layout data. With `--include-chat-empty-state`, adds read-only display-only chat empty-state data. With `--include-chat-local-only-policy`, adds read-only local-only/cloud-block policy data. With `--include-chat-preferences`, adds read-only chat preferences/settings data. With `--include-chat-session-index`, adds read-only empty chat session index data. With `--include-chat-session-store-policy`, adds read-only disabled chat session-store policy data. With `--include-chat-session-title-policy`, adds read-only placeholder session-title policy data. With `--include-chat-transcript-policy`, adds read-only chat transcript retention/export policy data. With `--include-chat-send-result`, adds read-only blocked chat send-result data. With `--include-chat-composer`, adds read-only chat composer/input-control data. With `--include-chat-model-status`, adds read-only blocked chat model-status display data. With `--include-chat-model-selection-policy`, adds read-only disabled chat model-selection data. With `--include-chat-context-policy`, adds read-only disabled chat context-window/tokenization policy data. With `--include-chat-model-load-request`, adds read-only disabled chat model-load request data. With `--include-chat-session`, adds read-only blocked chat/session and lifecycle summaries. With `--include-chat-readiness`, adds read-only chat readiness checks and recovery actions. With `--include-device-session`, adds a read-only device/session status panel. With `--include-runtime-readiness`, adds a read-only runtime readiness summary. With `--backend pccx-lab`, calls `pccx-lab status --format json` and forwards the run-status envelope (exits non-zero if binary is missing or output is invalid). |
 | [`scripts/device-session-status-stub.sh`](./scripts/device-session-status-stub.sh) | Data-only device/session status JSON for the Gemma 3N E4B + KV260 target. Reports connection, model load, session, diagnostics, readiness, discovery paths, flow steps, and error taxonomy as placeholder / blocked. |
 | [`scripts/runtime-readiness-stub.sh`](./scripts/runtime-readiness-stub.sh) | Data-only runtime readiness JSON for the Gemma 3N E4B + KV260 target. Reports blocked / not yet evidence-backed. |
 | [`scripts/chat-session-stub.sh`](./scripts/chat-session-stub.sh) | Data-only standalone chat/session JSON for the Gemma 3N E4B + KV260 target. Reports disabled send controls, inactive session state, no prompt/response persistence, and readiness handoff references. |
@@ -113,6 +113,7 @@ and verify host-side prerequisites before the real engine lands.
 | [`scripts/chat-redaction-policy-stub.sh`](./scripts/chat-redaction-policy-stub.sh) | Data-only disabled chat redaction-policy JSON for the Gemma 3N E4B + KV260 target. Reports redaction rule, content scan, PII, secret, prompt, response, transcript, message, attachment, clipboard, audit, and persistence gates without loading rules, scanning content, applying redactions, reading files, or starting model/runtime paths. |
 | [`scripts/chat-attachment-policy-stub.sh`](./scripts/chat-attachment-policy-stub.sh) | Data-only disabled chat attachment-policy JSON for the Gemma 3N E4B + KV260 target. Reports disabled file picker, file read, upload, import, preview, and persistence gates without reading file names, paths, metadata, contents, clipboard data, transcripts, generated artifacts, model paths, runtime logs, or artifacts. |
 | [`scripts/chat-shortcut-map-stub.sh`](./scripts/chat-shortcut-map-stub.sh) | Data-only disabled chat shortcut-map JSON for the Gemma 3N E4B + KV260 target. Reports planned keyboard accelerator and focus metadata without installing listeners, capturing key events, dispatching commands, changing focus, reading prompts, sessions, transcripts, messages, files, or clipboard data, or starting runtime paths. |
+| [`scripts/chat-status-summary-stub.sh`](./scripts/chat-status-summary-stub.sh) | Data-only chat status-summary JSON for the Gemma 3N E4B + KV260 target. Aggregates existing checked chat surface references into blocked/disabled display cards without reading prompts, session stores, configuration, model paths, runtime logs, artifacts, provider state, or hardware state. |
 | [`scripts/chat-transcript-policy-stub.sh`](./scripts/chat-transcript-policy-stub.sh) | Data-only chat transcript policy JSON for the Gemma 3N E4B + KV260 target. Reports retention, export, storage, and privacy policy state without reading, generating, storing, persisting, summarizing, or exporting prompt/response/transcript content. |
 | [`scripts/chat-audit-event-stub.sh`](./scripts/chat-audit-event-stub.sh) | Data-only chat audit-event JSON for the Gemma 3N E4B + KV260 target. Reports blocked send metadata, redaction policy, absent prompt/response/transcript content, and disabled audit persistence. |
 | [`scripts/chat-error-taxonomy-stub.sh`](./scripts/chat-error-taxonomy-stub.sh) | Data-only chat error taxonomy JSON for the Gemma 3N E4B + KV260 target. Groups blocked readiness, model/runtime, session, and policy errors without reading prompts, providers, configs, model paths, logs, stores, or artifacts. |
@@ -150,6 +151,7 @@ bash scripts/status-stub.sh --include-chat-clipboard-policy
 bash scripts/status-stub.sh --include-chat-redaction-policy
 bash scripts/status-stub.sh --include-chat-attachment-policy
 bash scripts/status-stub.sh --include-chat-shortcut-map
+bash scripts/status-stub.sh --include-chat-status-summary
 bash scripts/status-stub.sh --include-device-session
 bash scripts/status-stub.sh --include-runtime-readiness
 bash scripts/device-session-status-stub.sh --model gemma3n-e4b --target kv260
@@ -180,6 +182,7 @@ bash scripts/chat-clipboard-policy-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-redaction-policy-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-attachment-policy-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-shortcut-map-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/chat-status-summary-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-surface-preview.sh --model gemma3n-e4b --target kv260
 bash scripts/launch-stub.sh --dry-run
 bash scripts/chat-stub.sh --dry-run --prompt "hello"
@@ -359,6 +362,7 @@ python3 contracts/chat_session_store_policy_contract.py --model gemma3n-e4b --ta
 python3 contracts/chat_shortcut_map_contract.py --model gemma3n-e4b --target kv260
 python3 contracts/chat_session_title_policy_contract.py --model gemma3n-e4b --target kv260
 python3 contracts/chat_empty_state_contract.py --model gemma3n-e4b --target kv260
+python3 contracts/chat_status_summary_contract.py --model gemma3n-e4b --target kv260
 bash scripts/chat-model-status-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-model-selection-policy-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-model-load-request-stub.sh --model gemma3n-e4b --target kv260
@@ -393,6 +397,7 @@ bash scripts/status-stub.sh --include-chat-session-store-policy
 bash scripts/status-stub.sh --include-chat-shortcut-map
 bash scripts/status-stub.sh --include-chat-session-title-policy
 bash scripts/status-stub.sh --include-chat-empty-state
+bash scripts/status-stub.sh --include-chat-status-summary
 python3 scripts/tests/chat_session_contract_test.py
 python3 scripts/tests/chat_model_status_contract_test.py
 python3 scripts/tests/chat_model_selection_policy_contract_test.py
@@ -409,6 +414,7 @@ python3 scripts/tests/chat_attachment_policy_contract_test.py
 python3 scripts/tests/chat_session_store_policy_contract_test.py
 python3 scripts/tests/chat_shortcut_map_contract_test.py
 python3 scripts/tests/chat_empty_state_contract_test.py
+python3 scripts/tests/chat_status_summary_contract_test.py
 python3 scripts/tests/chat_surface_preview_test.py
 bash scripts/tests/status-chat-model-status.sh
 bash scripts/tests/status-chat-model-selection-policy.sh
@@ -426,6 +432,7 @@ bash scripts/tests/status-chat-session-store-policy.sh
 bash scripts/tests/status-chat-shortcut-map.sh
 bash scripts/tests/status-chat-session-title-policy.sh
 bash scripts/tests/status-chat-empty-state.sh
+bash scripts/tests/status-chat-status-summary.sh
 ```
 
 The checked chat/session fixture reports the chat surface as blocked,

--- a/contracts/chat_status_summary_contract.py
+++ b/contracts/chat_status_summary_contract.py
@@ -1,0 +1,413 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Data-only chat status summary contract for the planned launcher UI.
+
+The contract aggregates existing checked chat surface references into a
+display-only blocked status summary. It does not read prompts, transcripts,
+session stores, model assets, runtime logs, provider configuration, artifacts,
+or hardware state; it does not start runtime code or invoke other PCCX tools.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import sys
+
+
+SCHEMA_VERSION = "pccx.chatStatusSummary.v0"
+
+CHAT_STATUS_SUMMARY_FIELDS = (
+    "schemaVersion",
+    "statusSummaryId",
+    "fixtureVersion",
+    "lastUpdatedSource",
+    "targetDevice",
+    "targetBoard",
+    "targetModel",
+    "overallState",
+    "surfaceState",
+    "sessionState",
+    "modelState",
+    "runtimeState",
+    "sendState",
+    "contentState",
+    "privacyState",
+    "evidenceState",
+    "statusCards",
+    "blockedReasons",
+    "nextActions",
+    "handoffRefs",
+    "safetyFlags",
+    "limitations",
+    "issueRefs",
+)
+
+STATUS_CARD_FIELDS = (
+    "cardId",
+    "label",
+    "sourceRef",
+    "schemaVersion",
+    "state",
+    "severity",
+    "summary",
+    "contentPolicy",
+    "requiredBefore",
+)
+
+BLOCKED_REASON_FIELDS = (
+    "reasonId",
+    "state",
+    "summary",
+    "requiredBefore",
+)
+
+NEXT_ACTION_FIELDS = (
+    "actionId",
+    "label",
+    "state",
+    "enabled",
+    "summary",
+    "sideEffectPolicy",
+)
+
+HANDOFF_REF_FIELDS = (
+    "refId",
+    "schemaVersion",
+    "fixturePath",
+    "state",
+    "summary",
+)
+
+CHAT_STATUS_SUMMARY_STATE_VALUES = (
+    "available_as_data",
+    "blocked",
+    "disabled",
+    "empty_not_captured",
+    "inactive",
+    "not_configured",
+    "not_loaded",
+    "not_started",
+    "not_used",
+    "placeholder",
+    "planned",
+    "requires_evidence",
+    "requires_review",
+    "summary_only",
+    "target_selected",
+    "unavailable",
+)
+
+_CHAT_STATUS_SUMMARY = {
+    "schemaVersion": SCHEMA_VERSION,
+    "statusSummaryId": "chat_status_summary_gemma3n_e4b_kv260_placeholder",
+    "fixtureVersion": "chat-status-summary.gemma3n-e4b-kv260.2026-05-05",
+    "lastUpdatedSource": "pccx_launcher_issue_9_chat_status_summary_boundary_2026-05-05",
+    "targetDevice": "kv260",
+    "targetBoard": "xilinx_kria_kv260",
+    "targetModel": "gemma3n-e4b",
+    "overallState": "blocked",
+    "surfaceState": "available_as_data",
+    "sessionState": "inactive",
+    "modelState": "blocked",
+    "runtimeState": "blocked",
+    "sendState": "disabled",
+    "contentState": "empty_not_captured",
+    "privacyState": "summary_only",
+    "evidenceState": "blocked",
+    "statusCards": [
+        {
+            "cardId": "surface_layout",
+            "label": "surface layout",
+            "sourceRef": "chat_surface_layout",
+            "schemaVersion": "pccx.chatSurfaceLayout.v0",
+            "state": "available_as_data",
+            "severity": "info",
+            "summary": "The planned chat shell regions can be rendered from checked local data.",
+            "contentPolicy": "no_prompt_response_transcript_or_session_content",
+            "requiredBefore": "chat_shell_enabled",
+        },
+        {
+            "cardId": "session_state",
+            "label": "session state",
+            "sourceRef": "chat_session",
+            "schemaVersion": "pccx.chatSession.v0",
+            "state": "inactive",
+            "severity": "blocked",
+            "summary": "No active launcher-owned chat session exists.",
+            "contentPolicy": "no_session_store_title_summary_or_path_content",
+            "requiredBefore": "session_restore_or_export_enabled",
+        },
+        {
+            "cardId": "model_status",
+            "label": "model status",
+            "sourceRef": "chat_model_status",
+            "schemaVersion": "pccx.chatModelStatus.v0",
+            "state": "blocked",
+            "severity": "blocked",
+            "summary": "Model status remains descriptor-only with no local asset or runtime load.",
+            "contentPolicy": "no_model_path_weight_tokenizer_or_checksum_content",
+            "requiredBefore": "model_load_enabled",
+        },
+        {
+            "cardId": "readiness",
+            "label": "chat readiness",
+            "sourceRef": "chat_readiness",
+            "schemaVersion": "pccx.chatReadiness.v0",
+            "state": "blocked",
+            "severity": "blocked",
+            "summary": "Chat readiness is blocked until runtime, device, model, and store evidence exist.",
+            "contentPolicy": "summary_only_no_runtime_log_or_artifact_content",
+            "requiredBefore": "send_message_enabled",
+        },
+        {
+            "cardId": "composer",
+            "label": "composer",
+            "sourceRef": "chat_composer",
+            "schemaVersion": "pccx.chatComposer.v0",
+            "state": "available_as_data",
+            "severity": "info",
+            "summary": "Composer controls can be displayed as disabled/local data without prompt capture.",
+            "contentPolicy": "no_prompt_text_or_attachment_content",
+            "requiredBefore": "prompt_capture_enabled",
+        },
+        {
+            "cardId": "send_result",
+            "label": "send result",
+            "sourceRef": "chat_send_result",
+            "schemaVersion": "pccx.chatSendResult.v0",
+            "state": "disabled",
+            "severity": "blocked",
+            "summary": "Send remains disabled and no input is accepted by this boundary.",
+            "contentPolicy": "no_prompt_echo_or_generated_response",
+            "requiredBefore": "assistant_response_available",
+        },
+        {
+            "cardId": "message_list",
+            "label": "message list",
+            "sourceRef": "chat_message_list",
+            "schemaVersion": "pccx.chatMessageList.v0",
+            "state": "empty_not_captured",
+            "severity": "info",
+            "summary": "The conversation viewport is empty because no messages are captured.",
+            "contentPolicy": "no_message_body_transcript_or_summary_content",
+            "requiredBefore": "conversation_history_displayed",
+        },
+        {
+            "cardId": "response_stream",
+            "label": "response stream",
+            "sourceRef": "chat_response_stream",
+            "schemaVersion": "pccx.chatResponseStream.v0",
+            "state": "disabled",
+            "severity": "blocked",
+            "summary": "Assistant streaming remains disabled and no token stream exists.",
+            "contentPolicy": "no_response_chunk_token_or_runtime_log_content",
+            "requiredBefore": "stream_transport_enabled",
+        },
+        {
+            "cardId": "privacy_controls",
+            "label": "privacy controls",
+            "sourceRef": "chat_redaction_policy",
+            "schemaVersion": "pccx.chatRedactionPolicy.v0",
+            "state": "summary_only",
+            "severity": "blocked",
+            "summary": "Privacy and redaction controls are summary-only with content scanning disabled.",
+            "contentPolicy": "no_raw_content_detector_match_or_redaction_result",
+            "requiredBefore": "content_scan_or_redaction_enabled",
+        },
+    ],
+    "blockedReasons": [
+        {
+            "reasonId": "runtime_evidence_absent",
+            "state": "blocked",
+            "summary": "No reviewed runtime readiness evidence exists for local chat execution.",
+            "requiredBefore": "send_message_enabled",
+        },
+        {
+            "reasonId": "model_load_absent",
+            "state": "blocked",
+            "summary": "No reviewed model asset, validation, load, warmup, or unload boundary is enabled.",
+            "requiredBefore": "model_status_ready",
+        },
+        {
+            "reasonId": "device_session_absent",
+            "state": "inactive",
+            "summary": "No active device session is represented by this local fixture.",
+            "requiredBefore": "runtime_session_started",
+        },
+        {
+            "reasonId": "session_store_absent",
+            "state": "not_configured",
+            "summary": "No reviewed session store, retention, restore, or export path exists.",
+            "requiredBefore": "session_management_enabled",
+        },
+        {
+            "reasonId": "content_boundary_absent",
+            "state": "requires_review",
+            "summary": "Prompt, response, transcript, attachment, clipboard, and redaction content boundaries remain disabled or summary-only.",
+            "requiredBefore": "prompt_or_response_content_displayed",
+        },
+    ],
+    "nextActions": [
+        {
+            "actionId": "review_readiness_data",
+            "label": "review readiness data",
+            "state": "available_as_data",
+            "enabled": False,
+            "summary": "Render existing checked readiness, model, session, and policy fixtures.",
+            "sideEffectPolicy": "read_only_data",
+        },
+        {
+            "actionId": "keep_send_disabled",
+            "label": "keep send disabled",
+            "state": "blocked",
+            "enabled": False,
+            "summary": "Do not accept prompts or dispatch runtime work from this summary.",
+            "sideEffectPolicy": "no_prompt_capture_no_runtime_execution",
+        },
+        {
+            "actionId": "wait_for_runtime_boundary",
+            "label": "wait for runtime boundary",
+            "state": "requires_evidence",
+            "enabled": False,
+            "summary": "Enable chat execution only after separate reviewed runtime and evidence boundaries exist.",
+            "sideEffectPolicy": "no_model_or_hardware_action",
+        },
+    ],
+    "handoffRefs": [
+        {
+            "refId": "chat_surface_layout",
+            "schemaVersion": "pccx.chatSurfaceLayout.v0",
+            "fixturePath": "contracts/fixtures/chat-surface-layout.gemma3n-e4b-kv260-placeholder.json",
+            "state": "available_as_data",
+            "summary": "Planned layout is consumed as local display data only.",
+        },
+        {
+            "refId": "chat_readiness",
+            "schemaVersion": "pccx.chatReadiness.v0",
+            "fixturePath": "contracts/fixtures/chat-readiness.gemma3n-e4b-kv260-placeholder.json",
+            "state": "blocked",
+            "summary": "Readiness stays blocked until evidence-backed runtime and session paths exist.",
+        },
+        {
+            "refId": "chat_model_status",
+            "schemaVersion": "pccx.chatModelStatus.v0",
+            "fixturePath": "contracts/fixtures/chat-model-status.gemma3n-e4b-kv260-placeholder.json",
+            "state": "blocked",
+            "summary": "Model status remains descriptor-only and blocked.",
+        },
+        {
+            "refId": "chat_session",
+            "schemaVersion": "pccx.chatSession.v0",
+            "fixturePath": "contracts/fixtures/chat-session.gemma3n-e4b-kv260-placeholder.json",
+            "state": "inactive",
+            "summary": "Base session state remains inactive local data.",
+        },
+        {
+            "refId": "chat_redaction_policy",
+            "schemaVersion": "pccx.chatRedactionPolicy.v0",
+            "fixturePath": "contracts/fixtures/chat-redaction-policy.gemma3n-e4b-kv260-placeholder.json",
+            "state": "summary_only",
+            "summary": "Redaction policy is referenced without loading rules or scanning content.",
+        },
+    ],
+    "safetyFlags": {
+        "dataOnly": True,
+        "readOnly": True,
+        "deterministic": True,
+        "statusSummaryOnly": True,
+        "aggregatesCheckedFixturesOnly": True,
+        "promptCapture": False,
+        "promptRead": False,
+        "promptContentIncluded": False,
+        "responseContentIncluded": False,
+        "transcriptContentIncluded": False,
+        "messageBodiesIncluded": False,
+        "sessionStoreRead": False,
+        "sessionPersistence": False,
+        "configRead": False,
+        "environmentRead": False,
+        "providerConfigRead": False,
+        "modelAssetRead": False,
+        "modelPathIncluded": False,
+        "modelLoadAttempted": False,
+        "modelExecution": False,
+        "runtimeExecution": False,
+        "responseGenerated": False,
+        "sendEnabled": False,
+        "clipboardRead": False,
+        "clipboardWrite": False,
+        "attachmentReads": False,
+        "fileContentRead": False,
+        "readsArtifacts": False,
+        "writesArtifacts": False,
+        "kv260Access": False,
+        "hardwareAccess": False,
+        "networkCalls": False,
+        "providerCalls": False,
+        "cloudCalls": False,
+        "executesPccxLab": False,
+        "executesSystemverilogIde": False,
+        "telemetry": False,
+        "writeBack": False,
+        "releaseOrTagAction": False,
+        "settingsChange": False,
+        "compatibilityClaim": False,
+    },
+    "limitations": [
+        "Data-only chat status summary over checked local fixture references.",
+        "No prompt, response, transcript, message, session-store, config, provider, model-path, runtime-log, artifact, private-path, secret, token, or hardware content is read.",
+        "No model load, runtime execution, provider call, network call, hardware access, telemetry, write-back, release, tag, settings, or repository action is performed.",
+        "Send and response streaming remain disabled until separate reviewed runtime, model, device-session, content, and persistence boundaries exist.",
+    ],
+    "issueRefs": [
+        "pccxai/pccx-llm-launcher#9",
+    ],
+}
+
+
+def create_gemma3n_e4b_kv260_chat_status_summary() -> dict:
+    """Return the checked Gemma 3N E4B plus KV260 chat status summary."""
+    return copy.deepcopy(_CHAT_STATUS_SUMMARY)
+
+
+def chat_status_summary_json(status: dict | None = None) -> str:
+    """Render a deterministic JSON representation."""
+    return json.dumps(
+        status
+        if status is not None
+        else create_gemma3n_e4b_kv260_chat_status_summary(),
+        indent=2,
+        sort_keys=True,
+    ) + "\n"
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Print data-only chat status summary JSON.",
+    )
+    parser.add_argument(
+        "--model",
+        default="gemma3n-e4b",
+        choices=("gemma3n-e4b",),
+        help="model descriptor target",
+    )
+    parser.add_argument(
+        "--target",
+        default="kv260",
+        choices=("kv260",),
+        help="target board/device",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parse_args(sys.argv[1:] if argv is None else argv)
+    sys.stdout.write(chat_status_summary_json())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contracts/fixtures/chat-status-summary.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-status-summary.gemma3n-e4b-kv260-placeholder.json
@@ -1,0 +1,266 @@
+{
+  "blockedReasons": [
+    {
+      "reasonId": "runtime_evidence_absent",
+      "requiredBefore": "send_message_enabled",
+      "state": "blocked",
+      "summary": "No reviewed runtime readiness evidence exists for local chat execution."
+    },
+    {
+      "reasonId": "model_load_absent",
+      "requiredBefore": "model_status_ready",
+      "state": "blocked",
+      "summary": "No reviewed model asset, validation, load, warmup, or unload boundary is enabled."
+    },
+    {
+      "reasonId": "device_session_absent",
+      "requiredBefore": "runtime_session_started",
+      "state": "inactive",
+      "summary": "No active device session is represented by this local fixture."
+    },
+    {
+      "reasonId": "session_store_absent",
+      "requiredBefore": "session_management_enabled",
+      "state": "not_configured",
+      "summary": "No reviewed session store, retention, restore, or export path exists."
+    },
+    {
+      "reasonId": "content_boundary_absent",
+      "requiredBefore": "prompt_or_response_content_displayed",
+      "state": "requires_review",
+      "summary": "Prompt, response, transcript, attachment, clipboard, and redaction content boundaries remain disabled or summary-only."
+    }
+  ],
+  "contentState": "empty_not_captured",
+  "evidenceState": "blocked",
+  "fixtureVersion": "chat-status-summary.gemma3n-e4b-kv260.2026-05-05",
+  "handoffRefs": [
+    {
+      "fixturePath": "contracts/fixtures/chat-surface-layout.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_surface_layout",
+      "schemaVersion": "pccx.chatSurfaceLayout.v0",
+      "state": "available_as_data",
+      "summary": "Planned layout is consumed as local display data only."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-readiness.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_readiness",
+      "schemaVersion": "pccx.chatReadiness.v0",
+      "state": "blocked",
+      "summary": "Readiness stays blocked until evidence-backed runtime and session paths exist."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-model-status.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_model_status",
+      "schemaVersion": "pccx.chatModelStatus.v0",
+      "state": "blocked",
+      "summary": "Model status remains descriptor-only and blocked."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-session.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_session",
+      "schemaVersion": "pccx.chatSession.v0",
+      "state": "inactive",
+      "summary": "Base session state remains inactive local data."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-redaction-policy.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_redaction_policy",
+      "schemaVersion": "pccx.chatRedactionPolicy.v0",
+      "state": "summary_only",
+      "summary": "Redaction policy is referenced without loading rules or scanning content."
+    }
+  ],
+  "issueRefs": [
+    "pccxai/pccx-llm-launcher#9"
+  ],
+  "lastUpdatedSource": "pccx_launcher_issue_9_chat_status_summary_boundary_2026-05-05",
+  "limitations": [
+    "Data-only chat status summary over checked local fixture references.",
+    "No prompt, response, transcript, message, session-store, config, provider, model-path, runtime-log, artifact, private-path, secret, token, or hardware content is read.",
+    "No model load, runtime execution, provider call, network call, hardware access, telemetry, write-back, release, tag, settings, or repository action is performed.",
+    "Send and response streaming remain disabled until separate reviewed runtime, model, device-session, content, and persistence boundaries exist."
+  ],
+  "modelState": "blocked",
+  "nextActions": [
+    {
+      "actionId": "review_readiness_data",
+      "enabled": false,
+      "label": "review readiness data",
+      "sideEffectPolicy": "read_only_data",
+      "state": "available_as_data",
+      "summary": "Render existing checked readiness, model, session, and policy fixtures."
+    },
+    {
+      "actionId": "keep_send_disabled",
+      "enabled": false,
+      "label": "keep send disabled",
+      "sideEffectPolicy": "no_prompt_capture_no_runtime_execution",
+      "state": "blocked",
+      "summary": "Do not accept prompts or dispatch runtime work from this summary."
+    },
+    {
+      "actionId": "wait_for_runtime_boundary",
+      "enabled": false,
+      "label": "wait for runtime boundary",
+      "sideEffectPolicy": "no_model_or_hardware_action",
+      "state": "requires_evidence",
+      "summary": "Enable chat execution only after separate reviewed runtime and evidence boundaries exist."
+    }
+  ],
+  "overallState": "blocked",
+  "privacyState": "summary_only",
+  "runtimeState": "blocked",
+  "safetyFlags": {
+    "aggregatesCheckedFixturesOnly": true,
+    "attachmentReads": false,
+    "clipboardRead": false,
+    "clipboardWrite": false,
+    "cloudCalls": false,
+    "compatibilityClaim": false,
+    "configRead": false,
+    "dataOnly": true,
+    "deterministic": true,
+    "environmentRead": false,
+    "executesPccxLab": false,
+    "executesSystemverilogIde": false,
+    "fileContentRead": false,
+    "hardwareAccess": false,
+    "kv260Access": false,
+    "messageBodiesIncluded": false,
+    "modelAssetRead": false,
+    "modelExecution": false,
+    "modelLoadAttempted": false,
+    "modelPathIncluded": false,
+    "networkCalls": false,
+    "promptCapture": false,
+    "promptContentIncluded": false,
+    "promptRead": false,
+    "providerCalls": false,
+    "providerConfigRead": false,
+    "readOnly": true,
+    "readsArtifacts": false,
+    "releaseOrTagAction": false,
+    "responseContentIncluded": false,
+    "responseGenerated": false,
+    "runtimeExecution": false,
+    "sendEnabled": false,
+    "sessionPersistence": false,
+    "sessionStoreRead": false,
+    "settingsChange": false,
+    "statusSummaryOnly": true,
+    "telemetry": false,
+    "transcriptContentIncluded": false,
+    "writeBack": false,
+    "writesArtifacts": false
+  },
+  "schemaVersion": "pccx.chatStatusSummary.v0",
+  "sendState": "disabled",
+  "sessionState": "inactive",
+  "statusCards": [
+    {
+      "cardId": "surface_layout",
+      "contentPolicy": "no_prompt_response_transcript_or_session_content",
+      "label": "surface layout",
+      "requiredBefore": "chat_shell_enabled",
+      "schemaVersion": "pccx.chatSurfaceLayout.v0",
+      "severity": "info",
+      "sourceRef": "chat_surface_layout",
+      "state": "available_as_data",
+      "summary": "The planned chat shell regions can be rendered from checked local data."
+    },
+    {
+      "cardId": "session_state",
+      "contentPolicy": "no_session_store_title_summary_or_path_content",
+      "label": "session state",
+      "requiredBefore": "session_restore_or_export_enabled",
+      "schemaVersion": "pccx.chatSession.v0",
+      "severity": "blocked",
+      "sourceRef": "chat_session",
+      "state": "inactive",
+      "summary": "No active launcher-owned chat session exists."
+    },
+    {
+      "cardId": "model_status",
+      "contentPolicy": "no_model_path_weight_tokenizer_or_checksum_content",
+      "label": "model status",
+      "requiredBefore": "model_load_enabled",
+      "schemaVersion": "pccx.chatModelStatus.v0",
+      "severity": "blocked",
+      "sourceRef": "chat_model_status",
+      "state": "blocked",
+      "summary": "Model status remains descriptor-only with no local asset or runtime load."
+    },
+    {
+      "cardId": "readiness",
+      "contentPolicy": "summary_only_no_runtime_log_or_artifact_content",
+      "label": "chat readiness",
+      "requiredBefore": "send_message_enabled",
+      "schemaVersion": "pccx.chatReadiness.v0",
+      "severity": "blocked",
+      "sourceRef": "chat_readiness",
+      "state": "blocked",
+      "summary": "Chat readiness is blocked until runtime, device, model, and store evidence exist."
+    },
+    {
+      "cardId": "composer",
+      "contentPolicy": "no_prompt_text_or_attachment_content",
+      "label": "composer",
+      "requiredBefore": "prompt_capture_enabled",
+      "schemaVersion": "pccx.chatComposer.v0",
+      "severity": "info",
+      "sourceRef": "chat_composer",
+      "state": "available_as_data",
+      "summary": "Composer controls can be displayed as disabled/local data without prompt capture."
+    },
+    {
+      "cardId": "send_result",
+      "contentPolicy": "no_prompt_echo_or_generated_response",
+      "label": "send result",
+      "requiredBefore": "assistant_response_available",
+      "schemaVersion": "pccx.chatSendResult.v0",
+      "severity": "blocked",
+      "sourceRef": "chat_send_result",
+      "state": "disabled",
+      "summary": "Send remains disabled and no input is accepted by this boundary."
+    },
+    {
+      "cardId": "message_list",
+      "contentPolicy": "no_message_body_transcript_or_summary_content",
+      "label": "message list",
+      "requiredBefore": "conversation_history_displayed",
+      "schemaVersion": "pccx.chatMessageList.v0",
+      "severity": "info",
+      "sourceRef": "chat_message_list",
+      "state": "empty_not_captured",
+      "summary": "The conversation viewport is empty because no messages are captured."
+    },
+    {
+      "cardId": "response_stream",
+      "contentPolicy": "no_response_chunk_token_or_runtime_log_content",
+      "label": "response stream",
+      "requiredBefore": "stream_transport_enabled",
+      "schemaVersion": "pccx.chatResponseStream.v0",
+      "severity": "blocked",
+      "sourceRef": "chat_response_stream",
+      "state": "disabled",
+      "summary": "Assistant streaming remains disabled and no token stream exists."
+    },
+    {
+      "cardId": "privacy_controls",
+      "contentPolicy": "no_raw_content_detector_match_or_redaction_result",
+      "label": "privacy controls",
+      "requiredBefore": "content_scan_or_redaction_enabled",
+      "schemaVersion": "pccx.chatRedactionPolicy.v0",
+      "severity": "blocked",
+      "sourceRef": "chat_redaction_policy",
+      "state": "summary_only",
+      "summary": "Privacy and redaction controls are summary-only with content scanning disabled."
+    }
+  ],
+  "statusSummaryId": "chat_status_summary_gemma3n_e4b_kv260_placeholder",
+  "surfaceState": "available_as_data",
+  "targetBoard": "xilinx_kria_kv260",
+  "targetDevice": "kv260",
+  "targetModel": "gemma3n-e4b"
+}

--- a/docs/STANDALONE_CHAT_SESSION_CONTRACT.md
+++ b/docs/STANDALONE_CHAT_SESSION_CONTRACT.md
@@ -33,6 +33,7 @@ The implementation lives in:
 - `contracts/chat_redaction_policy_contract.py`
 - `contracts/chat_attachment_policy_contract.py`
 - `contracts/chat_shortcut_map_contract.py`
+- `contracts/chat_status_summary_contract.py`
 - `contracts/fixtures/chat-session.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-model-status.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-model-selection-policy.gemma3n-e4b-kv260-placeholder.json`
@@ -58,6 +59,7 @@ The implementation lives in:
 - `contracts/fixtures/chat-redaction-policy.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-attachment-policy.gemma3n-e4b-kv260-placeholder.json`
 - `contracts/fixtures/chat-shortcut-map.gemma3n-e4b-kv260-placeholder.json`
+- `contracts/fixtures/chat-status-summary.gemma3n-e4b-kv260-placeholder.json`
 - `scripts/chat-session-stub.sh`
 - `scripts/chat-model-status-stub.sh`
 - `scripts/chat-model-selection-policy-stub.sh`
@@ -83,6 +85,7 @@ The implementation lives in:
 - `scripts/chat-redaction-policy-stub.sh`
 - `scripts/chat-attachment-policy-stub.sh`
 - `scripts/chat-shortcut-map-stub.sh`
+- `scripts/chat-status-summary-stub.sh`
 - `scripts/chat-surface-preview.sh`
 - `scripts/tests/chat_session_contract_test.py`
 - `scripts/tests/chat_model_status_contract_test.py`
@@ -109,6 +112,7 @@ The implementation lives in:
 - `scripts/tests/chat_redaction_policy_contract_test.py`
 - `scripts/tests/chat_attachment_policy_contract_test.py`
 - `scripts/tests/chat_shortcut_map_contract_test.py`
+- `scripts/tests/chat_status_summary_contract_test.py`
 - `scripts/tests/chat_surface_preview_test.py`
 - `scripts/tests/status-chat-model-status.sh`
 - `scripts/tests/status-chat-model-selection-policy.sh`
@@ -134,6 +138,7 @@ The implementation lives in:
 - `scripts/tests/status-chat-redaction-policy.sh`
 - `scripts/tests/status-chat-attachment-policy.sh`
 - `scripts/tests/status-chat-shortcut-map.sh`
+- `scripts/tests/status-chat-status-summary.sh`
 
 ## What Is Implemented
 
@@ -485,6 +490,8 @@ content-scanning boundary used by the planned standalone chat surface:
 ```bash
 bash scripts/chat-redaction-policy-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/status-stub.sh --include-chat-redaction-policy
+bash scripts/chat-status-summary-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/status-stub.sh --include-chat-status-summary
 ```
 
 It keeps redaction handling as local metadata: redaction rule review,
@@ -873,6 +880,10 @@ without prompt capture, response content, transcript content, provider
 configuration reads, model asset reads, session-store reads, artifact
 reads, artifact writes, runtime execution, model loading, provider calls,
 or target access.
+The status-summary contract adds a reviewable aggregate status shape over
+existing checked chat surface references without reading prompts, session
+stores, configuration, model paths, runtime logs, provider state,
+artifacts, or hardware state.
 The action-bar contract adds a reviewable disabled control shape without
 session creation, conversation clearing, transcript export, clipboard
 writes, attachment reads, retry attempts, stop signals, runtime

--- a/scripts/chat-status-summary-stub.sh
+++ b/scripts/chat-status-summary-stub.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+# Print the data-only chat status-summary contract.
+
+set -eu
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+
+python3 "$ROOT_DIR/contracts/chat_status_summary_contract.py" "$@"

--- a/scripts/status-stub.sh
+++ b/scripts/status-stub.sh
@@ -85,6 +85,9 @@
 # Chat shortcut-map boundary (explicit opt-in, read-only local data):
 #   --include-chat-shortcut-map
 #
+# Chat status-summary aggregate (explicit opt-in, read-only local data):
+#   --include-chat-status-summary
+#
 # pccx-lab backend (explicit opt-in):
 #   --backend pccx-lab        call pccx-lab status --format json
 #   PCCX_LAB_BIN              override path to pccx-lab binary (takes priority over PATH)
@@ -127,6 +130,115 @@ INCLUDE_CHAT_CLIPBOARD_POLICY="0"
 INCLUDE_CHAT_REDACTION_POLICY="0"
 INCLUDE_CHAT_ATTACHMENT_POLICY="0"
 INCLUDE_CHAT_SHORTCUT_MAP="0"
+INCLUDE_CHAT_STATUS_SUMMARY="0"
+
+print_chat_status_summary_summary() {
+    SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+    ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+    CHAT_STATUS_SUMMARY_STUB="$ROOT_DIR/scripts/chat-status-summary-stub.sh"
+
+    if [ ! -f "$CHAT_STATUS_SUMMARY_STUB" ]; then
+        ERROR "chat status summary stub not found: $CHAT_STATUS_SUMMARY_STUB"
+        return 1
+    fi
+
+    if ! CHAT_STATUS_SUMMARY_JSON="$(bash "$CHAT_STATUS_SUMMARY_STUB" --model gemma3n-e4b --target kv260 2>&1)"; then
+        ERROR "chat status summary stub failed"
+        printf '%s\n' "$CHAT_STATUS_SUMMARY_JSON" >&2
+        return 1
+    fi
+
+    if ! CHAT_STATUS_SUMMARY_TEXT="$(
+        printf '%s\n' "$CHAT_STATUS_SUMMARY_JSON" | python3 -c '
+import json
+import sys
+
+data = json.load(sys.stdin)
+flags = data["safetyFlags"]
+cards = " ".join(
+    "{}={}:{}".format(card["cardId"], card["state"], card["severity"])
+    for card in data["statusCards"]
+)
+blocked = " ".join(
+    "{}={}".format(reason["reasonId"], reason["state"])
+    for reason in data["blockedReasons"]
+)
+actions = " ".join(
+    "{}={}:{}".format(action["actionId"], action["state"], str(action["enabled"]).lower())
+    for action in data["nextActions"]
+)
+
+def b(value):
+    return "true" if value else "false"
+
+print("[INFO]  source     : scripts/chat-status-summary-stub.sh --model gemma3n-e4b --target kv260")
+print("[INFO]  boundary   : read-only data; no prompt/session-store/config/model/runtime/hardware/provider/lab/IDE execution")
+print("[INFO]  target     : {}".format(data["targetDevice"]))
+print("[INFO]  model      : {}".format(data["targetModel"]))
+print("[INFO]  overall   : {}".format(data["overallState"]))
+print("[INFO]  surface   : {}".format(data["surfaceState"]))
+print("[INFO]  session   : {}".format(data["sessionState"]))
+print("[INFO]  modelState: {}".format(data["modelState"]))
+print("[INFO]  runtime   : {}".format(data["runtimeState"]))
+print("[INFO]  send      : {}".format(data["sendState"]))
+print("[INFO]  content   : {}".format(data["contentState"]))
+print("[INFO]  privacy   : {}".format(data["privacyState"]))
+print("[INFO]  evidence  : {}".format(data["evidenceState"]))
+print("[INFO]  cards      : {}".format(cards))
+print("[INFO]  blocked    : {}".format(blocked))
+print("[INFO]  actions    : {}".format(actions))
+print(
+    "[INFO]  flags      : readOnly={} dataOnly={} deterministic={} "
+    "statusSummaryOnly={} aggregatesCheckedFixturesOnly={} "
+    "promptCapture={} promptRead={} promptContentIncluded={} "
+    "responseContentIncluded={} transcriptContentIncluded={} "
+    "messageBodiesIncluded={} sessionStoreRead={} configRead={} "
+    "environmentRead={} providerConfigRead={} modelAssetRead={} "
+    "modelLoadAttempted={} modelExecution={} runtimeExecution={} "
+    "responseGenerated={} sendEnabled={} kv260Access={} hardwareAccess={} "
+    "networkCalls={} providerCalls={} cloudCalls={} executesPccxLab={} "
+    "executesSystemverilogIde={} releaseOrTagAction={} settingsChange={}".format(
+        b(flags["readOnly"]),
+        b(flags["dataOnly"]),
+        b(flags["deterministic"]),
+        b(flags["statusSummaryOnly"]),
+        b(flags["aggregatesCheckedFixturesOnly"]),
+        b(flags["promptCapture"]),
+        b(flags["promptRead"]),
+        b(flags["promptContentIncluded"]),
+        b(flags["responseContentIncluded"]),
+        b(flags["transcriptContentIncluded"]),
+        b(flags["messageBodiesIncluded"]),
+        b(flags["sessionStoreRead"]),
+        b(flags["configRead"]),
+        b(flags["environmentRead"]),
+        b(flags["providerConfigRead"]),
+        b(flags["modelAssetRead"]),
+        b(flags["modelLoadAttempted"]),
+        b(flags["modelExecution"]),
+        b(flags["runtimeExecution"]),
+        b(flags["responseGenerated"]),
+        b(flags["sendEnabled"]),
+        b(flags["kv260Access"]),
+        b(flags["hardwareAccess"]),
+        b(flags["networkCalls"]),
+        b(flags["providerCalls"]),
+        b(flags["cloudCalls"]),
+        b(flags["executesPccxLab"]),
+        b(flags["executesSystemverilogIde"]),
+        b(flags["releaseOrTagAction"]),
+        b(flags["settingsChange"]),
+    )
+)
+'
+    )"; then
+        ERROR "chat status summary JSON could not be summarized"
+        return 1
+    fi
+
+    HEAD "chat status summary"
+    printf '%s\n' "$CHAT_STATUS_SUMMARY_TEXT"
+}
 
 print_chat_error_taxonomy_summary() {
     SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
@@ -3298,6 +3410,10 @@ while [ $# -gt 0 ]; do
             INCLUDE_CHAT_SHORTCUT_MAP="1"
             shift
             ;;
+        --include-chat-status-summary)
+            INCLUDE_CHAT_STATUS_SUMMARY="1"
+            shift
+            ;;
         --backend)
             BACKEND="${2:-}"
             if [ -z "$BACKEND" ]; then
@@ -3313,8 +3429,8 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-if [ -n "$BACKEND" ] && { [ "$INCLUDE_RUNTIME_READINESS" = "1" ] || [ "$INCLUDE_DEVICE_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SURFACE_LAYOUT" = "1" ] || [ "$INCLUDE_CHAT_EMPTY_STATE" = "1" ] || [ "$INCLUDE_CHAT_LOCAL_ONLY_POLICY" = "1" ] || [ "$INCLUDE_CHAT_PREFERENCES" = "1" ] || [ "$INCLUDE_CHAT_SESSION_INDEX" = "1" ] || [ "$INCLUDE_CHAT_SESSION_STORE_POLICY" = "1" ] || [ "$INCLUDE_CHAT_SESSION_TITLE_POLICY" = "1" ] || [ "$INCLUDE_CHAT_MODEL_STATUS" = "1" ] || [ "$INCLUDE_CHAT_MODEL_SELECTION_POLICY" = "1" ] || [ "$INCLUDE_CHAT_CONTEXT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_MODEL_LOAD_REQUEST" = "1" ] || [ "$INCLUDE_CHAT_READINESS" = "1" ] || [ "$INCLUDE_CHAT_COMPOSER" = "1" ] || [ "$INCLUDE_CHAT_SEND_RESULT" = "1" ] || [ "$INCLUDE_CHAT_TRANSCRIPT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_AUDIT_EVENT" = "1" ] || [ "$INCLUDE_CHAT_ERROR_TAXONOMY" = "1" ] || [ "$INCLUDE_CHAT_RESPONSE_STREAM" = "1" ] || [ "$INCLUDE_CHAT_MESSAGE_LIST" = "1" ] || [ "$INCLUDE_CHAT_ACTION_BAR" = "1" ] || [ "$INCLUDE_CHAT_CLIPBOARD_POLICY" = "1" ] || [ "$INCLUDE_CHAT_REDACTION_POLICY" = "1" ] || [ "$INCLUDE_CHAT_ATTACHMENT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_SHORTCUT_MAP" = "1" ]; }; then
-    ERROR "--include-runtime-readiness, --include-device-session, --include-chat-session, --include-chat-surface-layout, --include-chat-empty-state, --include-chat-local-only-policy, --include-chat-preferences, --include-chat-session-index, --include-chat-session-store-policy, --include-chat-session-title-policy, --include-chat-model-status, --include-chat-model-selection-policy, --include-chat-context-policy, --include-chat-model-load-request, --include-chat-readiness, --include-chat-composer, --include-chat-send-result, --include-chat-transcript-policy, --include-chat-audit-event, --include-chat-error-taxonomy, --include-chat-response-stream, --include-chat-message-list, --include-chat-action-bar, --include-chat-clipboard-policy, --include-chat-redaction-policy, --include-chat-attachment-policy, and --include-chat-shortcut-map are only supported in local scaffold mode"
+if [ -n "$BACKEND" ] && { [ "$INCLUDE_RUNTIME_READINESS" = "1" ] || [ "$INCLUDE_DEVICE_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SURFACE_LAYOUT" = "1" ] || [ "$INCLUDE_CHAT_EMPTY_STATE" = "1" ] || [ "$INCLUDE_CHAT_LOCAL_ONLY_POLICY" = "1" ] || [ "$INCLUDE_CHAT_PREFERENCES" = "1" ] || [ "$INCLUDE_CHAT_SESSION_INDEX" = "1" ] || [ "$INCLUDE_CHAT_SESSION_STORE_POLICY" = "1" ] || [ "$INCLUDE_CHAT_SESSION_TITLE_POLICY" = "1" ] || [ "$INCLUDE_CHAT_MODEL_STATUS" = "1" ] || [ "$INCLUDE_CHAT_MODEL_SELECTION_POLICY" = "1" ] || [ "$INCLUDE_CHAT_CONTEXT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_MODEL_LOAD_REQUEST" = "1" ] || [ "$INCLUDE_CHAT_READINESS" = "1" ] || [ "$INCLUDE_CHAT_COMPOSER" = "1" ] || [ "$INCLUDE_CHAT_SEND_RESULT" = "1" ] || [ "$INCLUDE_CHAT_TRANSCRIPT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_AUDIT_EVENT" = "1" ] || [ "$INCLUDE_CHAT_ERROR_TAXONOMY" = "1" ] || [ "$INCLUDE_CHAT_RESPONSE_STREAM" = "1" ] || [ "$INCLUDE_CHAT_MESSAGE_LIST" = "1" ] || [ "$INCLUDE_CHAT_ACTION_BAR" = "1" ] || [ "$INCLUDE_CHAT_CLIPBOARD_POLICY" = "1" ] || [ "$INCLUDE_CHAT_REDACTION_POLICY" = "1" ] || [ "$INCLUDE_CHAT_ATTACHMENT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_SHORTCUT_MAP" = "1" ] || [ "$INCLUDE_CHAT_STATUS_SUMMARY" = "1" ]; }; then
+    ERROR "--include-runtime-readiness, --include-device-session, --include-chat-session, --include-chat-surface-layout, --include-chat-empty-state, --include-chat-local-only-policy, --include-chat-preferences, --include-chat-session-index, --include-chat-session-store-policy, --include-chat-session-title-policy, --include-chat-model-status, --include-chat-model-selection-policy, --include-chat-context-policy, --include-chat-model-load-request, --include-chat-readiness, --include-chat-composer, --include-chat-send-result, --include-chat-transcript-policy, --include-chat-audit-event, --include-chat-error-taxonomy, --include-chat-response-stream, --include-chat-message-list, --include-chat-action-bar, --include-chat-clipboard-policy, --include-chat-redaction-policy, --include-chat-attachment-policy, --include-chat-shortcut-map, and --include-chat-status-summary are only supported in local scaffold mode"
     exit 1
 fi
 
@@ -3354,7 +3470,14 @@ if [ -z "$BACKEND" ]; then
     NOTE "chat redact   : opt-in via --include-chat-redaction-policy (read-only disabled redaction-policy data)"
     NOTE "chat attach   : opt-in via --include-chat-attachment-policy (read-only disabled attachment-policy data)"
     NOTE "chat shortcuts: opt-in via --include-chat-shortcut-map (read-only disabled shortcut-map data)"
+    NOTE "chat summary  : opt-in via --include-chat-status-summary (read-only aggregate status data)"
     NOTE "editor bridge  : planned (VS Code / other IDEs)"
+
+    if [ "$INCLUDE_CHAT_STATUS_SUMMARY" = "1" ]; then
+        if ! print_chat_status_summary_summary; then
+            exit 1
+        fi
+    fi
 
     if [ "$INCLUDE_CHAT_ERROR_TAXONOMY" = "1" ]; then
         if ! print_chat_error_taxonomy_summary; then

--- a/scripts/tests/chat_status_summary_contract_test.py
+++ b/scripts/tests/chat_status_summary_contract_test.py
@@ -1,0 +1,367 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Fixture tests for the standalone chat status-summary contract."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "contracts" / "chat_status_summary_contract.py"
+FIXTURE_PATH = (
+    ROOT
+    / "contracts"
+    / "fixtures"
+    / "chat-status-summary.gemma3n-e4b-kv260-placeholder.json"
+)
+SCRIPT_PATH = ROOT / "scripts" / "chat-status-summary-stub.sh"
+STATUS_TEST_PATH = ROOT / "scripts" / "tests" / "status-chat-status-summary.sh"
+DOC_PATH = ROOT / "docs" / "STANDALONE_CHAT_SESSION_CONTRACT.md"
+README_PATH = ROOT / "README.md"
+TEST_PATH = Path(__file__).resolve()
+CI_PATH = ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location(
+        "chat_status_summary_contract",
+        MODULE_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def flatten(value) -> str:
+    return json.dumps(value, sort_keys=True)
+
+
+def iter_state_values(value):
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            if key == "state" or key.endswith("State") or key.endswith("Status"):
+                yield nested
+            yield from iter_state_values(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            yield from iter_state_values(nested)
+
+
+def iter_keys(value):
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            yield key
+            yield from iter_keys(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            yield from iter_keys(nested)
+
+
+def assert_no_private_or_generated_data(text: str) -> None:
+    forbidden_patterns = [
+        r"/home/[^\s\"']+",
+        r"/Users/[^\s\"']+",
+        r"[A-Za-z]:\\Users\\",
+        r"\b(?:api[_-]?key|authorization|bearer|client[_-]?secret|password|private[_-]?key|secret|token)\b\s*[:=]",
+        r"\.(?:gguf|safetensors|ckpt|pt|pth|onnx)\b",
+        r"(?:weights|model_weights|model-cache)/(?:[^\"'\s]+)",
+        r"(?:raw[_-]?full[_-]?logs|hardware[_-]?dump|generated[_-]?blob)\s*[:=]",
+    ]
+    for pattern in forbidden_patterns:
+        assert not re.search(pattern, text, re.IGNORECASE), pattern
+
+
+def assert_no_runtime_implementation_terms(source: str) -> None:
+    forbidden = [
+        "subprocess",
+        "os.system",
+        "popen",
+        "socket",
+        "urllib",
+        "requests",
+        "http.client",
+        "openai",
+        "anthropic",
+        "gemini",
+        "modelcontextprotocol",
+        "websocket",
+        "xmutil",
+        "xrt-smi",
+        "lsusb",
+        "dmesg",
+    ]
+    lowered = source.lower()
+    for term in forbidden:
+        assert term not in lowered, term
+
+
+def assert_no_provider_configs(value) -> None:
+    forbidden_keys = {
+        "apiKey",
+        "accessToken",
+        "refreshToken",
+        "authorization",
+        "bearerToken",
+        "provider",
+        "providers",
+        "providerConfig",
+        "providerConfigs",
+    }
+    for key in iter_keys(value):
+        assert key not in forbidden_keys, key
+
+
+def assert_no_unsupported_claims(text: str) -> None:
+    literal_claims = [
+        "production" + "-ready",
+        "marketplace" + "-ready",
+        "stable " + "API",
+        "stable " + "ABI",
+        "KV260 inference " + "works",
+        "Gemma 3N E4B " + "runs on KV260",
+        "20 tok/s " + "achieved",
+        "timing " + "closed",
+        "bitstream " + "ready",
+        "launcher executes " + "pccx-lab",
+        "IDE controls " + "launcher",
+        "AI provider integration " + "is live",
+    ]
+    lowered = text.lower()
+    for claim in literal_claims:
+        assert claim.lower() not in lowered, claim
+
+
+def test_chat_status_summary_matches_fixture_and_is_deterministic() -> None:
+    module = load_module()
+    generated = module.create_gemma3n_e4b_kv260_chat_status_summary()
+    fixture = json.loads(read_text(FIXTURE_PATH))
+
+    assert generated == fixture
+    assert module.chat_status_summary_json(generated) == (
+        module.chat_status_summary_json(generated)
+    )
+    assert module.chat_status_summary_json(generated).endswith("\n")
+    assert json.loads(module.chat_status_summary_json(generated)) == fixture
+
+
+def test_cli_stub_outputs_deterministic_json() -> None:
+    fixture = json.loads(read_text(FIXTURE_PATH))
+    command = [
+        "bash",
+        str(SCRIPT_PATH),
+        "--model",
+        "gemma3n-e4b",
+        "--target",
+        "kv260",
+    ]
+    first = subprocess.run(command, check=True, capture_output=True, text=True)
+    second = subprocess.run(command, check=True, capture_output=True, text=True)
+
+    assert first.stderr == ""
+    assert first.stdout == second.stdout
+    assert first.stdout.endswith("\n")
+    assert json.loads(first.stdout) == fixture
+
+
+def test_required_fields_and_allowed_states() -> None:
+    module = load_module()
+    summary = module.create_gemma3n_e4b_kv260_chat_status_summary()
+    allowed = set(module.CHAT_STATUS_SUMMARY_STATE_VALUES)
+
+    assert tuple(summary.keys()) == module.CHAT_STATUS_SUMMARY_FIELDS
+    assert summary["schemaVersion"] == "pccx.chatStatusSummary.v0"
+
+    states = list(iter_state_values(summary))
+    assert states
+    for state in states:
+        assert state in allowed, state
+
+    for card in summary["statusCards"]:
+        assert tuple(card.keys()) == module.STATUS_CARD_FIELDS
+    for reason in summary["blockedReasons"]:
+        assert tuple(reason.keys()) == module.BLOCKED_REASON_FIELDS
+    for action in summary["nextActions"]:
+        assert tuple(action.keys()) == module.NEXT_ACTION_FIELDS
+    for ref in summary["handoffRefs"]:
+        assert tuple(ref.keys()) == module.HANDOFF_REF_FIELDS
+
+
+def test_chat_status_summary_covers_blocked_status_boundary() -> None:
+    summary = load_module().create_gemma3n_e4b_kv260_chat_status_summary()
+    cards = {card["cardId"]: card for card in summary["statusCards"]}
+    reasons = {reason["reasonId"]: reason for reason in summary["blockedReasons"]}
+    actions = {action["actionId"]: action for action in summary["nextActions"]}
+    refs = {ref["refId"]: ref for ref in summary["handoffRefs"]}
+
+    assert summary["overallState"] == "blocked"
+    assert summary["surfaceState"] == "available_as_data"
+    assert summary["sessionState"] == "inactive"
+    assert summary["modelState"] == "blocked"
+    assert summary["runtimeState"] == "blocked"
+    assert summary["sendState"] == "disabled"
+    assert summary["contentState"] == "empty_not_captured"
+    assert summary["privacyState"] == "summary_only"
+    assert set(cards) == {
+        "surface_layout",
+        "session_state",
+        "model_status",
+        "readiness",
+        "composer",
+        "send_result",
+        "message_list",
+        "response_stream",
+        "privacy_controls",
+    }
+    assert cards["surface_layout"]["state"] == "available_as_data"
+    assert cards["session_state"]["state"] == "inactive"
+    assert cards["model_status"]["state"] == "blocked"
+    assert cards["readiness"]["state"] == "blocked"
+    assert cards["send_result"]["state"] == "disabled"
+    assert cards["message_list"]["state"] == "empty_not_captured"
+    assert set(reasons) == {
+        "runtime_evidence_absent",
+        "model_load_absent",
+        "device_session_absent",
+        "session_store_absent",
+        "content_boundary_absent",
+    }
+    assert set(actions) == {
+        "review_readiness_data",
+        "keep_send_disabled",
+        "wait_for_runtime_boundary",
+    }
+    for action in actions.values():
+        assert action["enabled"] is False
+    assert set(refs) == {
+        "chat_surface_layout",
+        "chat_readiness",
+        "chat_model_status",
+        "chat_session",
+        "chat_redaction_policy",
+    }
+
+
+def test_safety_flags_preserve_summary_only_boundary() -> None:
+    summary = load_module().create_gemma3n_e4b_kv260_chat_status_summary()
+    flags = summary["safetyFlags"]
+
+    assert flags["dataOnly"] is True
+    assert flags["readOnly"] is True
+    assert flags["deterministic"] is True
+    assert flags["statusSummaryOnly"] is True
+    assert flags["aggregatesCheckedFixturesOnly"] is True
+    for name in [
+        "promptCapture",
+        "promptRead",
+        "promptContentIncluded",
+        "responseContentIncluded",
+        "transcriptContentIncluded",
+        "messageBodiesIncluded",
+        "sessionStoreRead",
+        "sessionPersistence",
+        "configRead",
+        "environmentRead",
+        "providerConfigRead",
+        "modelAssetRead",
+        "modelPathIncluded",
+        "modelLoadAttempted",
+        "modelExecution",
+        "runtimeExecution",
+        "responseGenerated",
+        "sendEnabled",
+        "clipboardRead",
+        "clipboardWrite",
+        "attachmentReads",
+        "fileContentRead",
+        "readsArtifacts",
+        "writesArtifacts",
+        "kv260Access",
+        "hardwareAccess",
+        "networkCalls",
+        "providerCalls",
+        "cloudCalls",
+        "executesPccxLab",
+        "executesSystemverilogIde",
+        "telemetry",
+        "writeBack",
+        "releaseOrTagAction",
+        "settingsChange",
+        "compatibilityClaim",
+    ]:
+        assert flags[name] is False, name
+
+
+def test_docs_and_sources_avoid_private_data_runtime_calls_or_overclaims() -> None:
+    module_source = read_text(MODULE_PATH)
+    script_source = read_text(SCRIPT_PATH)
+    status_test_source = read_text(STATUS_TEST_PATH)
+    summary = load_module().create_gemma3n_e4b_kv260_chat_status_summary()
+    scan_text = "\n".join([
+        read_text(FIXTURE_PATH),
+        read_text(DOC_PATH),
+        read_text(README_PATH),
+        flatten(summary),
+        module_source,
+        script_source,
+        status_test_source,
+    ])
+    runtime_source = "\n".join([module_source, script_source])
+
+    assert_no_runtime_implementation_terms(runtime_source)
+    assert_no_private_or_generated_data(scan_text)
+    assert_no_provider_configs(summary)
+    assert_no_unsupported_claims(scan_text)
+
+
+def test_source_headers_for_touched_code_files() -> None:
+    expected_headers = {
+        MODULE_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        SCRIPT_PATH: [
+            "#!/usr/bin/env bash",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        STATUS_TEST_PATH: [
+            "#!/usr/bin/env bash",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        TEST_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        CI_PATH: [
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+    }
+
+    for path, header in expected_headers.items():
+        assert read_text(path).splitlines()[: len(header)] == header, path
+
+
+test_chat_status_summary_matches_fixture_and_is_deterministic()
+test_cli_stub_outputs_deterministic_json()
+test_required_fields_and_allowed_states()
+test_chat_status_summary_covers_blocked_status_boundary()
+test_safety_flags_preserve_summary_only_boundary()
+test_docs_and_sources_avoid_private_data_runtime_calls_or_overclaims()
+test_source_headers_for_touched_code_files()
+
+print("chat status summary contract tests ok")

--- a/scripts/tests/status-chat-status-summary.sh
+++ b/scripts/tests/status-chat-status-summary.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+# scripts/tests/status-chat-status-summary.sh - status chat summary tests.
+#
+# Usage: bash scripts/tests/status-chat-status-summary.sh [path/to/status-stub.sh]
+
+set -eu
+
+PASS() { printf '[PASS]  %s\n' "$*"; }
+FAIL() { printf '[FAIL] %s\n' "$*" >&2; }
+HEAD() { printf '\n=== %s ===\n' "$*"; }
+
+STUB="${1:-scripts/status-stub.sh}"
+
+if [ ! -x "$STUB" ]; then
+    chmod +x "$STUB"
+fi
+
+contains() {
+    case "$1" in
+        *"$2"*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+require_contains() {
+    local output="$1"
+    local expected="$2"
+    if ! contains "$output" "$expected"; then
+        FAIL "expected output to contain: $expected"
+        printf '%s\n' "$output" >&2
+        exit 1
+    fi
+}
+
+require_not_contains() {
+    local output="$1"
+    local forbidden="$2"
+    if contains "$output" "$forbidden"; then
+        FAIL "output contained forbidden text: $forbidden"
+        printf '%s\n' "$output" >&2
+        exit 1
+    fi
+}
+
+HEAD "1: status can include chat status summary"
+OUTPUT="$("$STUB" --include-chat-status-summary)"
+require_contains "$OUTPUT" "=== chat status summary ==="
+require_contains "$OUTPUT" "source     : scripts/chat-status-summary-stub.sh --model gemma3n-e4b --target kv260"
+require_contains "$OUTPUT" "boundary   : read-only data; no prompt/session-store/config/model/runtime/hardware/provider/lab/IDE execution"
+require_contains "$OUTPUT" "target     : kv260"
+require_contains "$OUTPUT" "model      : gemma3n-e4b"
+require_contains "$OUTPUT" "overall   : blocked"
+require_contains "$OUTPUT" "surface   : available_as_data"
+require_contains "$OUTPUT" "session   : inactive"
+require_contains "$OUTPUT" "modelState: blocked"
+require_contains "$OUTPUT" "runtime   : blocked"
+require_contains "$OUTPUT" "send      : disabled"
+require_contains "$OUTPUT" "content   : empty_not_captured"
+require_contains "$OUTPUT" "privacy   : summary_only"
+PASS "chat status-summary section is present and conservative"
+
+HEAD "2: aggregate cards and blockers are summarized"
+require_contains "$OUTPUT" "cards      : surface_layout=available_as_data:info"
+require_contains "$OUTPUT" "session_state=inactive:blocked"
+require_contains "$OUTPUT" "model_status=blocked:blocked"
+require_contains "$OUTPUT" "readiness=blocked:blocked"
+require_contains "$OUTPUT" "composer=available_as_data:info"
+require_contains "$OUTPUT" "send_result=disabled:blocked"
+require_contains "$OUTPUT" "message_list=empty_not_captured:info"
+require_contains "$OUTPUT" "response_stream=disabled:blocked"
+require_contains "$OUTPUT" "privacy_controls=summary_only:blocked"
+require_contains "$OUTPUT" "blocked    : runtime_evidence_absent=blocked"
+require_contains "$OUTPUT" "model_load_absent=blocked"
+require_contains "$OUTPUT" "device_session_absent=inactive"
+require_contains "$OUTPUT" "session_store_absent=not_configured"
+require_contains "$OUTPUT" "content_boundary_absent=requires_review"
+require_contains "$OUTPUT" "actions    : review_readiness_data=available_as_data:false"
+require_contains "$OUTPUT" "keep_send_disabled=blocked:false"
+require_contains "$OUTPUT" "wait_for_runtime_boundary=requires_evidence:false"
+PASS "status cards, blockers, and actions are summarized"
+
+HEAD "3: safety flags stay summary-only and non-executing"
+require_contains "$OUTPUT" "readOnly=true"
+require_contains "$OUTPUT" "dataOnly=true"
+require_contains "$OUTPUT" "deterministic=true"
+require_contains "$OUTPUT" "statusSummaryOnly=true"
+require_contains "$OUTPUT" "aggregatesCheckedFixturesOnly=true"
+require_contains "$OUTPUT" "promptCapture=false"
+require_contains "$OUTPUT" "promptRead=false"
+require_contains "$OUTPUT" "promptContentIncluded=false"
+require_contains "$OUTPUT" "responseContentIncluded=false"
+require_contains "$OUTPUT" "transcriptContentIncluded=false"
+require_contains "$OUTPUT" "messageBodiesIncluded=false"
+require_contains "$OUTPUT" "sessionStoreRead=false"
+require_contains "$OUTPUT" "configRead=false"
+require_contains "$OUTPUT" "environmentRead=false"
+require_contains "$OUTPUT" "providerConfigRead=false"
+require_contains "$OUTPUT" "modelAssetRead=false"
+require_contains "$OUTPUT" "modelLoadAttempted=false"
+require_contains "$OUTPUT" "modelExecution=false"
+require_contains "$OUTPUT" "runtimeExecution=false"
+require_contains "$OUTPUT" "responseGenerated=false"
+require_contains "$OUTPUT" "sendEnabled=false"
+require_contains "$OUTPUT" "kv260Access=false"
+require_contains "$OUTPUT" "hardwareAccess=false"
+require_contains "$OUTPUT" "networkCalls=false"
+require_contains "$OUTPUT" "providerCalls=false"
+require_contains "$OUTPUT" "cloudCalls=false"
+require_contains "$OUTPUT" "executesPccxLab=false"
+require_contains "$OUTPUT" "executesSystemverilogIde=false"
+require_contains "$OUTPUT" "releaseOrTagAction=false"
+require_contains "$OUTPUT" "settingsChange=false"
+PASS "execution-related flags remain false"
+
+HEAD "4: output is deterministic"
+OUTPUT_AGAIN="$("$STUB" --include-chat-status-summary)"
+if [ "$OUTPUT" != "$OUTPUT_AGAIN" ]; then
+    FAIL "status chat status-summary output changed between runs"
+    exit 1
+fi
+PASS "status chat status-summary output is deterministic"
+
+HEAD "5: chat status-summary option does not combine with pccx-lab backend"
+if "$STUB" --include-chat-status-summary --backend pccx-lab >/dev/null 2>&1; then
+    FAIL "expected combined chat-status-summary/backend mode to fail"
+    exit 1
+fi
+PASS "chat status-summary remains separate from backend execution"
+
+HEAD "6: output avoids known overclaims"
+FORBIDDEN_PREFIX="KV260 inference"
+FORBIDDEN_CLAIM="${FORBIDDEN_PREFIX} works"
+require_not_contains "$OUTPUT" "$FORBIDDEN_CLAIM"
+THROUGHPUT_PREFIX="20 tok/s"
+THROUGHPUT_CLAIM="${THROUGHPUT_PREFIX} achieved"
+require_not_contains "$OUTPUT" "$THROUGHPUT_CLAIM"
+PASS "no chat status-summary or throughput overclaim in status output"
+
+printf '\n[DONE]  all status-chat-status-summary tests passed\n'


### PR DESCRIPTION
## Summary
- Add checked `pccx.chatStatusSummary.v0` data-only contract, fixture, and stub for blocked/disabled chat status cards.
- Add `status-stub.sh --include-chat-status-summary` to render the aggregate from local checked data.
- Wire README, standalone chat docs, CI, and focused contract/status tests.

Refs #9

## Validation
- `python3 scripts/tests/chat_status_summary_contract_test.py`
- `bash scripts/tests/status-chat-status-summary.sh scripts/status-stub.sh`
- `for test_file in scripts/tests/*_test.py; do python3 "$test_file"; done`
- `for test_file in scripts/tests/status-*.sh; do bash "$test_file" scripts/status-stub.sh; done`
- `bash scripts/status-stub.sh --include-chat-status-summary`
- `bash scripts/chat-status-summary-stub.sh --model gemma3n-e4b --target kv260`
- `python3 -m py_compile contracts/*.py scripts/tests/*.py`
- `find scripts -type f -name '*.sh' -not -name '*.snapshot' -exec bash -n {} +`
- `./scripts/check.sh`
- `./scripts/check-device-stub.sh`
- `./scripts/install-stub.sh`
- `git diff --check`
- local forbidden-claim scan: clean

## Safety
- Data-only/read-only; no prompt, session-store, config, env, provider, model path, runtime log, artifact, or hardware reads.
- No model loading, runtime execution, provider/network/cloud calls, KV260 access, hardware access, pccx-lab execution, or IDE execution.
- No release, tag, settings, stable API/ABI, hardware readiness, or runtime-performance claim.