### PR TITLE
Add chat review packet boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,7 @@ jobs:
                    scripts/chat-attachment-policy-stub.sh \
                    scripts/chat-shortcut-map-stub.sh \
                    scripts/chat-status-summary-stub.sh \
+                   scripts/chat-review-packet-stub.sh \
                    scripts/chat-surface-preview.sh \
                    scripts/chat-stub.sh; do
             [ -f "$f" ] && chmod +x "$f" || true
@@ -283,6 +284,10 @@ jobs:
         run: ./scripts/status-stub.sh --include-chat-status-summary
       - name: run scripts/chat-status-summary-stub.sh
         run: ./scripts/chat-status-summary-stub.sh --model gemma3n-e4b --target kv260
+      - name: run scripts/status-stub.sh with chat review packet
+        run: ./scripts/status-stub.sh --include-chat-review-packet
+      - name: run scripts/chat-review-packet-stub.sh
+        run: ./scripts/chat-review-packet-stub.sh --model gemma3n-e4b --target kv260
       - name: run scripts/chat-surface-preview.sh
         run: ./scripts/chat-surface-preview.sh --model gemma3n-e4b --target kv260
       - name: run scripts/chat-stub.sh --dry-run
@@ -359,6 +364,8 @@ jobs:
         run: python3 scripts/tests/chat_shortcut_map_contract_test.py
       - name: run chat status-summary contract tests
         run: python3 scripts/tests/chat_status_summary_contract_test.py
+      - name: run chat review-packet contract tests
+        run: python3 scripts/tests/chat_review_packet_contract_test.py
       - name: run chat surface preview tests
         run: python3 scripts/tests/chat_surface_preview_test.py
 
@@ -398,6 +405,7 @@ jobs:
           chmod +x scripts/chat-attachment-policy-stub.sh
           chmod +x scripts/chat-shortcut-map-stub.sh
           chmod +x scripts/chat-status-summary-stub.sh
+          chmod +x scripts/chat-review-packet-stub.sh
           chmod +x scripts/launch-stub.sh
           chmod +x scripts/tests/status-backend.sh
           chmod +x scripts/tests/status-device-session.sh
@@ -428,6 +436,7 @@ jobs:
           chmod +x scripts/tests/status-chat-attachment-policy.sh
           chmod +x scripts/tests/status-chat-shortcut-map.sh
           chmod +x scripts/tests/status-chat-status-summary.sh
+          chmod +x scripts/tests/status-chat-review-packet.sh
       - name: shellcheck status-stub and test script
         run: |
           sudo apt-get update -q && sudo apt-get install -y -q shellcheck
@@ -461,6 +470,7 @@ jobs:
           shellcheck scripts/tests/status-chat-attachment-policy.sh
           shellcheck scripts/tests/status-chat-shortcut-map.sh
           shellcheck scripts/tests/status-chat-status-summary.sh
+          shellcheck scripts/tests/status-chat-review-packet.sh
       - name: run status-backend tests
         run: bash scripts/tests/status-backend.sh scripts/status-stub.sh
       - name: run status-device-session tests
@@ -519,3 +529,5 @@ jobs:
         run: bash scripts/tests/status-chat-shortcut-map.sh scripts/status-stub.sh
       - name: run status-chat-status-summary tests
         run: bash scripts/tests/status-chat-status-summary.sh scripts/status-stub.sh
+      - name: run status-chat-review-packet tests
+        run: bash scripts/tests/status-chat-review-packet.sh scripts/status-stub.sh

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ and verify host-side prerequisites before the real engine lands.
 | [`scripts/check.sh`](./scripts/check.sh) | Probe host info, tooling availability, edge-device hints. Always exits 0. |
 | [`scripts/check-device-stub.sh`](./scripts/check-device-stub.sh) | Narrowly scoped device-tree / FPGA-node probe (KV260 / Kria detection only). Always exits 0. |
 | [`scripts/install-stub.sh`](./scripts/install-stub.sh) | Preview of the planned install flow; reports which host runtime pieces are present, lists device-side pieces as future deliverables. Always exits 0. |
-| [`scripts/status-stub.sh`](./scripts/status-stub.sh) | Launcher state summary. Default mode: local scaffold output, always exits 0. With `--include-chat-action-bar`, adds read-only disabled chat action-bar data. With `--include-chat-clipboard-policy`, adds read-only disabled chat clipboard-policy data. With `--include-chat-redaction-policy`, adds read-only disabled chat redaction-policy data. With `--include-chat-attachment-policy`, adds read-only disabled chat attachment-policy data. With `--include-chat-shortcut-map`, adds read-only disabled chat shortcut-map data. With `--include-chat-status-summary`, adds read-only aggregate chat status-summary data. With `--include-chat-message-list`, adds read-only empty chat message-list data. With `--include-chat-response-stream`, adds read-only blocked chat response stream data. With `--include-chat-error-taxonomy`, adds read-only chat error taxonomy data. With `--include-chat-audit-event`, adds read-only blocked chat audit-event metadata. With `--include-chat-surface-layout`, adds read-only chat surface layout data. With `--include-chat-empty-state`, adds read-only display-only chat empty-state data. With `--include-chat-local-only-policy`, adds read-only local-only/cloud-block policy data. With `--include-chat-preferences`, adds read-only chat preferences/settings data. With `--include-chat-session-index`, adds read-only empty chat session index data. With `--include-chat-session-store-policy`, adds read-only disabled chat session-store policy data. With `--include-chat-session-title-policy`, adds read-only placeholder session-title policy data. With `--include-chat-transcript-policy`, adds read-only chat transcript retention/export policy data. With `--include-chat-send-result`, adds read-only blocked chat send-result data. With `--include-chat-composer`, adds read-only chat composer/input-control data. With `--include-chat-model-status`, adds read-only blocked chat model-status display data. With `--include-chat-model-selection-policy`, adds read-only disabled chat model-selection data. With `--include-chat-context-policy`, adds read-only disabled chat context-window/tokenization policy data. With `--include-chat-model-load-request`, adds read-only disabled chat model-load request data. With `--include-chat-session`, adds read-only blocked chat/session and lifecycle summaries. With `--include-chat-readiness`, adds read-only chat readiness checks and recovery actions. With `--include-device-session`, adds a read-only device/session status panel. With `--include-runtime-readiness`, adds a read-only runtime readiness summary. With `--backend pccx-lab`, calls `pccx-lab status --format json` and forwards the run-status envelope (exits non-zero if binary is missing or output is invalid). |
+| [`scripts/status-stub.sh`](./scripts/status-stub.sh) | Launcher state summary. Default mode: local scaffold output, always exits 0. With `--include-chat-action-bar`, adds read-only disabled chat action-bar data. With `--include-chat-clipboard-policy`, adds read-only disabled chat clipboard-policy data. With `--include-chat-redaction-policy`, adds read-only disabled chat redaction-policy data. With `--include-chat-attachment-policy`, adds read-only disabled chat attachment-policy data. With `--include-chat-shortcut-map`, adds read-only disabled chat shortcut-map data. With `--include-chat-status-summary`, adds read-only aggregate chat status-summary data. With `--include-chat-review-packet`, adds read-only chat review-packet data over existing checked fixture references. With `--include-chat-message-list`, adds read-only empty chat message-list data. With `--include-chat-response-stream`, adds read-only blocked chat response stream data. With `--include-chat-error-taxonomy`, adds read-only chat error taxonomy data. With `--include-chat-audit-event`, adds read-only blocked chat audit-event metadata. With `--include-chat-surface-layout`, adds read-only chat surface layout data. With `--include-chat-empty-state`, adds read-only display-only chat empty-state data. With `--include-chat-local-only-policy`, adds read-only local-only/cloud-block policy data. With `--include-chat-preferences`, adds read-only chat preferences/settings data. With `--include-chat-session-index`, adds read-only empty chat session index data. With `--include-chat-session-store-policy`, adds read-only disabled chat session-store policy data. With `--include-chat-session-title-policy`, adds read-only placeholder session-title policy data. With `--include-chat-transcript-policy`, adds read-only chat transcript retention/export policy data. With `--include-chat-send-result`, adds read-only blocked chat send-result data. With `--include-chat-composer`, adds read-only chat composer/input-control data. With `--include-chat-model-status`, adds read-only blocked chat model-status display data. With `--include-chat-model-selection-policy`, adds read-only disabled chat model-selection data. With `--include-chat-context-policy`, adds read-only disabled chat context-window/tokenization policy data. With `--include-chat-model-load-request`, adds read-only disabled chat model-load request data. With `--include-chat-session`, adds read-only blocked chat/session and lifecycle summaries. With `--include-chat-readiness`, adds read-only chat readiness checks and recovery actions. With `--include-device-session`, adds a read-only device/session status panel. With `--include-runtime-readiness`, adds a read-only runtime readiness summary. With `--backend pccx-lab`, calls `pccx-lab status --format json` and forwards the run-status envelope (exits non-zero if binary is missing or output is invalid). |
 | [`scripts/device-session-status-stub.sh`](./scripts/device-session-status-stub.sh) | Data-only device/session status JSON for the Gemma 3N E4B + KV260 target. Reports connection, model load, session, diagnostics, readiness, discovery paths, flow steps, and error taxonomy as placeholder / blocked. |
 | [`scripts/runtime-readiness-stub.sh`](./scripts/runtime-readiness-stub.sh) | Data-only runtime readiness JSON for the Gemma 3N E4B + KV260 target. Reports blocked / not yet evidence-backed. |
 | [`scripts/chat-session-stub.sh`](./scripts/chat-session-stub.sh) | Data-only standalone chat/session JSON for the Gemma 3N E4B + KV260 target. Reports disabled send controls, inactive session state, no prompt/response persistence, and readiness handoff references. |
@@ -114,6 +114,7 @@ and verify host-side prerequisites before the real engine lands.
 | [`scripts/chat-attachment-policy-stub.sh`](./scripts/chat-attachment-policy-stub.sh) | Data-only disabled chat attachment-policy JSON for the Gemma 3N E4B + KV260 target. Reports disabled file picker, file read, upload, import, preview, and persistence gates without reading file names, paths, metadata, contents, clipboard data, transcripts, generated artifacts, model paths, runtime logs, or artifacts. |
 | [`scripts/chat-shortcut-map-stub.sh`](./scripts/chat-shortcut-map-stub.sh) | Data-only disabled chat shortcut-map JSON for the Gemma 3N E4B + KV260 target. Reports planned keyboard accelerator and focus metadata without installing listeners, capturing key events, dispatching commands, changing focus, reading prompts, sessions, transcripts, messages, files, or clipboard data, or starting runtime paths. |
 | [`scripts/chat-status-summary-stub.sh`](./scripts/chat-status-summary-stub.sh) | Data-only chat status-summary JSON for the Gemma 3N E4B + KV260 target. Aggregates existing checked chat surface references into blocked/disabled display cards without reading prompts, session stores, configuration, model paths, runtime logs, artifacts, provider state, or hardware state. |
+| [`scripts/chat-review-packet-stub.sh`](./scripts/chat-review-packet-stub.sh) | Data-only chat review-packet JSON for the Gemma 3N E4B + KV260 target. Collects existing checked chat fixture references and review gates without approving prompt capture, session-store reads, model loading, runtime execution, provider calls, or hardware access. |
 | [`scripts/chat-transcript-policy-stub.sh`](./scripts/chat-transcript-policy-stub.sh) | Data-only chat transcript policy JSON for the Gemma 3N E4B + KV260 target. Reports retention, export, storage, and privacy policy state without reading, generating, storing, persisting, summarizing, or exporting prompt/response/transcript content. |
 | [`scripts/chat-audit-event-stub.sh`](./scripts/chat-audit-event-stub.sh) | Data-only chat audit-event JSON for the Gemma 3N E4B + KV260 target. Reports blocked send metadata, redaction policy, absent prompt/response/transcript content, and disabled audit persistence. |
 | [`scripts/chat-error-taxonomy-stub.sh`](./scripts/chat-error-taxonomy-stub.sh) | Data-only chat error taxonomy JSON for the Gemma 3N E4B + KV260 target. Groups blocked readiness, model/runtime, session, and policy errors without reading prompts, providers, configs, model paths, logs, stores, or artifacts. |
@@ -152,6 +153,7 @@ bash scripts/status-stub.sh --include-chat-redaction-policy
 bash scripts/status-stub.sh --include-chat-attachment-policy
 bash scripts/status-stub.sh --include-chat-shortcut-map
 bash scripts/status-stub.sh --include-chat-status-summary
+bash scripts/status-stub.sh --include-chat-review-packet
 bash scripts/status-stub.sh --include-device-session
 bash scripts/status-stub.sh --include-runtime-readiness
 bash scripts/device-session-status-stub.sh --model gemma3n-e4b --target kv260
@@ -183,6 +185,7 @@ bash scripts/chat-redaction-policy-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-attachment-policy-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-shortcut-map-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-status-summary-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/chat-review-packet-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-surface-preview.sh --model gemma3n-e4b --target kv260
 bash scripts/launch-stub.sh --dry-run
 bash scripts/chat-stub.sh --dry-run --prompt "hello"
@@ -363,6 +366,7 @@ python3 contracts/chat_shortcut_map_contract.py --model gemma3n-e4b --target kv2
 python3 contracts/chat_session_title_policy_contract.py --model gemma3n-e4b --target kv260
 python3 contracts/chat_empty_state_contract.py --model gemma3n-e4b --target kv260
 python3 contracts/chat_status_summary_contract.py --model gemma3n-e4b --target kv260
+python3 contracts/chat_review_packet_contract.py --model gemma3n-e4b --target kv260
 bash scripts/chat-model-status-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-model-selection-policy-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-model-load-request-stub.sh --model gemma3n-e4b --target kv260
@@ -380,6 +384,7 @@ bash scripts/chat-clipboard-policy-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-redaction-policy-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-attachment-policy-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-shortcut-map-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/chat-review-packet-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-surface-preview.sh --model gemma3n-e4b --target kv260
 bash scripts/status-stub.sh --include-chat-model-status
 bash scripts/status-stub.sh --include-chat-model-selection-policy
@@ -398,6 +403,7 @@ bash scripts/status-stub.sh --include-chat-shortcut-map
 bash scripts/status-stub.sh --include-chat-session-title-policy
 bash scripts/status-stub.sh --include-chat-empty-state
 bash scripts/status-stub.sh --include-chat-status-summary
+bash scripts/status-stub.sh --include-chat-review-packet
 python3 scripts/tests/chat_session_contract_test.py
 python3 scripts/tests/chat_model_status_contract_test.py
 python3 scripts/tests/chat_model_selection_policy_contract_test.py
@@ -415,6 +421,7 @@ python3 scripts/tests/chat_session_store_policy_contract_test.py
 python3 scripts/tests/chat_shortcut_map_contract_test.py
 python3 scripts/tests/chat_empty_state_contract_test.py
 python3 scripts/tests/chat_status_summary_contract_test.py
+python3 scripts/tests/chat_review_packet_contract_test.py
 python3 scripts/tests/chat_surface_preview_test.py
 bash scripts/tests/status-chat-model-status.sh
 bash scripts/tests/status-chat-model-selection-policy.sh
@@ -433,6 +440,7 @@ bash scripts/tests/status-chat-shortcut-map.sh
 bash scripts/tests/status-chat-session-title-policy.sh
 bash scripts/tests/status-chat-empty-state.sh
 bash scripts/tests/status-chat-status-summary.sh
+bash scripts/tests/status-chat-review-packet.sh
 ```
 
 The checked chat/session fixture reports the chat surface as blocked,

--- a/contracts/chat_review_packet_contract.py
+++ b/contracts/chat_review_packet_contract.py
@@ -1,0 +1,449 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Data-only chat review packet contract for the planned launcher UI.
+
+The contract gathers existing checked chat fixture references into a
+review-only packet for maintainer handoff. It does not accept prompts, read
+transcripts, read session stores, load models, start runtime code, call
+providers, invoke PCCX tools, touch hardware, or mutate repository state.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import sys
+
+
+SCHEMA_VERSION = "pccx.chatReviewPacket.v0"
+
+CHAT_REVIEW_PACKET_FIELDS = (
+    "schemaVersion",
+    "reviewPacketId",
+    "fixtureVersion",
+    "lastUpdatedSource",
+    "targetDevice",
+    "targetBoard",
+    "targetModel",
+    "reviewState",
+    "approvalState",
+    "executionState",
+    "contentState",
+    "privacyState",
+    "evidenceState",
+    "reviewSections",
+    "requiredReviews",
+    "blockedReasons",
+    "handoffRefs",
+    "safetyFlags",
+    "limitations",
+    "issueRefs",
+)
+
+REVIEW_SECTION_FIELDS = (
+    "sectionId",
+    "label",
+    "sourceRefs",
+    "state",
+    "summary",
+    "contentPolicy",
+    "requiredBefore",
+)
+
+REQUIRED_REVIEW_FIELDS = (
+    "reviewId",
+    "label",
+    "state",
+    "accepted",
+    "summary",
+    "requiredEvidence",
+    "sideEffectPolicy",
+)
+
+BLOCKED_REASON_FIELDS = (
+    "reasonId",
+    "state",
+    "summary",
+    "requiredBefore",
+)
+
+HANDOFF_REF_FIELDS = (
+    "refId",
+    "schemaVersion",
+    "fixturePath",
+    "state",
+    "summary",
+)
+
+CHAT_REVIEW_PACKET_STATE_VALUES = (
+    "available_as_data",
+    "blocked",
+    "disabled",
+    "empty_not_captured",
+    "inactive",
+    "not_approved",
+    "not_configured",
+    "not_loaded",
+    "not_started",
+    "not_used",
+    "planned",
+    "requires_evidence",
+    "requires_review",
+    "summary_only",
+    "target_selected",
+    "unavailable",
+)
+
+_CHAT_REVIEW_PACKET = {
+    "schemaVersion": SCHEMA_VERSION,
+    "reviewPacketId": "chat_review_packet_gemma3n_e4b_kv260_placeholder",
+    "fixtureVersion": "chat-review-packet.gemma3n-e4b-kv260.2026-05-05",
+    "lastUpdatedSource": "pccx_launcher_issue_9_chat_review_packet_boundary_2026-05-05",
+    "targetDevice": "kv260",
+    "targetBoard": "xilinx_kria_kv260",
+    "targetModel": "gemma3n-e4b",
+    "reviewState": "blocked",
+    "approvalState": "not_approved",
+    "executionState": "not_started",
+    "contentState": "empty_not_captured",
+    "privacyState": "requires_review",
+    "evidenceState": "requires_evidence",
+    "reviewSections": [
+        {
+            "sectionId": "surface_and_controls",
+            "label": "surface and controls",
+            "sourceRefs": [
+                "chat_surface_layout",
+                "chat_composer",
+                "chat_action_bar",
+                "chat_shortcut_map",
+            ],
+            "state": "available_as_data",
+            "summary": "The chat shell, input controls, actions, and shortcuts are display data only.",
+            "contentPolicy": "no_prompt_text_message_body_clipboard_or_file_content",
+            "requiredBefore": "chat_shell_enabled",
+        },
+        {
+            "sectionId": "session_management",
+            "label": "session management",
+            "sourceRefs": [
+                "chat_session",
+                "chat_session_lifecycle",
+                "chat_session_index",
+                "chat_session_store_policy",
+                "chat_session_title_policy",
+                "chat_transcript_policy",
+            ],
+            "state": "blocked",
+            "summary": "Session create, restore, clear, close, title, store, transcript, and export paths remain disabled or unavailable.",
+            "contentPolicy": "no_store_manifest_session_record_title_summary_transcript_prompt_or_response_content",
+            "requiredBefore": "session_management_enabled",
+        },
+        {
+            "sectionId": "model_runtime_and_device",
+            "label": "model runtime and device",
+            "sourceRefs": [
+                "chat_model_status",
+                "chat_model_selection_policy",
+                "chat_model_load_request",
+                "runtime_readiness",
+                "device_session_status",
+            ],
+            "state": "requires_evidence",
+            "summary": "Model selection and load metadata remain blocked until separate runtime and device evidence exists.",
+            "contentPolicy": "no_model_path_weight_tokenizer_checksum_runtime_log_or_device_dump_content",
+            "requiredBefore": "model_load_or_runtime_session_enabled",
+        },
+        {
+            "sectionId": "content_flow",
+            "label": "content flow",
+            "sourceRefs": [
+                "chat_send_result",
+                "chat_message_list",
+                "chat_response_stream",
+                "chat_context_policy",
+                "chat_empty_state",
+            ],
+            "state": "disabled",
+            "summary": "Prompt acceptance, message append, response streaming, token context, and generated output remain disabled.",
+            "contentPolicy": "no_prompt_response_transcript_message_summary_token_or_context_content",
+            "requiredBefore": "send_or_response_enabled",
+        },
+        {
+            "sectionId": "privacy_and_local_only_policy",
+            "label": "privacy and local-only policy",
+            "sourceRefs": [
+                "chat_local_only_policy",
+                "chat_redaction_policy",
+                "chat_attachment_policy",
+                "chat_clipboard_policy",
+                "chat_audit_event",
+                "chat_error_taxonomy",
+            ],
+            "state": "requires_review",
+            "summary": "Local-only, redaction, attachment, clipboard, audit, and error policy metadata remain review-only.",
+            "contentPolicy": "no_provider_config_secret_token_clipboard_attachment_audit_or_raw_error_payload",
+            "requiredBefore": "privacy_or_attachment_paths_enabled",
+        },
+        {
+            "sectionId": "aggregate_status",
+            "label": "aggregate status",
+            "sourceRefs": [
+                "chat_status_summary",
+            ],
+            "state": "summary_only",
+            "summary": "The existing status summary is referenced as a checked display summary, not copied into this packet.",
+            "contentPolicy": "status_summary_reference_only_no_status_card_duplication",
+            "requiredBefore": "review_packet_approved",
+        },
+    ],
+    "requiredReviews": [
+        {
+            "reviewId": "runtime_evidence_review",
+            "label": "runtime evidence review",
+            "state": "requires_evidence",
+            "accepted": False,
+            "summary": "Runtime readiness and device session evidence are not approved by this packet.",
+            "requiredEvidence": [
+                "reviewed_runtime_readiness_fixture",
+                "reviewed_device_session_status_fixture",
+            ],
+            "sideEffectPolicy": "no_runtime_or_hardware_action",
+        },
+        {
+            "reviewId": "model_asset_review",
+            "label": "model asset review",
+            "state": "not_approved",
+            "accepted": False,
+            "summary": "Model asset location, checksum, tokenizer, load, warmup, unload, and persistence remain unapproved.",
+            "requiredEvidence": [
+                "reviewed_model_asset_input_boundary",
+                "reviewed_model_load_request_boundary",
+            ],
+            "sideEffectPolicy": "no_model_path_read_or_model_load",
+        },
+        {
+            "reviewId": "session_store_review",
+            "label": "session store review",
+            "state": "not_approved",
+            "accepted": False,
+            "summary": "Session store path, manifest, read, write, retention, migration, and export remain unapproved.",
+            "requiredEvidence": [
+                "reviewed_session_store_policy",
+                "reviewed_transcript_retention_policy",
+            ],
+            "sideEffectPolicy": "no_session_store_or_transcript_access",
+        },
+        {
+            "reviewId": "content_privacy_review",
+            "label": "content privacy review",
+            "state": "requires_review",
+            "accepted": False,
+            "summary": "Prompt, response, transcript, attachment, clipboard, redaction, audit, and error content boundaries remain review-only.",
+            "requiredEvidence": [
+                "reviewed_redaction_policy",
+                "reviewed_attachment_policy",
+                "reviewed_clipboard_policy",
+            ],
+            "sideEffectPolicy": "no_content_scan_redaction_clipboard_or_file_action",
+        },
+        {
+            "reviewId": "send_enablement_review",
+            "label": "send enablement review",
+            "state": "blocked",
+            "accepted": False,
+            "summary": "Send, response streaming, context assembly, stop, retry, copy, and export controls remain disabled.",
+            "requiredEvidence": [
+                "reviewed_prompt_capture_boundary",
+                "reviewed_response_stream_boundary",
+                "reviewed_action_execution_boundary",
+            ],
+            "sideEffectPolicy": "no_prompt_capture_or_runtime_dispatch",
+        },
+    ],
+    "blockedReasons": [
+        {
+            "reasonId": "review_packet_not_approved",
+            "state": "not_approved",
+            "summary": "This packet records review blockers only; it does not approve runtime or UI behavior.",
+            "requiredBefore": "standalone_chat_enabled",
+        },
+        {
+            "reasonId": "runtime_and_device_evidence_absent",
+            "state": "requires_evidence",
+            "summary": "Runtime readiness and target device session evidence are not present in this launcher boundary.",
+            "requiredBefore": "model_or_runtime_execution_enabled",
+        },
+        {
+            "reasonId": "model_asset_boundary_absent",
+            "state": "not_loaded",
+            "summary": "No reviewed local model asset path, tokenizer, checksum, load, warmup, or unload path exists.",
+            "requiredBefore": "model_status_ready",
+        },
+        {
+            "reasonId": "session_store_boundary_absent",
+            "state": "not_configured",
+            "summary": "No reviewed local session store, transcript retention, title, manifest, restore, or export path exists.",
+            "requiredBefore": "session_management_enabled",
+        },
+        {
+            "reasonId": "content_privacy_boundary_absent",
+            "state": "requires_review",
+            "summary": "Prompt, response, transcript, attachment, clipboard, redaction, audit, and error payload boundaries remain disabled or summary-only.",
+            "requiredBefore": "prompt_or_response_content_displayed",
+        },
+    ],
+    "handoffRefs": [
+        {
+            "refId": "chat_status_summary",
+            "schemaVersion": "pccx.chatStatusSummary.v0",
+            "fixturePath": "contracts/fixtures/chat-status-summary.gemma3n-e4b-kv260-placeholder.json",
+            "state": "summary_only",
+            "summary": "Aggregate UI status remains a separate checked display summary.",
+        },
+        {
+            "refId": "chat_local_only_policy",
+            "schemaVersion": "pccx.chatLocalOnlyPolicy.v0",
+            "fixturePath": "contracts/fixtures/chat-local-only-policy.gemma3n-e4b-kv260-placeholder.json",
+            "state": "blocked",
+            "summary": "Local-only policy keeps cloud and provider fallback paths disabled.",
+        },
+        {
+            "refId": "chat_redaction_policy",
+            "schemaVersion": "pccx.chatRedactionPolicy.v0",
+            "fixturePath": "contracts/fixtures/chat-redaction-policy.gemma3n-e4b-kv260-placeholder.json",
+            "state": "summary_only",
+            "summary": "Redaction policy is referenced without loading rules or scanning content.",
+        },
+        {
+            "refId": "chat_session_store_policy",
+            "schemaVersion": "pccx.chatSessionStorePolicy.v0",
+            "fixturePath": "contracts/fixtures/chat-session-store-policy.gemma3n-e4b-kv260-placeholder.json",
+            "state": "not_configured",
+            "summary": "Session store policy remains disabled and no store is read.",
+        },
+        {
+            "refId": "chat_model_load_request",
+            "schemaVersion": "pccx.chatModelLoadRequest.v0",
+            "fixturePath": "contracts/fixtures/chat-model-load-request.gemma3n-e4b-kv260-placeholder.json",
+            "state": "blocked",
+            "summary": "Model load request remains blocked with no asset path read or load attempt.",
+        },
+        {
+            "refId": "chat_readiness",
+            "schemaVersion": "pccx.chatReadiness.v0",
+            "fixturePath": "contracts/fixtures/chat-readiness.gemma3n-e4b-kv260-placeholder.json",
+            "state": "blocked",
+            "summary": "Readiness stays blocked until runtime, device, model, store, and privacy evidence exists.",
+        },
+    ],
+    "safetyFlags": {
+        "dataOnly": True,
+        "readOnly": True,
+        "deterministic": True,
+        "reviewPacketOnly": True,
+        "aggregatesCheckedFixturesOnly": True,
+        "statusSummaryReferencedOnly": True,
+        "approvalGranted": False,
+        "promptCapture": False,
+        "promptRead": False,
+        "promptContentIncluded": False,
+        "responseContentIncluded": False,
+        "transcriptContentIncluded": False,
+        "messageBodiesIncluded": False,
+        "sessionStoreRead": False,
+        "sessionPersistence": False,
+        "summaryGenerated": False,
+        "transcriptExported": False,
+        "clipboardRead": False,
+        "clipboardWrite": False,
+        "attachmentReads": False,
+        "fileMetadataRead": False,
+        "fileContentRead": False,
+        "directoryScan": False,
+        "redactionRulesLoaded": False,
+        "contentScan": False,
+        "redactionApplied": False,
+        "auditLogWritten": False,
+        "configRead": False,
+        "environmentRead": False,
+        "providerConfigRead": False,
+        "modelAssetRead": False,
+        "modelPathIncluded": False,
+        "modelLoadAttempted": False,
+        "modelExecution": False,
+        "runtimeExecution": False,
+        "responseGenerated": False,
+        "sendEnabled": False,
+        "readsArtifacts": False,
+        "writesArtifacts": False,
+        "kv260Access": False,
+        "hardwareAccess": False,
+        "networkCalls": False,
+        "providerCalls": False,
+        "cloudCalls": False,
+        "executesPccxLab": False,
+        "executesSystemverilogIde": False,
+        "telemetry": False,
+        "writeBack": False,
+        "releaseOrTagAction": False,
+        "settingsChange": False,
+        "compatibilityClaim": False,
+    },
+    "limitations": [
+        "Data-only chat review packet over existing checked fixture references.",
+        "No prompt, response, transcript, message, session-store, config, provider, model-path, runtime-log, artifact, private-path, secret, token, or hardware content is read.",
+        "No model load, runtime execution, provider call, network call, hardware access, telemetry, write-back, release, tag, settings, or repository action is performed.",
+        "This packet does not approve standalone chat enablement; it records remaining review and evidence gates only.",
+    ],
+    "issueRefs": [
+        "pccxai/pccx-llm-launcher#9",
+    ],
+}
+
+
+def create_gemma3n_e4b_kv260_chat_review_packet() -> dict:
+    """Return the checked Gemma 3N E4B plus KV260 chat review packet."""
+    return copy.deepcopy(_CHAT_REVIEW_PACKET)
+
+
+def chat_review_packet_json(packet: dict | None = None) -> str:
+    """Render a deterministic JSON representation."""
+    return json.dumps(
+        packet
+        if packet is not None
+        else create_gemma3n_e4b_kv260_chat_review_packet(),
+        indent=2,
+        sort_keys=True,
+    ) + "\n"
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Print data-only chat review packet JSON.",
+    )
+    parser.add_argument(
+        "--model",
+        default="gemma3n-e4b",
+        choices=("gemma3n-e4b",),
+        help="model descriptor target",
+    )
+    parser.add_argument(
+        "--target",
+        default="kv260",
+        choices=("kv260",),
+        help="target board/device",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parse_args(sys.argv[1:] if argv is None else argv)
+    sys.stdout.write(chat_review_packet_json())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contracts/fixtures/chat-review-packet.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-review-packet.gemma3n-e4b-kv260-placeholder.json
@@ -1,0 +1,306 @@
+{
+  "approvalState": "not_approved",
+  "blockedReasons": [
+    {
+      "reasonId": "review_packet_not_approved",
+      "requiredBefore": "standalone_chat_enabled",
+      "state": "not_approved",
+      "summary": "This packet records review blockers only; it does not approve runtime or UI behavior."
+    },
+    {
+      "reasonId": "runtime_and_device_evidence_absent",
+      "requiredBefore": "model_or_runtime_execution_enabled",
+      "state": "requires_evidence",
+      "summary": "Runtime readiness and target device session evidence are not present in this launcher boundary."
+    },
+    {
+      "reasonId": "model_asset_boundary_absent",
+      "requiredBefore": "model_status_ready",
+      "state": "not_loaded",
+      "summary": "No reviewed local model asset path, tokenizer, checksum, load, warmup, or unload path exists."
+    },
+    {
+      "reasonId": "session_store_boundary_absent",
+      "requiredBefore": "session_management_enabled",
+      "state": "not_configured",
+      "summary": "No reviewed local session store, transcript retention, title, manifest, restore, or export path exists."
+    },
+    {
+      "reasonId": "content_privacy_boundary_absent",
+      "requiredBefore": "prompt_or_response_content_displayed",
+      "state": "requires_review",
+      "summary": "Prompt, response, transcript, attachment, clipboard, redaction, audit, and error payload boundaries remain disabled or summary-only."
+    }
+  ],
+  "contentState": "empty_not_captured",
+  "evidenceState": "requires_evidence",
+  "executionState": "not_started",
+  "fixtureVersion": "chat-review-packet.gemma3n-e4b-kv260.2026-05-05",
+  "handoffRefs": [
+    {
+      "fixturePath": "contracts/fixtures/chat-status-summary.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_status_summary",
+      "schemaVersion": "pccx.chatStatusSummary.v0",
+      "state": "summary_only",
+      "summary": "Aggregate UI status remains a separate checked display summary."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-local-only-policy.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_local_only_policy",
+      "schemaVersion": "pccx.chatLocalOnlyPolicy.v0",
+      "state": "blocked",
+      "summary": "Local-only policy keeps cloud and provider fallback paths disabled."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-redaction-policy.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_redaction_policy",
+      "schemaVersion": "pccx.chatRedactionPolicy.v0",
+      "state": "summary_only",
+      "summary": "Redaction policy is referenced without loading rules or scanning content."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-session-store-policy.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_session_store_policy",
+      "schemaVersion": "pccx.chatSessionStorePolicy.v0",
+      "state": "not_configured",
+      "summary": "Session store policy remains disabled and no store is read."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-model-load-request.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_model_load_request",
+      "schemaVersion": "pccx.chatModelLoadRequest.v0",
+      "state": "blocked",
+      "summary": "Model load request remains blocked with no asset path read or load attempt."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-readiness.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_readiness",
+      "schemaVersion": "pccx.chatReadiness.v0",
+      "state": "blocked",
+      "summary": "Readiness stays blocked until runtime, device, model, store, and privacy evidence exists."
+    }
+  ],
+  "issueRefs": [
+    "pccxai/pccx-llm-launcher#9"
+  ],
+  "lastUpdatedSource": "pccx_launcher_issue_9_chat_review_packet_boundary_2026-05-05",
+  "limitations": [
+    "Data-only chat review packet over existing checked fixture references.",
+    "No prompt, response, transcript, message, session-store, config, provider, model-path, runtime-log, artifact, private-path, secret, token, or hardware content is read.",
+    "No model load, runtime execution, provider call, network call, hardware access, telemetry, write-back, release, tag, settings, or repository action is performed.",
+    "This packet does not approve standalone chat enablement; it records remaining review and evidence gates only."
+  ],
+  "privacyState": "requires_review",
+  "requiredReviews": [
+    {
+      "accepted": false,
+      "label": "runtime evidence review",
+      "requiredEvidence": [
+        "reviewed_runtime_readiness_fixture",
+        "reviewed_device_session_status_fixture"
+      ],
+      "reviewId": "runtime_evidence_review",
+      "sideEffectPolicy": "no_runtime_or_hardware_action",
+      "state": "requires_evidence",
+      "summary": "Runtime readiness and device session evidence are not approved by this packet."
+    },
+    {
+      "accepted": false,
+      "label": "model asset review",
+      "requiredEvidence": [
+        "reviewed_model_asset_input_boundary",
+        "reviewed_model_load_request_boundary"
+      ],
+      "reviewId": "model_asset_review",
+      "sideEffectPolicy": "no_model_path_read_or_model_load",
+      "state": "not_approved",
+      "summary": "Model asset location, checksum, tokenizer, load, warmup, unload, and persistence remain unapproved."
+    },
+    {
+      "accepted": false,
+      "label": "session store review",
+      "requiredEvidence": [
+        "reviewed_session_store_policy",
+        "reviewed_transcript_retention_policy"
+      ],
+      "reviewId": "session_store_review",
+      "sideEffectPolicy": "no_session_store_or_transcript_access",
+      "state": "not_approved",
+      "summary": "Session store path, manifest, read, write, retention, migration, and export remain unapproved."
+    },
+    {
+      "accepted": false,
+      "label": "content privacy review",
+      "requiredEvidence": [
+        "reviewed_redaction_policy",
+        "reviewed_attachment_policy",
+        "reviewed_clipboard_policy"
+      ],
+      "reviewId": "content_privacy_review",
+      "sideEffectPolicy": "no_content_scan_redaction_clipboard_or_file_action",
+      "state": "requires_review",
+      "summary": "Prompt, response, transcript, attachment, clipboard, redaction, audit, and error content boundaries remain review-only."
+    },
+    {
+      "accepted": false,
+      "label": "send enablement review",
+      "requiredEvidence": [
+        "reviewed_prompt_capture_boundary",
+        "reviewed_response_stream_boundary",
+        "reviewed_action_execution_boundary"
+      ],
+      "reviewId": "send_enablement_review",
+      "sideEffectPolicy": "no_prompt_capture_or_runtime_dispatch",
+      "state": "blocked",
+      "summary": "Send, response streaming, context assembly, stop, retry, copy, and export controls remain disabled."
+    }
+  ],
+  "reviewPacketId": "chat_review_packet_gemma3n_e4b_kv260_placeholder",
+  "reviewSections": [
+    {
+      "contentPolicy": "no_prompt_text_message_body_clipboard_or_file_content",
+      "label": "surface and controls",
+      "requiredBefore": "chat_shell_enabled",
+      "sectionId": "surface_and_controls",
+      "sourceRefs": [
+        "chat_surface_layout",
+        "chat_composer",
+        "chat_action_bar",
+        "chat_shortcut_map"
+      ],
+      "state": "available_as_data",
+      "summary": "The chat shell, input controls, actions, and shortcuts are display data only."
+    },
+    {
+      "contentPolicy": "no_store_manifest_session_record_title_summary_transcript_prompt_or_response_content",
+      "label": "session management",
+      "requiredBefore": "session_management_enabled",
+      "sectionId": "session_management",
+      "sourceRefs": [
+        "chat_session",
+        "chat_session_lifecycle",
+        "chat_session_index",
+        "chat_session_store_policy",
+        "chat_session_title_policy",
+        "chat_transcript_policy"
+      ],
+      "state": "blocked",
+      "summary": "Session create, restore, clear, close, title, store, transcript, and export paths remain disabled or unavailable."
+    },
+    {
+      "contentPolicy": "no_model_path_weight_tokenizer_checksum_runtime_log_or_device_dump_content",
+      "label": "model runtime and device",
+      "requiredBefore": "model_load_or_runtime_session_enabled",
+      "sectionId": "model_runtime_and_device",
+      "sourceRefs": [
+        "chat_model_status",
+        "chat_model_selection_policy",
+        "chat_model_load_request",
+        "runtime_readiness",
+        "device_session_status"
+      ],
+      "state": "requires_evidence",
+      "summary": "Model selection and load metadata remain blocked until separate runtime and device evidence exists."
+    },
+    {
+      "contentPolicy": "no_prompt_response_transcript_message_summary_token_or_context_content",
+      "label": "content flow",
+      "requiredBefore": "send_or_response_enabled",
+      "sectionId": "content_flow",
+      "sourceRefs": [
+        "chat_send_result",
+        "chat_message_list",
+        "chat_response_stream",
+        "chat_context_policy",
+        "chat_empty_state"
+      ],
+      "state": "disabled",
+      "summary": "Prompt acceptance, message append, response streaming, token context, and generated output remain disabled."
+    },
+    {
+      "contentPolicy": "no_provider_config_secret_token_clipboard_attachment_audit_or_raw_error_payload",
+      "label": "privacy and local-only policy",
+      "requiredBefore": "privacy_or_attachment_paths_enabled",
+      "sectionId": "privacy_and_local_only_policy",
+      "sourceRefs": [
+        "chat_local_only_policy",
+        "chat_redaction_policy",
+        "chat_attachment_policy",
+        "chat_clipboard_policy",
+        "chat_audit_event",
+        "chat_error_taxonomy"
+      ],
+      "state": "requires_review",
+      "summary": "Local-only, redaction, attachment, clipboard, audit, and error policy metadata remain review-only."
+    },
+    {
+      "contentPolicy": "status_summary_reference_only_no_status_card_duplication",
+      "label": "aggregate status",
+      "requiredBefore": "review_packet_approved",
+      "sectionId": "aggregate_status",
+      "sourceRefs": [
+        "chat_status_summary"
+      ],
+      "state": "summary_only",
+      "summary": "The existing status summary is referenced as a checked display summary, not copied into this packet."
+    }
+  ],
+  "reviewState": "blocked",
+  "safetyFlags": {
+    "aggregatesCheckedFixturesOnly": true,
+    "approvalGranted": false,
+    "attachmentReads": false,
+    "auditLogWritten": false,
+    "clipboardRead": false,
+    "clipboardWrite": false,
+    "cloudCalls": false,
+    "compatibilityClaim": false,
+    "configRead": false,
+    "contentScan": false,
+    "dataOnly": true,
+    "deterministic": true,
+    "directoryScan": false,
+    "environmentRead": false,
+    "executesPccxLab": false,
+    "executesSystemverilogIde": false,
+    "fileContentRead": false,
+    "fileMetadataRead": false,
+    "hardwareAccess": false,
+    "kv260Access": false,
+    "messageBodiesIncluded": false,
+    "modelAssetRead": false,
+    "modelExecution": false,
+    "modelLoadAttempted": false,
+    "modelPathIncluded": false,
+    "networkCalls": false,
+    "promptCapture": false,
+    "promptContentIncluded": false,
+    "promptRead": false,
+    "providerCalls": false,
+    "providerConfigRead": false,
+    "readOnly": true,
+    "readsArtifacts": false,
+    "redactionApplied": false,
+    "redactionRulesLoaded": false,
+    "releaseOrTagAction": false,
+    "responseContentIncluded": false,
+    "responseGenerated": false,
+    "reviewPacketOnly": true,
+    "runtimeExecution": false,
+    "sendEnabled": false,
+    "sessionPersistence": false,
+    "sessionStoreRead": false,
+    "settingsChange": false,
+    "statusSummaryReferencedOnly": true,
+    "summaryGenerated": false,
+    "telemetry": false,
+    "transcriptContentIncluded": false,
+    "transcriptExported": false,
+    "writeBack": false,
+    "writesArtifacts": false
+  },
+  "schemaVersion": "pccx.chatReviewPacket.v0",
+  "targetBoard": "xilinx_kria_kv260",
+  "targetDevice": "kv260",
+  "targetModel": "gemma3n-e4b"
+}

--- a/scripts/chat-review-packet-stub.sh
+++ b/scripts/chat-review-packet-stub.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+# Print the data-only chat review-packet contract.
+
+set -eu
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+
+python3 "$ROOT_DIR/contracts/chat_review_packet_contract.py" "$@"

--- a/scripts/status-stub.sh
+++ b/scripts/status-stub.sh
@@ -88,6 +88,9 @@
 # Chat status-summary aggregate (explicit opt-in, read-only local data):
 #   --include-chat-status-summary
 #
+# Chat review-packet aggregate (explicit opt-in, read-only local data):
+#   --include-chat-review-packet
+#
 # pccx-lab backend (explicit opt-in):
 #   --backend pccx-lab        call pccx-lab status --format json
 #   PCCX_LAB_BIN              override path to pccx-lab binary (takes priority over PATH)
@@ -131,6 +134,7 @@ INCLUDE_CHAT_REDACTION_POLICY="0"
 INCLUDE_CHAT_ATTACHMENT_POLICY="0"
 INCLUDE_CHAT_SHORTCUT_MAP="0"
 INCLUDE_CHAT_STATUS_SUMMARY="0"
+INCLUDE_CHAT_REVIEW_PACKET="0"
 
 print_chat_status_summary_summary() {
     SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
@@ -238,6 +242,132 @@ print(
 
     HEAD "chat status summary"
     printf '%s\n' "$CHAT_STATUS_SUMMARY_TEXT"
+}
+
+print_chat_review_packet_summary() {
+    SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+    ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+    CHAT_REVIEW_PACKET_STUB="$ROOT_DIR/scripts/chat-review-packet-stub.sh"
+
+    if [ ! -f "$CHAT_REVIEW_PACKET_STUB" ]; then
+        ERROR "chat review packet stub not found: $CHAT_REVIEW_PACKET_STUB"
+        return 1
+    fi
+
+    if ! CHAT_REVIEW_PACKET_JSON="$(bash "$CHAT_REVIEW_PACKET_STUB" --model gemma3n-e4b --target kv260 2>&1)"; then
+        ERROR "chat review packet stub failed"
+        printf '%s\n' "$CHAT_REVIEW_PACKET_JSON" >&2
+        return 1
+    fi
+
+    if ! CHAT_REVIEW_PACKET_TEXT="$(
+        printf '%s\n' "$CHAT_REVIEW_PACKET_JSON" | python3 -c '
+import json
+import sys
+
+data = json.load(sys.stdin)
+flags = data["safetyFlags"]
+sections = " ".join(
+    "{}={}".format(section["sectionId"], section["state"])
+    for section in data["reviewSections"]
+)
+reviews = " ".join(
+    "{}={}:{}".format(review["reviewId"], review["state"], str(review["accepted"]).lower())
+    for review in data["requiredReviews"]
+)
+blocked = " ".join(
+    "{}={}".format(reason["reasonId"], reason["state"])
+    for reason in data["blockedReasons"]
+)
+refs = " ".join(
+    "{}={}".format(ref["refId"], ref["state"])
+    for ref in data["handoffRefs"]
+)
+
+def b(value):
+    return "true" if value else "false"
+
+print("[INFO]  source     : scripts/chat-review-packet-stub.sh --model gemma3n-e4b --target kv260")
+print("[INFO]  boundary   : read-only data; no prompt/session-store/config/model/runtime/hardware/provider/lab/IDE execution")
+print("[INFO]  target     : {}".format(data["targetDevice"]))
+print("[INFO]  model      : {}".format(data["targetModel"]))
+print("[INFO]  review    : {}".format(data["reviewState"]))
+print("[INFO]  approval  : {}".format(data["approvalState"]))
+print("[INFO]  execution : {}".format(data["executionState"]))
+print("[INFO]  content   : {}".format(data["contentState"]))
+print("[INFO]  privacy   : {}".format(data["privacyState"]))
+print("[INFO]  evidence  : {}".format(data["evidenceState"]))
+print("[INFO]  sections   : {}".format(sections))
+print("[INFO]  reviews    : {}".format(reviews))
+print("[INFO]  blocked    : {}".format(blocked))
+print("[INFO]  refs       : {}".format(refs))
+print(
+    "[INFO]  flags      : readOnly={} dataOnly={} deterministic={} "
+    "reviewPacketOnly={} aggregatesCheckedFixturesOnly={} "
+    "statusSummaryReferencedOnly={} approvalGranted={} promptCapture={} "
+    "promptRead={} promptContentIncluded={} responseContentIncluded={} "
+    "transcriptContentIncluded={} messageBodiesIncluded={} sessionStoreRead={} "
+    "sessionPersistence={} summaryGenerated={} transcriptExported={} "
+    "clipboardRead={} clipboardWrite={} attachmentReads={} fileMetadataRead={} "
+    "fileContentRead={} directoryScan={} redactionRulesLoaded={} contentScan={} "
+    "redactionApplied={} auditLogWritten={} configRead={} environmentRead={} "
+    "providerConfigRead={} modelAssetRead={} modelLoadAttempted={} "
+    "modelExecution={} runtimeExecution={} responseGenerated={} sendEnabled={} "
+    "kv260Access={} hardwareAccess={} networkCalls={} providerCalls={} "
+    "cloudCalls={} executesPccxLab={} executesSystemverilogIde={}".format(
+        b(flags["readOnly"]),
+        b(flags["dataOnly"]),
+        b(flags["deterministic"]),
+        b(flags["reviewPacketOnly"]),
+        b(flags["aggregatesCheckedFixturesOnly"]),
+        b(flags["statusSummaryReferencedOnly"]),
+        b(flags["approvalGranted"]),
+        b(flags["promptCapture"]),
+        b(flags["promptRead"]),
+        b(flags["promptContentIncluded"]),
+        b(flags["responseContentIncluded"]),
+        b(flags["transcriptContentIncluded"]),
+        b(flags["messageBodiesIncluded"]),
+        b(flags["sessionStoreRead"]),
+        b(flags["sessionPersistence"]),
+        b(flags["summaryGenerated"]),
+        b(flags["transcriptExported"]),
+        b(flags["clipboardRead"]),
+        b(flags["clipboardWrite"]),
+        b(flags["attachmentReads"]),
+        b(flags["fileMetadataRead"]),
+        b(flags["fileContentRead"]),
+        b(flags["directoryScan"]),
+        b(flags["redactionRulesLoaded"]),
+        b(flags["contentScan"]),
+        b(flags["redactionApplied"]),
+        b(flags["auditLogWritten"]),
+        b(flags["configRead"]),
+        b(flags["environmentRead"]),
+        b(flags["providerConfigRead"]),
+        b(flags["modelAssetRead"]),
+        b(flags["modelLoadAttempted"]),
+        b(flags["modelExecution"]),
+        b(flags["runtimeExecution"]),
+        b(flags["responseGenerated"]),
+        b(flags["sendEnabled"]),
+        b(flags["kv260Access"]),
+        b(flags["hardwareAccess"]),
+        b(flags["networkCalls"]),
+        b(flags["providerCalls"]),
+        b(flags["cloudCalls"]),
+        b(flags["executesPccxLab"]),
+        b(flags["executesSystemverilogIde"]),
+    )
+)
+'
+    )"; then
+        ERROR "chat review packet JSON could not be summarized"
+        return 1
+    fi
+
+    HEAD "chat review packet"
+    printf '%s\n' "$CHAT_REVIEW_PACKET_TEXT"
 }
 
 print_chat_error_taxonomy_summary() {
@@ -3414,6 +3544,10 @@ while [ $# -gt 0 ]; do
             INCLUDE_CHAT_STATUS_SUMMARY="1"
             shift
             ;;
+        --include-chat-review-packet)
+            INCLUDE_CHAT_REVIEW_PACKET="1"
+            shift
+            ;;
         --backend)
             BACKEND="${2:-}"
             if [ -z "$BACKEND" ]; then
@@ -3429,8 +3563,8 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-if [ -n "$BACKEND" ] && { [ "$INCLUDE_RUNTIME_READINESS" = "1" ] || [ "$INCLUDE_DEVICE_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SURFACE_LAYOUT" = "1" ] || [ "$INCLUDE_CHAT_EMPTY_STATE" = "1" ] || [ "$INCLUDE_CHAT_LOCAL_ONLY_POLICY" = "1" ] || [ "$INCLUDE_CHAT_PREFERENCES" = "1" ] || [ "$INCLUDE_CHAT_SESSION_INDEX" = "1" ] || [ "$INCLUDE_CHAT_SESSION_STORE_POLICY" = "1" ] || [ "$INCLUDE_CHAT_SESSION_TITLE_POLICY" = "1" ] || [ "$INCLUDE_CHAT_MODEL_STATUS" = "1" ] || [ "$INCLUDE_CHAT_MODEL_SELECTION_POLICY" = "1" ] || [ "$INCLUDE_CHAT_CONTEXT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_MODEL_LOAD_REQUEST" = "1" ] || [ "$INCLUDE_CHAT_READINESS" = "1" ] || [ "$INCLUDE_CHAT_COMPOSER" = "1" ] || [ "$INCLUDE_CHAT_SEND_RESULT" = "1" ] || [ "$INCLUDE_CHAT_TRANSCRIPT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_AUDIT_EVENT" = "1" ] || [ "$INCLUDE_CHAT_ERROR_TAXONOMY" = "1" ] || [ "$INCLUDE_CHAT_RESPONSE_STREAM" = "1" ] || [ "$INCLUDE_CHAT_MESSAGE_LIST" = "1" ] || [ "$INCLUDE_CHAT_ACTION_BAR" = "1" ] || [ "$INCLUDE_CHAT_CLIPBOARD_POLICY" = "1" ] || [ "$INCLUDE_CHAT_REDACTION_POLICY" = "1" ] || [ "$INCLUDE_CHAT_ATTACHMENT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_SHORTCUT_MAP" = "1" ] || [ "$INCLUDE_CHAT_STATUS_SUMMARY" = "1" ]; }; then
-    ERROR "--include-runtime-readiness, --include-device-session, --include-chat-session, --include-chat-surface-layout, --include-chat-empty-state, --include-chat-local-only-policy, --include-chat-preferences, --include-chat-session-index, --include-chat-session-store-policy, --include-chat-session-title-policy, --include-chat-model-status, --include-chat-model-selection-policy, --include-chat-context-policy, --include-chat-model-load-request, --include-chat-readiness, --include-chat-composer, --include-chat-send-result, --include-chat-transcript-policy, --include-chat-audit-event, --include-chat-error-taxonomy, --include-chat-response-stream, --include-chat-message-list, --include-chat-action-bar, --include-chat-clipboard-policy, --include-chat-redaction-policy, --include-chat-attachment-policy, --include-chat-shortcut-map, and --include-chat-status-summary are only supported in local scaffold mode"
+if [ -n "$BACKEND" ] && { [ "$INCLUDE_RUNTIME_READINESS" = "1" ] || [ "$INCLUDE_DEVICE_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SURFACE_LAYOUT" = "1" ] || [ "$INCLUDE_CHAT_EMPTY_STATE" = "1" ] || [ "$INCLUDE_CHAT_LOCAL_ONLY_POLICY" = "1" ] || [ "$INCLUDE_CHAT_PREFERENCES" = "1" ] || [ "$INCLUDE_CHAT_SESSION_INDEX" = "1" ] || [ "$INCLUDE_CHAT_SESSION_STORE_POLICY" = "1" ] || [ "$INCLUDE_CHAT_SESSION_TITLE_POLICY" = "1" ] || [ "$INCLUDE_CHAT_MODEL_STATUS" = "1" ] || [ "$INCLUDE_CHAT_MODEL_SELECTION_POLICY" = "1" ] || [ "$INCLUDE_CHAT_CONTEXT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_MODEL_LOAD_REQUEST" = "1" ] || [ "$INCLUDE_CHAT_READINESS" = "1" ] || [ "$INCLUDE_CHAT_COMPOSER" = "1" ] || [ "$INCLUDE_CHAT_SEND_RESULT" = "1" ] || [ "$INCLUDE_CHAT_TRANSCRIPT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_AUDIT_EVENT" = "1" ] || [ "$INCLUDE_CHAT_ERROR_TAXONOMY" = "1" ] || [ "$INCLUDE_CHAT_RESPONSE_STREAM" = "1" ] || [ "$INCLUDE_CHAT_MESSAGE_LIST" = "1" ] || [ "$INCLUDE_CHAT_ACTION_BAR" = "1" ] || [ "$INCLUDE_CHAT_CLIPBOARD_POLICY" = "1" ] || [ "$INCLUDE_CHAT_REDACTION_POLICY" = "1" ] || [ "$INCLUDE_CHAT_ATTACHMENT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_SHORTCUT_MAP" = "1" ] || [ "$INCLUDE_CHAT_STATUS_SUMMARY" = "1" ] || [ "$INCLUDE_CHAT_REVIEW_PACKET" = "1" ]; }; then
+    ERROR "--include-runtime-readiness, --include-device-session, --include-chat-session, --include-chat-surface-layout, --include-chat-empty-state, --include-chat-local-only-policy, --include-chat-preferences, --include-chat-session-index, --include-chat-session-store-policy, --include-chat-session-title-policy, --include-chat-model-status, --include-chat-model-selection-policy, --include-chat-context-policy, --include-chat-model-load-request, --include-chat-readiness, --include-chat-composer, --include-chat-send-result, --include-chat-transcript-policy, --include-chat-audit-event, --include-chat-error-taxonomy, --include-chat-response-stream, --include-chat-message-list, --include-chat-action-bar, --include-chat-clipboard-policy, --include-chat-redaction-policy, --include-chat-attachment-policy, --include-chat-shortcut-map, --include-chat-status-summary, and --include-chat-review-packet are only supported in local scaffold mode"
     exit 1
 fi
 
@@ -3471,7 +3605,14 @@ if [ -z "$BACKEND" ]; then
     NOTE "chat attach   : opt-in via --include-chat-attachment-policy (read-only disabled attachment-policy data)"
     NOTE "chat shortcuts: opt-in via --include-chat-shortcut-map (read-only disabled shortcut-map data)"
     NOTE "chat summary  : opt-in via --include-chat-status-summary (read-only aggregate status data)"
+    NOTE "chat review   : opt-in via --include-chat-review-packet (read-only review packet data)"
     NOTE "editor bridge  : planned (VS Code / other IDEs)"
+
+    if [ "$INCLUDE_CHAT_REVIEW_PACKET" = "1" ]; then
+        if ! print_chat_review_packet_summary; then
+            exit 1
+        fi
+    fi
 
     if [ "$INCLUDE_CHAT_STATUS_SUMMARY" = "1" ]; then
         if ! print_chat_status_summary_summary; then

--- a/scripts/tests/chat_review_packet_contract_test.py
+++ b/scripts/tests/chat_review_packet_contract_test.py
@@ -1,0 +1,370 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Fixture tests for the standalone chat review-packet contract."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "contracts" / "chat_review_packet_contract.py"
+FIXTURE_PATH = (
+    ROOT
+    / "contracts"
+    / "fixtures"
+    / "chat-review-packet.gemma3n-e4b-kv260-placeholder.json"
+)
+SCRIPT_PATH = ROOT / "scripts" / "chat-review-packet-stub.sh"
+STATUS_TEST_PATH = ROOT / "scripts" / "tests" / "status-chat-review-packet.sh"
+README_PATH = ROOT / "README.md"
+TEST_PATH = Path(__file__).resolve()
+CI_PATH = ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location(
+        "chat_review_packet_contract",
+        MODULE_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def flatten(value) -> str:
+    return json.dumps(value, sort_keys=True)
+
+
+def iter_state_values(value):
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            if key == "state" or key.endswith("State") or key.endswith("Status"):
+                yield nested
+            yield from iter_state_values(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            yield from iter_state_values(nested)
+
+
+def iter_keys(value):
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            yield key
+            yield from iter_keys(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            yield from iter_keys(nested)
+
+
+def assert_no_private_or_generated_data(text: str) -> None:
+    forbidden_patterns = [
+        r"/home/[^\s\"']+",
+        r"/Users/[^\s\"']+",
+        r"[A-Za-z]:\\Users\\",
+        r"\b(?:api[_-]?key|authorization|bearer|client[_-]?secret|password|private[_-]?key|secret|token)\b\s*[:=]",
+        r"\.(?:gguf|safetensors|ckpt|pt|pth|onnx)\b",
+        r"(?:weights|model_weights|model-cache)/(?:[^\"'\s]+)",
+        r"(?:raw[_-]?full[_-]?logs|hardware[_-]?dump|generated[_-]?blob)\s*[:=]",
+    ]
+    for pattern in forbidden_patterns:
+        assert not re.search(pattern, text, re.IGNORECASE), pattern
+
+
+def assert_no_runtime_implementation_terms(source: str) -> None:
+    forbidden = [
+        "subprocess",
+        "os.system",
+        "popen",
+        "socket",
+        "urllib",
+        "requests",
+        "http.client",
+        "openai",
+        "anthropic",
+        "gemini",
+        "modelcontextprotocol",
+        "websocket",
+        "xmutil",
+        "xrt-smi",
+        "lsusb",
+        "dmesg",
+    ]
+    lowered = source.lower()
+    for term in forbidden:
+        assert term not in lowered, term
+
+
+def assert_no_provider_configs(value) -> None:
+    forbidden_keys = {
+        "apiKey",
+        "accessToken",
+        "refreshToken",
+        "authorization",
+        "bearerToken",
+        "provider",
+        "providers",
+        "providerConfig",
+        "providerConfigs",
+    }
+    for key in iter_keys(value):
+        assert key not in forbidden_keys, key
+
+
+def assert_no_unsupported_claims(text: str) -> None:
+    literal_claims = [
+        "production" + "-ready",
+        "marketplace" + "-ready",
+        "stable " + "API",
+        "stable " + "ABI",
+        "KV260 inference " + "works",
+        "Gemma 3N E4B " + "runs on KV260",
+        "20 tok/s " + "achieved",
+        "timing " + "closed",
+        "bitstream " + "ready",
+        "launcher executes " + "pccx-lab",
+        "IDE controls " + "launcher",
+        "AI provider integration " + "is live",
+    ]
+    lowered = text.lower()
+    for claim in literal_claims:
+        assert claim.lower() not in lowered, claim
+
+
+def test_chat_review_packet_matches_fixture_and_is_deterministic() -> None:
+    module = load_module()
+    generated = module.create_gemma3n_e4b_kv260_chat_review_packet()
+    fixture = json.loads(read_text(FIXTURE_PATH))
+
+    assert generated == fixture
+    assert module.chat_review_packet_json(generated) == (
+        module.chat_review_packet_json(generated)
+    )
+    assert module.chat_review_packet_json(generated).endswith("\n")
+    assert json.loads(module.chat_review_packet_json(generated)) == fixture
+
+
+def test_cli_stub_outputs_deterministic_json() -> None:
+    fixture = json.loads(read_text(FIXTURE_PATH))
+    command = [
+        "bash",
+        str(SCRIPT_PATH),
+        "--model",
+        "gemma3n-e4b",
+        "--target",
+        "kv260",
+    ]
+    first = subprocess.run(command, check=True, capture_output=True, text=True)
+    second = subprocess.run(command, check=True, capture_output=True, text=True)
+
+    assert first.stderr == ""
+    assert first.stdout == second.stdout
+    assert first.stdout.endswith("\n")
+    assert json.loads(first.stdout) == fixture
+
+
+def test_required_fields_and_allowed_states() -> None:
+    module = load_module()
+    packet = module.create_gemma3n_e4b_kv260_chat_review_packet()
+    allowed = set(module.CHAT_REVIEW_PACKET_STATE_VALUES)
+
+    assert tuple(packet.keys()) == module.CHAT_REVIEW_PACKET_FIELDS
+    assert packet["schemaVersion"] == "pccx.chatReviewPacket.v0"
+
+    states = list(iter_state_values(packet))
+    assert states
+    for state in states:
+        assert state in allowed, state
+
+    for section in packet["reviewSections"]:
+        assert tuple(section.keys()) == module.REVIEW_SECTION_FIELDS
+    for review in packet["requiredReviews"]:
+        assert tuple(review.keys()) == module.REQUIRED_REVIEW_FIELDS
+    for reason in packet["blockedReasons"]:
+        assert tuple(reason.keys()) == module.BLOCKED_REASON_FIELDS
+    for ref in packet["handoffRefs"]:
+        assert tuple(ref.keys()) == module.HANDOFF_REF_FIELDS
+
+
+def test_chat_review_packet_covers_review_gates_without_approval() -> None:
+    packet = load_module().create_gemma3n_e4b_kv260_chat_review_packet()
+    sections = {section["sectionId"]: section for section in packet["reviewSections"]}
+    reviews = {review["reviewId"]: review for review in packet["requiredReviews"]}
+    reasons = {reason["reasonId"]: reason for reason in packet["blockedReasons"]}
+    refs = {ref["refId"]: ref for ref in packet["handoffRefs"]}
+
+    assert packet["reviewState"] == "blocked"
+    assert packet["approvalState"] == "not_approved"
+    assert packet["executionState"] == "not_started"
+    assert packet["contentState"] == "empty_not_captured"
+    assert packet["privacyState"] == "requires_review"
+    assert packet["evidenceState"] == "requires_evidence"
+    assert set(sections) == {
+        "surface_and_controls",
+        "session_management",
+        "model_runtime_and_device",
+        "content_flow",
+        "privacy_and_local_only_policy",
+        "aggregate_status",
+    }
+    assert sections["aggregate_status"]["contentPolicy"] == (
+        "status_summary_reference_only_no_status_card_duplication"
+    )
+    assert set(reviews) == {
+        "runtime_evidence_review",
+        "model_asset_review",
+        "session_store_review",
+        "content_privacy_review",
+        "send_enablement_review",
+    }
+    for review in reviews.values():
+        assert review["accepted"] is False
+    assert set(reasons) == {
+        "review_packet_not_approved",
+        "runtime_and_device_evidence_absent",
+        "model_asset_boundary_absent",
+        "session_store_boundary_absent",
+        "content_privacy_boundary_absent",
+    }
+    assert set(refs) == {
+        "chat_status_summary",
+        "chat_local_only_policy",
+        "chat_redaction_policy",
+        "chat_session_store_policy",
+        "chat_model_load_request",
+        "chat_readiness",
+    }
+
+
+def test_safety_flags_preserve_review_only_boundary() -> None:
+    packet = load_module().create_gemma3n_e4b_kv260_chat_review_packet()
+    flags = packet["safetyFlags"]
+
+    assert flags["dataOnly"] is True
+    assert flags["readOnly"] is True
+    assert flags["deterministic"] is True
+    assert flags["reviewPacketOnly"] is True
+    assert flags["aggregatesCheckedFixturesOnly"] is True
+    assert flags["statusSummaryReferencedOnly"] is True
+    for name in [
+        "approvalGranted",
+        "promptCapture",
+        "promptRead",
+        "promptContentIncluded",
+        "responseContentIncluded",
+        "transcriptContentIncluded",
+        "messageBodiesIncluded",
+        "sessionStoreRead",
+        "sessionPersistence",
+        "summaryGenerated",
+        "transcriptExported",
+        "clipboardRead",
+        "clipboardWrite",
+        "attachmentReads",
+        "fileMetadataRead",
+        "fileContentRead",
+        "directoryScan",
+        "redactionRulesLoaded",
+        "contentScan",
+        "redactionApplied",
+        "auditLogWritten",
+        "configRead",
+        "environmentRead",
+        "providerConfigRead",
+        "modelAssetRead",
+        "modelPathIncluded",
+        "modelLoadAttempted",
+        "modelExecution",
+        "runtimeExecution",
+        "responseGenerated",
+        "sendEnabled",
+        "readsArtifacts",
+        "writesArtifacts",
+        "kv260Access",
+        "hardwareAccess",
+        "networkCalls",
+        "providerCalls",
+        "cloudCalls",
+        "executesPccxLab",
+        "executesSystemverilogIde",
+        "telemetry",
+        "writeBack",
+        "releaseOrTagAction",
+        "settingsChange",
+        "compatibilityClaim",
+    ]:
+        assert flags[name] is False, name
+
+
+def test_docs_and_sources_avoid_private_data_runtime_calls_or_overclaims() -> None:
+    module_source = read_text(MODULE_PATH)
+    script_source = read_text(SCRIPT_PATH)
+    status_test_source = read_text(STATUS_TEST_PATH)
+    packet = load_module().create_gemma3n_e4b_kv260_chat_review_packet()
+    scan_text = "\n".join([
+        read_text(FIXTURE_PATH),
+        read_text(README_PATH),
+        flatten(packet),
+        module_source,
+        script_source,
+        status_test_source,
+    ])
+    runtime_source = "\n".join([module_source, script_source])
+
+    assert_no_runtime_implementation_terms(runtime_source)
+    assert_no_private_or_generated_data(scan_text)
+    assert_no_provider_configs(packet)
+    assert_no_unsupported_claims(scan_text)
+
+
+def test_source_headers_for_touched_code_files() -> None:
+    expected_headers = {
+        MODULE_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        SCRIPT_PATH: [
+            "#!/usr/bin/env bash",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        STATUS_TEST_PATH: [
+            "#!/usr/bin/env bash",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        TEST_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        CI_PATH: [
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+    }
+
+    for path, header in expected_headers.items():
+        assert read_text(path).splitlines()[: len(header)] == header, path
+
+
+test_chat_review_packet_matches_fixture_and_is_deterministic()
+test_cli_stub_outputs_deterministic_json()
+test_required_fields_and_allowed_states()
+test_chat_review_packet_covers_review_gates_without_approval()
+test_safety_flags_preserve_review_only_boundary()
+test_docs_and_sources_avoid_private_data_runtime_calls_or_overclaims()
+test_source_headers_for_touched_code_files()
+
+print("chat review packet contract tests ok")

--- a/scripts/tests/status-chat-review-packet.sh
+++ b/scripts/tests/status-chat-review-packet.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+# scripts/tests/status-chat-review-packet.sh - status chat review-packet tests.
+#
+# Usage: bash scripts/tests/status-chat-review-packet.sh [path/to/status-stub.sh]
+
+set -eu
+
+PASS() { printf '[PASS]  %s\n' "$*"; }
+FAIL() { printf '[FAIL] %s\n' "$*" >&2; }
+HEAD() { printf '\n=== %s ===\n' "$*"; }
+
+STUB="${1:-scripts/status-stub.sh}"
+
+if [ ! -x "$STUB" ]; then
+    chmod +x "$STUB"
+fi
+
+contains() {
+    case "$1" in
+        *"$2"*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+require_contains() {
+    local output="$1"
+    local expected="$2"
+    if ! contains "$output" "$expected"; then
+        FAIL "expected output to contain: $expected"
+        printf '%s\n' "$output" >&2
+        exit 1
+    fi
+}
+
+require_not_contains() {
+    local output="$1"
+    local forbidden="$2"
+    if contains "$output" "$forbidden"; then
+        FAIL "output contained forbidden text: $forbidden"
+        printf '%s\n' "$output" >&2
+        exit 1
+    fi
+}
+
+HEAD "1: status can include chat review packet"
+OUTPUT="$("$STUB" --include-chat-review-packet)"
+require_contains "$OUTPUT" "=== chat review packet ==="
+require_contains "$OUTPUT" "source     : scripts/chat-review-packet-stub.sh --model gemma3n-e4b --target kv260"
+require_contains "$OUTPUT" "boundary   : read-only data; no prompt/session-store/config/model/runtime/hardware/provider/lab/IDE execution"
+require_contains "$OUTPUT" "target     : kv260"
+require_contains "$OUTPUT" "model      : gemma3n-e4b"
+require_contains "$OUTPUT" "review    : blocked"
+require_contains "$OUTPUT" "approval  : not_approved"
+require_contains "$OUTPUT" "execution : not_started"
+require_contains "$OUTPUT" "content   : empty_not_captured"
+require_contains "$OUTPUT" "privacy   : requires_review"
+require_contains "$OUTPUT" "evidence  : requires_evidence"
+PASS "chat review-packet section is present and conservative"
+
+HEAD "2: review sections, required reviews, and blockers are summarized"
+require_contains "$OUTPUT" "sections   : surface_and_controls=available_as_data"
+require_contains "$OUTPUT" "session_management=blocked"
+require_contains "$OUTPUT" "model_runtime_and_device=requires_evidence"
+require_contains "$OUTPUT" "content_flow=disabled"
+require_contains "$OUTPUT" "privacy_and_local_only_policy=requires_review"
+require_contains "$OUTPUT" "aggregate_status=summary_only"
+require_contains "$OUTPUT" "reviews    : runtime_evidence_review=requires_evidence:false"
+require_contains "$OUTPUT" "model_asset_review=not_approved:false"
+require_contains "$OUTPUT" "session_store_review=not_approved:false"
+require_contains "$OUTPUT" "content_privacy_review=requires_review:false"
+require_contains "$OUTPUT" "send_enablement_review=blocked:false"
+require_contains "$OUTPUT" "blocked    : review_packet_not_approved=not_approved"
+require_contains "$OUTPUT" "runtime_and_device_evidence_absent=requires_evidence"
+require_contains "$OUTPUT" "model_asset_boundary_absent=not_loaded"
+require_contains "$OUTPUT" "session_store_boundary_absent=not_configured"
+require_contains "$OUTPUT" "content_privacy_boundary_absent=requires_review"
+require_contains "$OUTPUT" "refs       : chat_status_summary=summary_only"
+require_contains "$OUTPUT" "chat_local_only_policy=blocked"
+require_contains "$OUTPUT" "chat_redaction_policy=summary_only"
+require_contains "$OUTPUT" "chat_session_store_policy=not_configured"
+require_contains "$OUTPUT" "chat_model_load_request=blocked"
+require_contains "$OUTPUT" "chat_readiness=blocked"
+PASS "review packet gates and references are summarized"
+
+HEAD "3: safety flags stay review-only and non-executing"
+require_contains "$OUTPUT" "readOnly=true"
+require_contains "$OUTPUT" "dataOnly=true"
+require_contains "$OUTPUT" "deterministic=true"
+require_contains "$OUTPUT" "reviewPacketOnly=true"
+require_contains "$OUTPUT" "aggregatesCheckedFixturesOnly=true"
+require_contains "$OUTPUT" "statusSummaryReferencedOnly=true"
+require_contains "$OUTPUT" "approvalGranted=false"
+require_contains "$OUTPUT" "promptCapture=false"
+require_contains "$OUTPUT" "promptRead=false"
+require_contains "$OUTPUT" "promptContentIncluded=false"
+require_contains "$OUTPUT" "responseContentIncluded=false"
+require_contains "$OUTPUT" "transcriptContentIncluded=false"
+require_contains "$OUTPUT" "messageBodiesIncluded=false"
+require_contains "$OUTPUT" "sessionStoreRead=false"
+require_contains "$OUTPUT" "sessionPersistence=false"
+require_contains "$OUTPUT" "summaryGenerated=false"
+require_contains "$OUTPUT" "transcriptExported=false"
+require_contains "$OUTPUT" "clipboardRead=false"
+require_contains "$OUTPUT" "clipboardWrite=false"
+require_contains "$OUTPUT" "attachmentReads=false"
+require_contains "$OUTPUT" "fileMetadataRead=false"
+require_contains "$OUTPUT" "fileContentRead=false"
+require_contains "$OUTPUT" "directoryScan=false"
+require_contains "$OUTPUT" "redactionRulesLoaded=false"
+require_contains "$OUTPUT" "contentScan=false"
+require_contains "$OUTPUT" "redactionApplied=false"
+require_contains "$OUTPUT" "auditLogWritten=false"
+require_contains "$OUTPUT" "configRead=false"
+require_contains "$OUTPUT" "environmentRead=false"
+require_contains "$OUTPUT" "providerConfigRead=false"
+require_contains "$OUTPUT" "modelAssetRead=false"
+require_contains "$OUTPUT" "modelLoadAttempted=false"
+require_contains "$OUTPUT" "modelExecution=false"
+require_contains "$OUTPUT" "runtimeExecution=false"
+require_contains "$OUTPUT" "responseGenerated=false"
+require_contains "$OUTPUT" "sendEnabled=false"
+require_contains "$OUTPUT" "kv260Access=false"
+require_contains "$OUTPUT" "hardwareAccess=false"
+require_contains "$OUTPUT" "networkCalls=false"
+require_contains "$OUTPUT" "providerCalls=false"
+require_contains "$OUTPUT" "cloudCalls=false"
+require_contains "$OUTPUT" "executesPccxLab=false"
+require_contains "$OUTPUT" "executesSystemverilogIde=false"
+PASS "execution-related flags remain false"
+
+HEAD "4: output is deterministic"
+OUTPUT_AGAIN="$("$STUB" --include-chat-review-packet)"
+if [ "$OUTPUT" != "$OUTPUT_AGAIN" ]; then
+    FAIL "status chat review-packet output changed between runs"
+    exit 1
+fi
+PASS "status chat review-packet output is deterministic"
+
+HEAD "5: chat review-packet option does not combine with pccx-lab backend"
+if "$STUB" --include-chat-review-packet --backend pccx-lab >/dev/null 2>&1; then
+    FAIL "expected combined chat-review-packet/backend mode to fail"
+    exit 1
+fi
+PASS "chat review-packet remains separate from backend execution"
+
+HEAD "6: output avoids known overclaims"
+FORBIDDEN_PREFIX="KV260 inference"
+FORBIDDEN_CLAIM="${FORBIDDEN_PREFIX} works"
+require_not_contains "$OUTPUT" "$FORBIDDEN_CLAIM"
+THROUGHPUT_PREFIX="20 tok/s"
+THROUGHPUT_CLAIM="${THROUGHPUT_PREFIX} achieved"
+require_not_contains "$OUTPUT" "$THROUGHPUT_CLAIM"
+PASS "no chat review-packet or throughput overclaim in status output"
+
+printf '\n[DONE]  all status-chat-review-packet tests passed\n'


### PR DESCRIPTION
## Summary
- add a checked data-only chat review-packet contract and fixture over existing chat surface, session, model/runtime, content, privacy, and status-summary references
- add a review-packet stub plus status-stub opt-in output for local scaffold review
- wire README and CI coverage for the new contract and status test

Refs #9.

## Validation
- `python3 scripts/tests/chat_review_packet_contract_test.py`
- `bash scripts/tests/status-chat-review-packet.sh scripts/status-stub.sh`
- `bash scripts/chat-review-packet-stub.sh --model gemma3n-e4b --target kv260`
- `bash scripts/status-stub.sh --include-chat-review-packet`
- `python3 -m py_compile contracts/*.py scripts/tests/*.py`
- `find scripts -type f -name '*.sh' -not -name '*.snapshot' -exec bash -n {} +`
- `for test_file in scripts/tests/*_test.py; do python3 "$test_file"; done`
- `for test_file in scripts/tests/status-*.sh; do bash "$test_file" scripts/status-stub.sh; done`
- `./scripts/check.sh`
- `./scripts/check-device-stub.sh`
- `./scripts/install-stub.sh`
- `./scripts/launch-stub.sh --dry-run`
- `./scripts/chat-stub.sh --dry-run --prompt hello`
- local forbidden-claim scan
- `git diff --check`
- `git diff --cached --check`

## Scope notes
- no prompt capture, prompt read, prompt echo, transcript/session-store reads, summary generation, clipboard or file access, audit writes, model asset reads, model loading, runtime execution, provider/network/cloud calls, pccx-lab or IDE execution, hardware/KV260 access, settings changes, release/tag actions, or stable API/ABI claims
- local shellcheck is not installed in this environment; CI installs and runs shellcheck
