### PR TITLE
Add chat gap matrix boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,7 @@ jobs:
                    scripts/chat-shortcut-map-stub.sh \
                    scripts/chat-status-summary-stub.sh \
                    scripts/chat-review-packet-stub.sh \
+                   scripts/chat-gap-matrix-stub.sh \
                    scripts/chat-surface-preview.sh \
                    scripts/chat-stub.sh; do
             [ -f "$f" ] && chmod +x "$f" || true
@@ -288,6 +289,10 @@ jobs:
         run: ./scripts/status-stub.sh --include-chat-review-packet
       - name: run scripts/chat-review-packet-stub.sh
         run: ./scripts/chat-review-packet-stub.sh --model gemma3n-e4b --target kv260
+      - name: run scripts/status-stub.sh with chat gap matrix
+        run: ./scripts/status-stub.sh --include-chat-gap-matrix
+      - name: run scripts/chat-gap-matrix-stub.sh
+        run: ./scripts/chat-gap-matrix-stub.sh --model gemma3n-e4b --target kv260
       - name: run scripts/chat-surface-preview.sh
         run: ./scripts/chat-surface-preview.sh --model gemma3n-e4b --target kv260
       - name: run scripts/chat-stub.sh --dry-run
@@ -366,6 +371,8 @@ jobs:
         run: python3 scripts/tests/chat_status_summary_contract_test.py
       - name: run chat review-packet contract tests
         run: python3 scripts/tests/chat_review_packet_contract_test.py
+      - name: run chat gap-matrix contract tests
+        run: python3 scripts/tests/chat_gap_matrix_contract_test.py
       - name: run chat surface preview tests
         run: python3 scripts/tests/chat_surface_preview_test.py
 
@@ -406,6 +413,7 @@ jobs:
           chmod +x scripts/chat-shortcut-map-stub.sh
           chmod +x scripts/chat-status-summary-stub.sh
           chmod +x scripts/chat-review-packet-stub.sh
+          chmod +x scripts/chat-gap-matrix-stub.sh
           chmod +x scripts/launch-stub.sh
           chmod +x scripts/tests/status-backend.sh
           chmod +x scripts/tests/status-device-session.sh
@@ -437,6 +445,7 @@ jobs:
           chmod +x scripts/tests/status-chat-shortcut-map.sh
           chmod +x scripts/tests/status-chat-status-summary.sh
           chmod +x scripts/tests/status-chat-review-packet.sh
+          chmod +x scripts/tests/status-chat-gap-matrix.sh
       - name: shellcheck status-stub and test script
         run: |
           sudo apt-get update -q && sudo apt-get install -y -q shellcheck
@@ -471,6 +480,7 @@ jobs:
           shellcheck scripts/tests/status-chat-shortcut-map.sh
           shellcheck scripts/tests/status-chat-status-summary.sh
           shellcheck scripts/tests/status-chat-review-packet.sh
+          shellcheck scripts/tests/status-chat-gap-matrix.sh
       - name: run status-backend tests
         run: bash scripts/tests/status-backend.sh scripts/status-stub.sh
       - name: run status-device-session tests
@@ -531,3 +541,5 @@ jobs:
         run: bash scripts/tests/status-chat-status-summary.sh scripts/status-stub.sh
       - name: run status-chat-review-packet tests
         run: bash scripts/tests/status-chat-review-packet.sh scripts/status-stub.sh
+      - name: run status-chat-gap-matrix tests
+        run: bash scripts/tests/status-chat-gap-matrix.sh scripts/status-stub.sh

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ and verify host-side prerequisites before the real engine lands.
 | [`scripts/check.sh`](./scripts/check.sh) | Probe host info, tooling availability, edge-device hints. Always exits 0. |
 | [`scripts/check-device-stub.sh`](./scripts/check-device-stub.sh) | Narrowly scoped device-tree / FPGA-node probe (KV260 / Kria detection only). Always exits 0. |
 | [`scripts/install-stub.sh`](./scripts/install-stub.sh) | Preview of the planned install flow; reports which host runtime pieces are present, lists device-side pieces as future deliverables. Always exits 0. |
-| [`scripts/status-stub.sh`](./scripts/status-stub.sh) | Launcher state summary. Default mode: local scaffold output, always exits 0. With `--include-chat-action-bar`, adds read-only disabled chat action-bar data. With `--include-chat-clipboard-policy`, adds read-only disabled chat clipboard-policy data. With `--include-chat-redaction-policy`, adds read-only disabled chat redaction-policy data. With `--include-chat-attachment-policy`, adds read-only disabled chat attachment-policy data. With `--include-chat-shortcut-map`, adds read-only disabled chat shortcut-map data. With `--include-chat-status-summary`, adds read-only aggregate chat status-summary data. With `--include-chat-review-packet`, adds read-only chat review-packet data over existing checked fixture references. With `--include-chat-message-list`, adds read-only empty chat message-list data. With `--include-chat-response-stream`, adds read-only blocked chat response stream data. With `--include-chat-error-taxonomy`, adds read-only chat error taxonomy data. With `--include-chat-audit-event`, adds read-only blocked chat audit-event metadata. With `--include-chat-surface-layout`, adds read-only chat surface layout data. With `--include-chat-empty-state`, adds read-only display-only chat empty-state data. With `--include-chat-local-only-policy`, adds read-only local-only/cloud-block policy data. With `--include-chat-preferences`, adds read-only chat preferences/settings data. With `--include-chat-session-index`, adds read-only empty chat session index data. With `--include-chat-session-store-policy`, adds read-only disabled chat session-store policy data. With `--include-chat-session-title-policy`, adds read-only placeholder session-title policy data. With `--include-chat-transcript-policy`, adds read-only chat transcript retention/export policy data. With `--include-chat-send-result`, adds read-only blocked chat send-result data. With `--include-chat-composer`, adds read-only chat composer/input-control data. With `--include-chat-model-status`, adds read-only blocked chat model-status display data. With `--include-chat-model-selection-policy`, adds read-only disabled chat model-selection data. With `--include-chat-context-policy`, adds read-only disabled chat context-window/tokenization policy data. With `--include-chat-model-load-request`, adds read-only disabled chat model-load request data. With `--include-chat-session`, adds read-only blocked chat/session and lifecycle summaries. With `--include-chat-readiness`, adds read-only chat readiness checks and recovery actions. With `--include-device-session`, adds a read-only device/session status panel. With `--include-runtime-readiness`, adds a read-only runtime readiness summary. With `--backend pccx-lab`, calls `pccx-lab status --format json` and forwards the run-status envelope (exits non-zero if binary is missing or output is invalid). |
+| [`scripts/status-stub.sh`](./scripts/status-stub.sh) | Launcher state summary. Default mode: local scaffold output, always exits 0. With `--include-chat-action-bar`, adds read-only disabled chat action-bar data. With `--include-chat-clipboard-policy`, adds read-only disabled chat clipboard-policy data. With `--include-chat-redaction-policy`, adds read-only disabled chat redaction-policy data. With `--include-chat-attachment-policy`, adds read-only disabled chat attachment-policy data. With `--include-chat-shortcut-map`, adds read-only disabled chat shortcut-map data. With `--include-chat-status-summary`, adds read-only aggregate chat status-summary data. With `--include-chat-review-packet`, adds read-only chat review-packet data over existing checked fixture references. With `--include-chat-gap-matrix`, adds read-only chat implementation gap-matrix data over existing checked fixture references. With `--include-chat-message-list`, adds read-only empty chat message-list data. With `--include-chat-response-stream`, adds read-only blocked chat response stream data. With `--include-chat-error-taxonomy`, adds read-only chat error taxonomy data. With `--include-chat-audit-event`, adds read-only blocked chat audit-event metadata. With `--include-chat-surface-layout`, adds read-only chat surface layout data. With `--include-chat-empty-state`, adds read-only display-only chat empty-state data. With `--include-chat-local-only-policy`, adds read-only local-only/cloud-block policy data. With `--include-chat-preferences`, adds read-only chat preferences/settings data. With `--include-chat-session-index`, adds read-only empty chat session index data. With `--include-chat-session-store-policy`, adds read-only disabled chat session-store policy data. With `--include-chat-session-title-policy`, adds read-only placeholder session-title policy data. With `--include-chat-transcript-policy`, adds read-only chat transcript retention/export policy data. With `--include-chat-send-result`, adds read-only blocked chat send-result data. With `--include-chat-composer`, adds read-only chat composer/input-control data. With `--include-chat-model-status`, adds read-only blocked chat model-status display data. With `--include-chat-model-selection-policy`, adds read-only disabled chat model-selection data. With `--include-chat-context-policy`, adds read-only disabled chat context-window/tokenization policy data. With `--include-chat-model-load-request`, adds read-only disabled chat model-load request data. With `--include-chat-session`, adds read-only blocked chat/session and lifecycle summaries. With `--include-chat-readiness`, adds read-only chat readiness checks and recovery actions. With `--include-device-session`, adds a read-only device/session status panel. With `--include-runtime-readiness`, adds a read-only runtime readiness summary. With `--backend pccx-lab`, calls `pccx-lab status --format json` and forwards the run-status envelope (exits non-zero if binary is missing or output is invalid). |
 | [`scripts/device-session-status-stub.sh`](./scripts/device-session-status-stub.sh) | Data-only device/session status JSON for the Gemma 3N E4B + KV260 target. Reports connection, model load, session, diagnostics, readiness, discovery paths, flow steps, and error taxonomy as placeholder / blocked. |
 | [`scripts/runtime-readiness-stub.sh`](./scripts/runtime-readiness-stub.sh) | Data-only runtime readiness JSON for the Gemma 3N E4B + KV260 target. Reports blocked / not yet evidence-backed. |
 | [`scripts/chat-session-stub.sh`](./scripts/chat-session-stub.sh) | Data-only standalone chat/session JSON for the Gemma 3N E4B + KV260 target. Reports disabled send controls, inactive session state, no prompt/response persistence, and readiness handoff references. |
@@ -115,6 +115,7 @@ and verify host-side prerequisites before the real engine lands.
 | [`scripts/chat-shortcut-map-stub.sh`](./scripts/chat-shortcut-map-stub.sh) | Data-only disabled chat shortcut-map JSON for the Gemma 3N E4B + KV260 target. Reports planned keyboard accelerator and focus metadata without installing listeners, capturing key events, dispatching commands, changing focus, reading prompts, sessions, transcripts, messages, files, or clipboard data, or starting runtime paths. |
 | [`scripts/chat-status-summary-stub.sh`](./scripts/chat-status-summary-stub.sh) | Data-only chat status-summary JSON for the Gemma 3N E4B + KV260 target. Aggregates existing checked chat surface references into blocked/disabled display cards without reading prompts, session stores, configuration, model paths, runtime logs, artifacts, provider state, or hardware state. |
 | [`scripts/chat-review-packet-stub.sh`](./scripts/chat-review-packet-stub.sh) | Data-only chat review-packet JSON for the Gemma 3N E4B + KV260 target. Collects existing checked chat fixture references and review gates without approving prompt capture, session-store reads, model loading, runtime execution, provider calls, or hardware access. |
+| [`scripts/chat-gap-matrix-stub.sh`](./scripts/chat-gap-matrix-stub.sh) | Data-only chat implementation gap-matrix JSON for the Gemma 3N E4B + KV260 target. Tracks remaining standalone chat blockers over existing checked fixture references without closing gaps, reading prompts, reading session stores, loading models, executing runtime paths, calling providers, reading files or clipboard data, invoking pccx-lab or IDE paths, touching hardware, or reading artifacts. |
 | [`scripts/chat-transcript-policy-stub.sh`](./scripts/chat-transcript-policy-stub.sh) | Data-only chat transcript policy JSON for the Gemma 3N E4B + KV260 target. Reports retention, export, storage, and privacy policy state without reading, generating, storing, persisting, summarizing, or exporting prompt/response/transcript content. |
 | [`scripts/chat-audit-event-stub.sh`](./scripts/chat-audit-event-stub.sh) | Data-only chat audit-event JSON for the Gemma 3N E4B + KV260 target. Reports blocked send metadata, redaction policy, absent prompt/response/transcript content, and disabled audit persistence. |
 | [`scripts/chat-error-taxonomy-stub.sh`](./scripts/chat-error-taxonomy-stub.sh) | Data-only chat error taxonomy JSON for the Gemma 3N E4B + KV260 target. Groups blocked readiness, model/runtime, session, and policy errors without reading prompts, providers, configs, model paths, logs, stores, or artifacts. |
@@ -154,6 +155,7 @@ bash scripts/status-stub.sh --include-chat-attachment-policy
 bash scripts/status-stub.sh --include-chat-shortcut-map
 bash scripts/status-stub.sh --include-chat-status-summary
 bash scripts/status-stub.sh --include-chat-review-packet
+bash scripts/status-stub.sh --include-chat-gap-matrix
 bash scripts/status-stub.sh --include-device-session
 bash scripts/status-stub.sh --include-runtime-readiness
 bash scripts/device-session-status-stub.sh --model gemma3n-e4b --target kv260
@@ -186,6 +188,7 @@ bash scripts/chat-attachment-policy-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-shortcut-map-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-status-summary-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-review-packet-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/chat-gap-matrix-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-surface-preview.sh --model gemma3n-e4b --target kv260
 bash scripts/launch-stub.sh --dry-run
 bash scripts/chat-stub.sh --dry-run --prompt "hello"
@@ -367,6 +370,7 @@ python3 contracts/chat_session_title_policy_contract.py --model gemma3n-e4b --ta
 python3 contracts/chat_empty_state_contract.py --model gemma3n-e4b --target kv260
 python3 contracts/chat_status_summary_contract.py --model gemma3n-e4b --target kv260
 python3 contracts/chat_review_packet_contract.py --model gemma3n-e4b --target kv260
+python3 contracts/chat_gap_matrix_contract.py --model gemma3n-e4b --target kv260
 bash scripts/chat-model-status-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-model-selection-policy-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-model-load-request-stub.sh --model gemma3n-e4b --target kv260
@@ -385,6 +389,7 @@ bash scripts/chat-redaction-policy-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-attachment-policy-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-shortcut-map-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-review-packet-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/chat-gap-matrix-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-surface-preview.sh --model gemma3n-e4b --target kv260
 bash scripts/status-stub.sh --include-chat-model-status
 bash scripts/status-stub.sh --include-chat-model-selection-policy
@@ -404,6 +409,7 @@ bash scripts/status-stub.sh --include-chat-session-title-policy
 bash scripts/status-stub.sh --include-chat-empty-state
 bash scripts/status-stub.sh --include-chat-status-summary
 bash scripts/status-stub.sh --include-chat-review-packet
+bash scripts/status-stub.sh --include-chat-gap-matrix
 python3 scripts/tests/chat_session_contract_test.py
 python3 scripts/tests/chat_model_status_contract_test.py
 python3 scripts/tests/chat_model_selection_policy_contract_test.py
@@ -422,6 +428,7 @@ python3 scripts/tests/chat_shortcut_map_contract_test.py
 python3 scripts/tests/chat_empty_state_contract_test.py
 python3 scripts/tests/chat_status_summary_contract_test.py
 python3 scripts/tests/chat_review_packet_contract_test.py
+python3 scripts/tests/chat_gap_matrix_contract_test.py
 python3 scripts/tests/chat_surface_preview_test.py
 bash scripts/tests/status-chat-model-status.sh
 bash scripts/tests/status-chat-model-selection-policy.sh
@@ -441,6 +448,7 @@ bash scripts/tests/status-chat-session-title-policy.sh
 bash scripts/tests/status-chat-empty-state.sh
 bash scripts/tests/status-chat-status-summary.sh
 bash scripts/tests/status-chat-review-packet.sh
+bash scripts/tests/status-chat-gap-matrix.sh
 ```
 
 The checked chat/session fixture reports the chat surface as blocked,
@@ -542,6 +550,15 @@ asset path, checksum, runtime preflight, load, warmup, unload, and
 persistence gates without reading configuration, environment values,
 model paths, asset paths, weights, tokenizers, checksum manifests,
 prompts, responses, transcripts, runtime logs, or artifacts.
+
+The chat status-summary, review-packet, and gap-matrix fixtures aggregate
+the checked chat boundary references without enabling them. The gap
+matrix records the remaining standalone chat blocker rows for runtime
+evidence, model assets, prompt input, response generation, session store,
+transcript/export, privacy, attachments/clipboard, audit, and UI
+enablement. It does not read prompt, transcript, session-store, model,
+file, clipboard, runtime, provider, hardware, or artifact data, and it
+does not close those gaps.
 
 The preview command renders that same contract as a deterministic
 terminal chat surface sketch with disabled controls, blocked reasons, and

--- a/contracts/chat_gap_matrix_contract.py
+++ b/contracts/chat_gap_matrix_contract.py
@@ -1,0 +1,501 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Data-only chat implementation gap matrix for the planned launcher UI.
+
+The matrix records remaining standalone chat gaps over existing checked
+fixture references. It does not accept prompts, read transcripts, read
+session stores, load models, start runtime code, call providers, invoke
+PCCX tools, touch hardware, read artifacts, or mutate repository state.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import sys
+
+
+SCHEMA_VERSION = "pccx.chatGapMatrix.v0"
+
+CHAT_GAP_MATRIX_FIELDS = (
+    "schemaVersion",
+    "gapMatrixId",
+    "fixtureVersion",
+    "lastUpdatedSource",
+    "targetDevice",
+    "targetBoard",
+    "targetModel",
+    "matrixState",
+    "standaloneChatState",
+    "reviewState",
+    "evidenceState",
+    "readinessState",
+    "gapRows",
+    "dependencyRefs",
+    "exitCriteria",
+    "blockedReasons",
+    "safetyFlags",
+    "limitations",
+    "issueRefs",
+)
+
+GAP_ROW_FIELDS = (
+    "gapId",
+    "label",
+    "area",
+    "sourceRefs",
+    "state",
+    "severity",
+    "summary",
+    "requiredBefore",
+    "sideEffectPolicy",
+)
+
+DEPENDENCY_REF_FIELDS = (
+    "refId",
+    "schemaVersion",
+    "fixturePath",
+    "state",
+    "summary",
+)
+
+EXIT_CRITERIA_FIELDS = (
+    "criteriaId",
+    "state",
+    "accepted",
+    "summary",
+    "requiredEvidence",
+    "blockedBy",
+)
+
+BLOCKED_REASON_FIELDS = (
+    "reasonId",
+    "state",
+    "summary",
+    "requiredBefore",
+)
+
+CHAT_GAP_MATRIX_STATE_VALUES = (
+    "available_as_data",
+    "blocked",
+    "disabled",
+    "empty_not_captured",
+    "inactive",
+    "not_approved",
+    "not_configured",
+    "not_loaded",
+    "not_started",
+    "planned",
+    "requires_evidence",
+    "requires_review",
+    "summary_only",
+    "target_selected",
+    "unavailable",
+)
+
+_CHAT_GAP_MATRIX = {
+    "schemaVersion": SCHEMA_VERSION,
+    "gapMatrixId": "chat_gap_matrix_gemma3n_e4b_kv260_placeholder",
+    "fixtureVersion": "chat-gap-matrix.gemma3n-e4b-kv260.2026-05-05",
+    "lastUpdatedSource": "pccx_launcher_issue_9_chat_gap_matrix_boundary_2026-05-05",
+    "targetDevice": "kv260",
+    "targetBoard": "xilinx_kria_kv260",
+    "targetModel": "gemma3n-e4b",
+    "matrixState": "available_as_data",
+    "standaloneChatState": "blocked",
+    "reviewState": "not_approved",
+    "evidenceState": "requires_evidence",
+    "readinessState": "blocked",
+    "gapRows": [
+        {
+            "gapId": "runtime_device_evidence",
+            "label": "runtime and device evidence",
+            "area": "runtime",
+            "sourceRefs": [
+                "runtime_readiness",
+                "device_session_status",
+                "chat_review_packet",
+            ],
+            "state": "requires_evidence",
+            "severity": "blocker",
+            "summary": "Runtime readiness and target device session evidence are still absent from this launcher boundary.",
+            "requiredBefore": "model_or_runtime_execution_enabled",
+            "sideEffectPolicy": "no_runtime_or_hardware_action",
+        },
+        {
+            "gapId": "model_asset_boundary",
+            "label": "model asset boundary",
+            "area": "model",
+            "sourceRefs": [
+                "model_runtime_descriptor",
+                "chat_model_selection_policy",
+                "chat_model_load_request",
+            ],
+            "state": "not_loaded",
+            "severity": "blocker",
+            "summary": "Model path, asset discovery, checksum, tokenizer, load, warmup, unload, and persistence remain disabled.",
+            "requiredBefore": "model_status_ready",
+            "sideEffectPolicy": "no_model_path_read_or_model_load",
+        },
+        {
+            "gapId": "prompt_input_boundary",
+            "label": "prompt input boundary",
+            "area": "content",
+            "sourceRefs": [
+                "chat_composer",
+                "chat_send_result",
+                "chat_review_packet",
+            ],
+            "state": "disabled",
+            "severity": "blocker",
+            "summary": "Prompt capture, prompt read, prompt echo, accepted input, validation handoff, and send dispatch remain disabled.",
+            "requiredBefore": "send_control_enabled",
+            "sideEffectPolicy": "no_prompt_capture_or_input_acceptance",
+        },
+        {
+            "gapId": "response_generation_boundary",
+            "label": "response generation boundary",
+            "area": "content",
+            "sourceRefs": [
+                "chat_response_stream",
+                "chat_message_list",
+                "chat_context_policy",
+            ],
+            "state": "disabled",
+            "severity": "blocker",
+            "summary": "Response generation, response chunks, token counts, context assembly, and transcript append remain disabled.",
+            "requiredBefore": "assistant_response_enabled",
+            "sideEffectPolicy": "no_response_generation_or_stream_transport",
+        },
+        {
+            "gapId": "session_store_boundary",
+            "label": "session store boundary",
+            "area": "session",
+            "sourceRefs": [
+                "chat_session",
+                "chat_session_lifecycle",
+                "chat_session_store_policy",
+                "chat_session_index",
+                "chat_session_title_policy",
+            ],
+            "state": "not_configured",
+            "severity": "blocker",
+            "summary": "Session store path, manifest, read, write, delete, restore, title, retention, migration, and export remain unconfigured.",
+            "requiredBefore": "session_management_enabled",
+            "sideEffectPolicy": "no_session_store_or_title_access",
+        },
+        {
+            "gapId": "transcript_export_boundary",
+            "label": "transcript and export boundary",
+            "area": "session",
+            "sourceRefs": [
+                "chat_transcript_policy",
+                "chat_action_bar",
+                "chat_session_lifecycle",
+            ],
+            "state": "disabled",
+            "severity": "blocker",
+            "summary": "Transcript reads, transcript persistence, export summary, raw export, and action-bar export controls remain disabled.",
+            "requiredBefore": "transcript_or_export_enabled",
+            "sideEffectPolicy": "no_transcript_read_write_or_export",
+        },
+        {
+            "gapId": "privacy_content_policy",
+            "label": "privacy and content policy",
+            "area": "privacy",
+            "sourceRefs": [
+                "chat_local_only_policy",
+                "chat_redaction_policy",
+                "chat_error_taxonomy",
+            ],
+            "state": "requires_review",
+            "severity": "blocker",
+            "summary": "Local-only policy, redaction, content scanning, detector execution, result persistence, and raw error payload handling remain review-only.",
+            "requiredBefore": "privacy_sensitive_content_paths_enabled",
+            "sideEffectPolicy": "no_content_scan_redaction_or_provider_call",
+        },
+        {
+            "gapId": "attachment_clipboard_boundary",
+            "label": "attachment and clipboard boundary",
+            "area": "input_output",
+            "sourceRefs": [
+                "chat_attachment_policy",
+                "chat_clipboard_policy",
+                "chat_action_bar",
+            ],
+            "state": "disabled",
+            "severity": "blocker",
+            "summary": "File picker, file metadata, file content, upload, import, preview, clipboard read, and clipboard write remain disabled.",
+            "requiredBefore": "attachment_or_clipboard_paths_enabled",
+            "sideEffectPolicy": "no_file_clipboard_or_directory_access",
+        },
+        {
+            "gapId": "audit_persistence_boundary",
+            "label": "audit persistence boundary",
+            "area": "audit",
+            "sourceRefs": [
+                "chat_audit_event",
+                "chat_redaction_policy",
+                "chat_review_packet",
+            ],
+            "state": "not_configured",
+            "severity": "blocker",
+            "summary": "Audit logging, event persistence, actor identifiers, raw logs, private paths, and generated blobs remain absent.",
+            "requiredBefore": "audit_logging_enabled",
+            "sideEffectPolicy": "no_audit_write_or_raw_log_read",
+        },
+        {
+            "gapId": "ui_enablement_boundary",
+            "label": "UI enablement boundary",
+            "area": "surface",
+            "sourceRefs": [
+                "chat_surface_layout",
+                "chat_empty_state",
+                "chat_action_bar",
+                "chat_shortcut_map",
+                "chat_status_summary",
+            ],
+            "state": "blocked",
+            "severity": "blocker",
+            "summary": "Surface layout, empty state, action-bar controls, shortcuts, and status cards remain display-only until the blocker rows close.",
+            "requiredBefore": "standalone_chat_ui_enabled",
+            "sideEffectPolicy": "no_action_execution_command_dispatch_or_focus_change",
+        },
+    ],
+    "dependencyRefs": [
+        {
+            "refId": "chat_review_packet",
+            "schemaVersion": "pccx.chatReviewPacket.v0",
+            "fixturePath": "contracts/fixtures/chat-review-packet.gemma3n-e4b-kv260-placeholder.json",
+            "state": "not_approved",
+            "summary": "Review packet remains blocked and records review gates only.",
+        },
+        {
+            "refId": "chat_status_summary",
+            "schemaVersion": "pccx.chatStatusSummary.v0",
+            "fixturePath": "contracts/fixtures/chat-status-summary.gemma3n-e4b-kv260-placeholder.json",
+            "state": "summary_only",
+            "summary": "Status summary remains a checked display aggregate and is not duplicated here.",
+        },
+        {
+            "refId": "chat_readiness",
+            "schemaVersion": "pccx.chatReadiness.v0",
+            "fixturePath": "contracts/fixtures/chat-readiness.gemma3n-e4b-kv260-placeholder.json",
+            "state": "blocked",
+            "summary": "Chat readiness remains blocked until runtime, device, model, store, and privacy evidence exists.",
+        },
+        {
+            "refId": "chat_model_load_request",
+            "schemaVersion": "pccx.chatModelLoadRequest.v0",
+            "fixturePath": "contracts/fixtures/chat-model-load-request.gemma3n-e4b-kv260-placeholder.json",
+            "state": "blocked",
+            "summary": "Model load request remains blocked with no model asset path read or load attempt.",
+        },
+        {
+            "refId": "chat_session_store_policy",
+            "schemaVersion": "pccx.chatSessionStorePolicy.v0",
+            "fixturePath": "contracts/fixtures/chat-session-store-policy.gemma3n-e4b-kv260-placeholder.json",
+            "state": "not_configured",
+            "summary": "Session store policy remains disabled and no local store is read.",
+        },
+        {
+            "refId": "chat_redaction_policy",
+            "schemaVersion": "pccx.chatRedactionPolicy.v0",
+            "fixturePath": "contracts/fixtures/chat-redaction-policy.gemma3n-e4b-kv260-placeholder.json",
+            "state": "summary_only",
+            "summary": "Redaction policy is referenced without loading rules, scanning content, or persisting results.",
+        },
+    ],
+    "exitCriteria": [
+        {
+            "criteriaId": "runtime_and_device_evidence_accepted",
+            "state": "requires_evidence",
+            "accepted": False,
+            "summary": "Runtime and device session evidence must be reviewed before runtime paths are enabled.",
+            "requiredEvidence": [
+                "runtime_readiness_with_reviewed_evidence",
+                "device_session_status_with_reviewed_target_state",
+            ],
+            "blockedBy": [
+                "runtime_device_evidence",
+            ],
+        },
+        {
+            "criteriaId": "model_and_session_boundaries_reviewed",
+            "state": "not_approved",
+            "accepted": False,
+            "summary": "Model asset and session-store boundaries must be reviewed before local chat state is enabled.",
+            "requiredEvidence": [
+                "reviewed_model_asset_boundary",
+                "reviewed_session_store_boundary",
+            ],
+            "blockedBy": [
+                "model_asset_boundary",
+                "session_store_boundary",
+            ],
+        },
+        {
+            "criteriaId": "content_privacy_boundaries_reviewed",
+            "state": "requires_review",
+            "accepted": False,
+            "summary": "Prompt, response, transcript, attachment, clipboard, redaction, and audit boundaries must be reviewed before content paths are enabled.",
+            "requiredEvidence": [
+                "reviewed_prompt_input_boundary",
+                "reviewed_response_stream_boundary",
+                "reviewed_privacy_policy_boundary",
+            ],
+            "blockedBy": [
+                "prompt_input_boundary",
+                "response_generation_boundary",
+                "privacy_content_policy",
+                "attachment_clipboard_boundary",
+                "audit_persistence_boundary",
+            ],
+        },
+    ],
+    "blockedReasons": [
+        {
+            "reasonId": "standalone_chat_not_enabled",
+            "state": "blocked",
+            "summary": "Standalone chat remains blocked because all gap rows are unresolved.",
+            "requiredBefore": "standalone_chat_enabled",
+        },
+        {
+            "reasonId": "review_packet_not_approved",
+            "state": "not_approved",
+            "summary": "The review packet is referenced but not approved by this matrix.",
+            "requiredBefore": "review_gate_closed",
+        },
+        {
+            "reasonId": "runtime_evidence_absent",
+            "state": "requires_evidence",
+            "summary": "Runtime, device, and hardware evidence remain outside this launcher boundary.",
+            "requiredBefore": "model_or_runtime_execution_enabled",
+        },
+        {
+            "reasonId": "content_paths_disabled",
+            "state": "disabled",
+            "summary": "Prompt, response, transcript, attachment, clipboard, redaction, audit, and export paths remain disabled.",
+            "requiredBefore": "content_or_io_enabled",
+        },
+    ],
+    "safetyFlags": {
+        "dataOnly": True,
+        "readOnly": True,
+        "deterministic": True,
+        "gapMatrixOnly": True,
+        "referencesCheckedFixturesOnly": True,
+        "reviewPacketReferencedOnly": True,
+        "statusSummaryReferencedOnly": True,
+        "gapClosed": False,
+        "approvalGranted": False,
+        "promptCapture": False,
+        "promptRead": False,
+        "promptContentIncluded": False,
+        "promptEchoed": False,
+        "inputAccepted": False,
+        "responseContentIncluded": False,
+        "responseGenerated": False,
+        "responseChunksEmitted": False,
+        "tokenCountMeasured": False,
+        "transcriptContentIncluded": False,
+        "messageBodiesIncluded": False,
+        "sessionStoreRead": False,
+        "sessionStoreWrite": False,
+        "sessionPersistence": False,
+        "summaryGenerated": False,
+        "transcriptExported": False,
+        "clipboardRead": False,
+        "clipboardWrite": False,
+        "attachmentReads": False,
+        "fileMetadataRead": False,
+        "fileContentRead": False,
+        "directoryScan": False,
+        "redactionRulesLoaded": False,
+        "contentScan": False,
+        "redactionApplied": False,
+        "auditLogWritten": False,
+        "configRead": False,
+        "environmentRead": False,
+        "providerConfigRead": False,
+        "modelAssetRead": False,
+        "modelPathIncluded": False,
+        "modelLoadAttempted": False,
+        "modelExecution": False,
+        "runtimeExecution": False,
+        "sendEnabled": False,
+        "readsArtifacts": False,
+        "writesArtifacts": False,
+        "kv260Access": False,
+        "hardwareAccess": False,
+        "networkCalls": False,
+        "providerCalls": False,
+        "cloudCalls": False,
+        "executesPccxLab": False,
+        "executesSystemverilogIde": False,
+        "commandDispatch": False,
+        "actionExecution": False,
+        "focusChanged": False,
+        "telemetry": False,
+        "writeBack": False,
+        "releaseOrTagAction": False,
+        "settingsChange": False,
+        "compatibilityClaim": False,
+    },
+    "limitations": [
+        "Data-only chat implementation gap matrix over existing checked fixture references.",
+        "No prompt, response, transcript, message, session-store, config, provider, model-path, runtime-log, artifact, private-path, secret, token, file, clipboard, or hardware content is read.",
+        "No model load, runtime execution, provider call, network call, hardware access, pccx-lab execution, IDE execution, telemetry, write-back, release, tag, settings, or repository action is performed.",
+        "This matrix does not close issue #9 or approve standalone chat enablement; it records remaining blocker rows only.",
+    ],
+    "issueRefs": [
+        "pccxai/pccx-llm-launcher#9",
+    ],
+}
+
+
+def create_gemma3n_e4b_kv260_chat_gap_matrix() -> dict:
+    """Return the checked Gemma 3N E4B plus KV260 chat gap matrix."""
+    return copy.deepcopy(_CHAT_GAP_MATRIX)
+
+
+def chat_gap_matrix_json(matrix: dict | None = None) -> str:
+    """Render a deterministic JSON representation."""
+    return json.dumps(
+        matrix
+        if matrix is not None
+        else create_gemma3n_e4b_kv260_chat_gap_matrix(),
+        indent=2,
+        sort_keys=True,
+    ) + "\n"
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Print data-only chat implementation gap matrix JSON.",
+    )
+    parser.add_argument(
+        "--model",
+        default="gemma3n-e4b",
+        choices=("gemma3n-e4b",),
+        help="model descriptor target",
+    )
+    parser.add_argument(
+        "--target",
+        default="kv260",
+        choices=("kv260",),
+        help="target board/device",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parse_args(sys.argv[1:] if argv is None else argv)
+    sys.stdout.write(chat_gap_matrix_json())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contracts/fixtures/chat-gap-matrix.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-gap-matrix.gemma3n-e4b-kv260-placeholder.json
@@ -1,0 +1,359 @@
+{
+  "blockedReasons": [
+    {
+      "reasonId": "standalone_chat_not_enabled",
+      "requiredBefore": "standalone_chat_enabled",
+      "state": "blocked",
+      "summary": "Standalone chat remains blocked because all gap rows are unresolved."
+    },
+    {
+      "reasonId": "review_packet_not_approved",
+      "requiredBefore": "review_gate_closed",
+      "state": "not_approved",
+      "summary": "The review packet is referenced but not approved by this matrix."
+    },
+    {
+      "reasonId": "runtime_evidence_absent",
+      "requiredBefore": "model_or_runtime_execution_enabled",
+      "state": "requires_evidence",
+      "summary": "Runtime, device, and hardware evidence remain outside this launcher boundary."
+    },
+    {
+      "reasonId": "content_paths_disabled",
+      "requiredBefore": "content_or_io_enabled",
+      "state": "disabled",
+      "summary": "Prompt, response, transcript, attachment, clipboard, redaction, audit, and export paths remain disabled."
+    }
+  ],
+  "dependencyRefs": [
+    {
+      "fixturePath": "contracts/fixtures/chat-review-packet.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_review_packet",
+      "schemaVersion": "pccx.chatReviewPacket.v0",
+      "state": "not_approved",
+      "summary": "Review packet remains blocked and records review gates only."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-status-summary.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_status_summary",
+      "schemaVersion": "pccx.chatStatusSummary.v0",
+      "state": "summary_only",
+      "summary": "Status summary remains a checked display aggregate and is not duplicated here."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-readiness.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_readiness",
+      "schemaVersion": "pccx.chatReadiness.v0",
+      "state": "blocked",
+      "summary": "Chat readiness remains blocked until runtime, device, model, store, and privacy evidence exists."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-model-load-request.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_model_load_request",
+      "schemaVersion": "pccx.chatModelLoadRequest.v0",
+      "state": "blocked",
+      "summary": "Model load request remains blocked with no model asset path read or load attempt."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-session-store-policy.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_session_store_policy",
+      "schemaVersion": "pccx.chatSessionStorePolicy.v0",
+      "state": "not_configured",
+      "summary": "Session store policy remains disabled and no local store is read."
+    },
+    {
+      "fixturePath": "contracts/fixtures/chat-redaction-policy.gemma3n-e4b-kv260-placeholder.json",
+      "refId": "chat_redaction_policy",
+      "schemaVersion": "pccx.chatRedactionPolicy.v0",
+      "state": "summary_only",
+      "summary": "Redaction policy is referenced without loading rules, scanning content, or persisting results."
+    }
+  ],
+  "evidenceState": "requires_evidence",
+  "exitCriteria": [
+    {
+      "accepted": false,
+      "blockedBy": [
+        "runtime_device_evidence"
+      ],
+      "criteriaId": "runtime_and_device_evidence_accepted",
+      "requiredEvidence": [
+        "runtime_readiness_with_reviewed_evidence",
+        "device_session_status_with_reviewed_target_state"
+      ],
+      "state": "requires_evidence",
+      "summary": "Runtime and device session evidence must be reviewed before runtime paths are enabled."
+    },
+    {
+      "accepted": false,
+      "blockedBy": [
+        "model_asset_boundary",
+        "session_store_boundary"
+      ],
+      "criteriaId": "model_and_session_boundaries_reviewed",
+      "requiredEvidence": [
+        "reviewed_model_asset_boundary",
+        "reviewed_session_store_boundary"
+      ],
+      "state": "not_approved",
+      "summary": "Model asset and session-store boundaries must be reviewed before local chat state is enabled."
+    },
+    {
+      "accepted": false,
+      "blockedBy": [
+        "prompt_input_boundary",
+        "response_generation_boundary",
+        "privacy_content_policy",
+        "attachment_clipboard_boundary",
+        "audit_persistence_boundary"
+      ],
+      "criteriaId": "content_privacy_boundaries_reviewed",
+      "requiredEvidence": [
+        "reviewed_prompt_input_boundary",
+        "reviewed_response_stream_boundary",
+        "reviewed_privacy_policy_boundary"
+      ],
+      "state": "requires_review",
+      "summary": "Prompt, response, transcript, attachment, clipboard, redaction, and audit boundaries must be reviewed before content paths are enabled."
+    }
+  ],
+  "fixtureVersion": "chat-gap-matrix.gemma3n-e4b-kv260.2026-05-05",
+  "gapMatrixId": "chat_gap_matrix_gemma3n_e4b_kv260_placeholder",
+  "gapRows": [
+    {
+      "area": "runtime",
+      "gapId": "runtime_device_evidence",
+      "label": "runtime and device evidence",
+      "requiredBefore": "model_or_runtime_execution_enabled",
+      "severity": "blocker",
+      "sideEffectPolicy": "no_runtime_or_hardware_action",
+      "sourceRefs": [
+        "runtime_readiness",
+        "device_session_status",
+        "chat_review_packet"
+      ],
+      "state": "requires_evidence",
+      "summary": "Runtime readiness and target device session evidence are still absent from this launcher boundary."
+    },
+    {
+      "area": "model",
+      "gapId": "model_asset_boundary",
+      "label": "model asset boundary",
+      "requiredBefore": "model_status_ready",
+      "severity": "blocker",
+      "sideEffectPolicy": "no_model_path_read_or_model_load",
+      "sourceRefs": [
+        "model_runtime_descriptor",
+        "chat_model_selection_policy",
+        "chat_model_load_request"
+      ],
+      "state": "not_loaded",
+      "summary": "Model path, asset discovery, checksum, tokenizer, load, warmup, unload, and persistence remain disabled."
+    },
+    {
+      "area": "content",
+      "gapId": "prompt_input_boundary",
+      "label": "prompt input boundary",
+      "requiredBefore": "send_control_enabled",
+      "severity": "blocker",
+      "sideEffectPolicy": "no_prompt_capture_or_input_acceptance",
+      "sourceRefs": [
+        "chat_composer",
+        "chat_send_result",
+        "chat_review_packet"
+      ],
+      "state": "disabled",
+      "summary": "Prompt capture, prompt read, prompt echo, accepted input, validation handoff, and send dispatch remain disabled."
+    },
+    {
+      "area": "content",
+      "gapId": "response_generation_boundary",
+      "label": "response generation boundary",
+      "requiredBefore": "assistant_response_enabled",
+      "severity": "blocker",
+      "sideEffectPolicy": "no_response_generation_or_stream_transport",
+      "sourceRefs": [
+        "chat_response_stream",
+        "chat_message_list",
+        "chat_context_policy"
+      ],
+      "state": "disabled",
+      "summary": "Response generation, response chunks, token counts, context assembly, and transcript append remain disabled."
+    },
+    {
+      "area": "session",
+      "gapId": "session_store_boundary",
+      "label": "session store boundary",
+      "requiredBefore": "session_management_enabled",
+      "severity": "blocker",
+      "sideEffectPolicy": "no_session_store_or_title_access",
+      "sourceRefs": [
+        "chat_session",
+        "chat_session_lifecycle",
+        "chat_session_store_policy",
+        "chat_session_index",
+        "chat_session_title_policy"
+      ],
+      "state": "not_configured",
+      "summary": "Session store path, manifest, read, write, delete, restore, title, retention, migration, and export remain unconfigured."
+    },
+    {
+      "area": "session",
+      "gapId": "transcript_export_boundary",
+      "label": "transcript and export boundary",
+      "requiredBefore": "transcript_or_export_enabled",
+      "severity": "blocker",
+      "sideEffectPolicy": "no_transcript_read_write_or_export",
+      "sourceRefs": [
+        "chat_transcript_policy",
+        "chat_action_bar",
+        "chat_session_lifecycle"
+      ],
+      "state": "disabled",
+      "summary": "Transcript reads, transcript persistence, export summary, raw export, and action-bar export controls remain disabled."
+    },
+    {
+      "area": "privacy",
+      "gapId": "privacy_content_policy",
+      "label": "privacy and content policy",
+      "requiredBefore": "privacy_sensitive_content_paths_enabled",
+      "severity": "blocker",
+      "sideEffectPolicy": "no_content_scan_redaction_or_provider_call",
+      "sourceRefs": [
+        "chat_local_only_policy",
+        "chat_redaction_policy",
+        "chat_error_taxonomy"
+      ],
+      "state": "requires_review",
+      "summary": "Local-only policy, redaction, content scanning, detector execution, result persistence, and raw error payload handling remain review-only."
+    },
+    {
+      "area": "input_output",
+      "gapId": "attachment_clipboard_boundary",
+      "label": "attachment and clipboard boundary",
+      "requiredBefore": "attachment_or_clipboard_paths_enabled",
+      "severity": "blocker",
+      "sideEffectPolicy": "no_file_clipboard_or_directory_access",
+      "sourceRefs": [
+        "chat_attachment_policy",
+        "chat_clipboard_policy",
+        "chat_action_bar"
+      ],
+      "state": "disabled",
+      "summary": "File picker, file metadata, file content, upload, import, preview, clipboard read, and clipboard write remain disabled."
+    },
+    {
+      "area": "audit",
+      "gapId": "audit_persistence_boundary",
+      "label": "audit persistence boundary",
+      "requiredBefore": "audit_logging_enabled",
+      "severity": "blocker",
+      "sideEffectPolicy": "no_audit_write_or_raw_log_read",
+      "sourceRefs": [
+        "chat_audit_event",
+        "chat_redaction_policy",
+        "chat_review_packet"
+      ],
+      "state": "not_configured",
+      "summary": "Audit logging, event persistence, actor identifiers, raw logs, private paths, and generated blobs remain absent."
+    },
+    {
+      "area": "surface",
+      "gapId": "ui_enablement_boundary",
+      "label": "UI enablement boundary",
+      "requiredBefore": "standalone_chat_ui_enabled",
+      "severity": "blocker",
+      "sideEffectPolicy": "no_action_execution_command_dispatch_or_focus_change",
+      "sourceRefs": [
+        "chat_surface_layout",
+        "chat_empty_state",
+        "chat_action_bar",
+        "chat_shortcut_map",
+        "chat_status_summary"
+      ],
+      "state": "blocked",
+      "summary": "Surface layout, empty state, action-bar controls, shortcuts, and status cards remain display-only until the blocker rows close."
+    }
+  ],
+  "issueRefs": [
+    "pccxai/pccx-llm-launcher#9"
+  ],
+  "lastUpdatedSource": "pccx_launcher_issue_9_chat_gap_matrix_boundary_2026-05-05",
+  "limitations": [
+    "Data-only chat implementation gap matrix over existing checked fixture references.",
+    "No prompt, response, transcript, message, session-store, config, provider, model-path, runtime-log, artifact, private-path, secret, token, file, clipboard, or hardware content is read.",
+    "No model load, runtime execution, provider call, network call, hardware access, pccx-lab execution, IDE execution, telemetry, write-back, release, tag, settings, or repository action is performed.",
+    "This matrix does not close issue #9 or approve standalone chat enablement; it records remaining blocker rows only."
+  ],
+  "matrixState": "available_as_data",
+  "readinessState": "blocked",
+  "reviewState": "not_approved",
+  "safetyFlags": {
+    "actionExecution": false,
+    "approvalGranted": false,
+    "attachmentReads": false,
+    "auditLogWritten": false,
+    "clipboardRead": false,
+    "clipboardWrite": false,
+    "cloudCalls": false,
+    "commandDispatch": false,
+    "compatibilityClaim": false,
+    "configRead": false,
+    "contentScan": false,
+    "dataOnly": true,
+    "deterministic": true,
+    "directoryScan": false,
+    "environmentRead": false,
+    "executesPccxLab": false,
+    "executesSystemverilogIde": false,
+    "fileContentRead": false,
+    "fileMetadataRead": false,
+    "focusChanged": false,
+    "gapClosed": false,
+    "gapMatrixOnly": true,
+    "hardwareAccess": false,
+    "inputAccepted": false,
+    "kv260Access": false,
+    "messageBodiesIncluded": false,
+    "modelAssetRead": false,
+    "modelExecution": false,
+    "modelLoadAttempted": false,
+    "modelPathIncluded": false,
+    "networkCalls": false,
+    "promptCapture": false,
+    "promptContentIncluded": false,
+    "promptEchoed": false,
+    "promptRead": false,
+    "providerCalls": false,
+    "providerConfigRead": false,
+    "readOnly": true,
+    "readsArtifacts": false,
+    "redactionApplied": false,
+    "redactionRulesLoaded": false,
+    "referencesCheckedFixturesOnly": true,
+    "releaseOrTagAction": false,
+    "responseChunksEmitted": false,
+    "responseContentIncluded": false,
+    "responseGenerated": false,
+    "reviewPacketReferencedOnly": true,
+    "runtimeExecution": false,
+    "sendEnabled": false,
+    "sessionPersistence": false,
+    "sessionStoreRead": false,
+    "sessionStoreWrite": false,
+    "settingsChange": false,
+    "statusSummaryReferencedOnly": true,
+    "summaryGenerated": false,
+    "telemetry": false,
+    "tokenCountMeasured": false,
+    "transcriptContentIncluded": false,
+    "transcriptExported": false,
+    "writeBack": false,
+    "writesArtifacts": false
+  },
+  "schemaVersion": "pccx.chatGapMatrix.v0",
+  "standaloneChatState": "blocked",
+  "targetBoard": "xilinx_kria_kv260",
+  "targetDevice": "kv260",
+  "targetModel": "gemma3n-e4b"
+}

--- a/scripts/chat-gap-matrix-stub.sh
+++ b/scripts/chat-gap-matrix-stub.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+# Print the data-only chat implementation gap matrix contract.
+
+set -eu
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+
+python3 "$ROOT_DIR/contracts/chat_gap_matrix_contract.py" "$@"

--- a/scripts/status-stub.sh
+++ b/scripts/status-stub.sh
@@ -91,6 +91,9 @@
 # Chat review-packet aggregate (explicit opt-in, read-only local data):
 #   --include-chat-review-packet
 #
+# Chat implementation gap matrix (explicit opt-in, read-only local data):
+#   --include-chat-gap-matrix
+#
 # pccx-lab backend (explicit opt-in):
 #   --backend pccx-lab        call pccx-lab status --format json
 #   PCCX_LAB_BIN              override path to pccx-lab binary (takes priority over PATH)
@@ -135,6 +138,7 @@ INCLUDE_CHAT_ATTACHMENT_POLICY="0"
 INCLUDE_CHAT_SHORTCUT_MAP="0"
 INCLUDE_CHAT_STATUS_SUMMARY="0"
 INCLUDE_CHAT_REVIEW_PACKET="0"
+INCLUDE_CHAT_GAP_MATRIX="0"
 
 print_chat_status_summary_summary() {
     SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
@@ -368,6 +372,150 @@ print(
 
     HEAD "chat review packet"
     printf '%s\n' "$CHAT_REVIEW_PACKET_TEXT"
+}
+
+print_chat_gap_matrix_summary() {
+    SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+    ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+    CHAT_GAP_MATRIX_STUB="$ROOT_DIR/scripts/chat-gap-matrix-stub.sh"
+
+    if [ ! -f "$CHAT_GAP_MATRIX_STUB" ]; then
+        ERROR "chat gap-matrix stub not found: $CHAT_GAP_MATRIX_STUB"
+        return 1
+    fi
+
+    if ! CHAT_GAP_MATRIX_JSON="$(bash "$CHAT_GAP_MATRIX_STUB" --model gemma3n-e4b --target kv260 2>&1)"; then
+        ERROR "chat gap-matrix stub failed"
+        printf '%s\n' "$CHAT_GAP_MATRIX_JSON" >&2
+        return 1
+    fi
+
+    if ! CHAT_GAP_MATRIX_TEXT="$(
+        printf '%s\n' "$CHAT_GAP_MATRIX_JSON" | python3 -c '
+import json
+import sys
+
+data = json.load(sys.stdin)
+flags = data["safetyFlags"]
+gaps = " ".join(
+    "{}={}:{}".format(row["gapId"], row["state"], row["severity"])
+    for row in data["gapRows"]
+)
+refs = " ".join(
+    "{}={}".format(ref["refId"], ref["state"])
+    for ref in data["dependencyRefs"]
+)
+criteria = " ".join(
+    "{}={}:{}".format(item["criteriaId"], item["state"], str(item["accepted"]).lower())
+    for item in data["exitCriteria"]
+)
+blocked = " ".join(
+    "{}={}".format(reason["reasonId"], reason["state"])
+    for reason in data["blockedReasons"]
+)
+
+def b(value):
+    return "true" if value else "false"
+
+print("[INFO]  source     : scripts/chat-gap-matrix-stub.sh --model gemma3n-e4b --target kv260")
+print("[INFO]  boundary   : read-only data; no prompt/session-store/model/runtime/provider/hardware/lab/IDE/artifact execution")
+print("[INFO]  target     : {}".format(data["targetDevice"]))
+print("[INFO]  model      : {}".format(data["targetModel"]))
+print("[INFO]  matrix     : {}".format(data["matrixState"]))
+print("[INFO]  standalone : {}".format(data["standaloneChatState"]))
+print("[INFO]  review    : {}".format(data["reviewState"]))
+print("[INFO]  evidence  : {}".format(data["evidenceState"]))
+print("[INFO]  readiness : {}".format(data["readinessState"]))
+print("[INFO]  gaps       : {}".format(gaps))
+print("[INFO]  refs       : {}".format(refs))
+print("[INFO]  criteria   : {}".format(criteria))
+print("[INFO]  blocked    : {}".format(blocked))
+print(
+    "[INFO]  flags      : readOnly={} dataOnly={} deterministic={} "
+    "gapMatrixOnly={} referencesCheckedFixturesOnly={} "
+    "reviewPacketReferencedOnly={} statusSummaryReferencedOnly={} "
+    "gapClosed={} approvalGranted={} promptCapture={} promptRead={} "
+    "promptContentIncluded={} promptEchoed={} inputAccepted={} "
+    "responseContentIncluded={} responseGenerated={} responseChunksEmitted={} "
+    "tokenCountMeasured={} transcriptContentIncluded={} "
+    "messageBodiesIncluded={} sessionStoreRead={} sessionStoreWrite={} "
+    "sessionPersistence={} summaryGenerated={} transcriptExported={} "
+    "clipboardRead={} clipboardWrite={} attachmentReads={} "
+    "fileMetadataRead={} fileContentRead={} directoryScan={} "
+    "redactionRulesLoaded={} contentScan={} redactionApplied={} "
+    "auditLogWritten={} configRead={} environmentRead={} "
+    "providerConfigRead={} modelAssetRead={} modelPathIncluded={} "
+    "modelLoadAttempted={} modelExecution={} runtimeExecution={} "
+    "sendEnabled={} readsArtifacts={} writesArtifacts={} kv260Access={} "
+    "hardwareAccess={} networkCalls={} providerCalls={} cloudCalls={} "
+    "executesPccxLab={} executesSystemverilogIde={} commandDispatch={} "
+    "actionExecution={} focusChanged={}".format(
+        b(flags["readOnly"]),
+        b(flags["dataOnly"]),
+        b(flags["deterministic"]),
+        b(flags["gapMatrixOnly"]),
+        b(flags["referencesCheckedFixturesOnly"]),
+        b(flags["reviewPacketReferencedOnly"]),
+        b(flags["statusSummaryReferencedOnly"]),
+        b(flags["gapClosed"]),
+        b(flags["approvalGranted"]),
+        b(flags["promptCapture"]),
+        b(flags["promptRead"]),
+        b(flags["promptContentIncluded"]),
+        b(flags["promptEchoed"]),
+        b(flags["inputAccepted"]),
+        b(flags["responseContentIncluded"]),
+        b(flags["responseGenerated"]),
+        b(flags["responseChunksEmitted"]),
+        b(flags["tokenCountMeasured"]),
+        b(flags["transcriptContentIncluded"]),
+        b(flags["messageBodiesIncluded"]),
+        b(flags["sessionStoreRead"]),
+        b(flags["sessionStoreWrite"]),
+        b(flags["sessionPersistence"]),
+        b(flags["summaryGenerated"]),
+        b(flags["transcriptExported"]),
+        b(flags["clipboardRead"]),
+        b(flags["clipboardWrite"]),
+        b(flags["attachmentReads"]),
+        b(flags["fileMetadataRead"]),
+        b(flags["fileContentRead"]),
+        b(flags["directoryScan"]),
+        b(flags["redactionRulesLoaded"]),
+        b(flags["contentScan"]),
+        b(flags["redactionApplied"]),
+        b(flags["auditLogWritten"]),
+        b(flags["configRead"]),
+        b(flags["environmentRead"]),
+        b(flags["providerConfigRead"]),
+        b(flags["modelAssetRead"]),
+        b(flags["modelPathIncluded"]),
+        b(flags["modelLoadAttempted"]),
+        b(flags["modelExecution"]),
+        b(flags["runtimeExecution"]),
+        b(flags["sendEnabled"]),
+        b(flags["readsArtifacts"]),
+        b(flags["writesArtifacts"]),
+        b(flags["kv260Access"]),
+        b(flags["hardwareAccess"]),
+        b(flags["networkCalls"]),
+        b(flags["providerCalls"]),
+        b(flags["cloudCalls"]),
+        b(flags["executesPccxLab"]),
+        b(flags["executesSystemverilogIde"]),
+        b(flags["commandDispatch"]),
+        b(flags["actionExecution"]),
+        b(flags["focusChanged"]),
+    )
+)
+'
+    )"; then
+        ERROR "chat gap-matrix JSON could not be summarized"
+        return 1
+    fi
+
+    HEAD "chat gap matrix"
+    printf '%s\n' "$CHAT_GAP_MATRIX_TEXT"
 }
 
 print_chat_error_taxonomy_summary() {
@@ -3548,6 +3696,10 @@ while [ $# -gt 0 ]; do
             INCLUDE_CHAT_REVIEW_PACKET="1"
             shift
             ;;
+        --include-chat-gap-matrix)
+            INCLUDE_CHAT_GAP_MATRIX="1"
+            shift
+            ;;
         --backend)
             BACKEND="${2:-}"
             if [ -z "$BACKEND" ]; then
@@ -3563,8 +3715,8 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-if [ -n "$BACKEND" ] && { [ "$INCLUDE_RUNTIME_READINESS" = "1" ] || [ "$INCLUDE_DEVICE_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SURFACE_LAYOUT" = "1" ] || [ "$INCLUDE_CHAT_EMPTY_STATE" = "1" ] || [ "$INCLUDE_CHAT_LOCAL_ONLY_POLICY" = "1" ] || [ "$INCLUDE_CHAT_PREFERENCES" = "1" ] || [ "$INCLUDE_CHAT_SESSION_INDEX" = "1" ] || [ "$INCLUDE_CHAT_SESSION_STORE_POLICY" = "1" ] || [ "$INCLUDE_CHAT_SESSION_TITLE_POLICY" = "1" ] || [ "$INCLUDE_CHAT_MODEL_STATUS" = "1" ] || [ "$INCLUDE_CHAT_MODEL_SELECTION_POLICY" = "1" ] || [ "$INCLUDE_CHAT_CONTEXT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_MODEL_LOAD_REQUEST" = "1" ] || [ "$INCLUDE_CHAT_READINESS" = "1" ] || [ "$INCLUDE_CHAT_COMPOSER" = "1" ] || [ "$INCLUDE_CHAT_SEND_RESULT" = "1" ] || [ "$INCLUDE_CHAT_TRANSCRIPT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_AUDIT_EVENT" = "1" ] || [ "$INCLUDE_CHAT_ERROR_TAXONOMY" = "1" ] || [ "$INCLUDE_CHAT_RESPONSE_STREAM" = "1" ] || [ "$INCLUDE_CHAT_MESSAGE_LIST" = "1" ] || [ "$INCLUDE_CHAT_ACTION_BAR" = "1" ] || [ "$INCLUDE_CHAT_CLIPBOARD_POLICY" = "1" ] || [ "$INCLUDE_CHAT_REDACTION_POLICY" = "1" ] || [ "$INCLUDE_CHAT_ATTACHMENT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_SHORTCUT_MAP" = "1" ] || [ "$INCLUDE_CHAT_STATUS_SUMMARY" = "1" ] || [ "$INCLUDE_CHAT_REVIEW_PACKET" = "1" ]; }; then
-    ERROR "--include-runtime-readiness, --include-device-session, --include-chat-session, --include-chat-surface-layout, --include-chat-empty-state, --include-chat-local-only-policy, --include-chat-preferences, --include-chat-session-index, --include-chat-session-store-policy, --include-chat-session-title-policy, --include-chat-model-status, --include-chat-model-selection-policy, --include-chat-context-policy, --include-chat-model-load-request, --include-chat-readiness, --include-chat-composer, --include-chat-send-result, --include-chat-transcript-policy, --include-chat-audit-event, --include-chat-error-taxonomy, --include-chat-response-stream, --include-chat-message-list, --include-chat-action-bar, --include-chat-clipboard-policy, --include-chat-redaction-policy, --include-chat-attachment-policy, --include-chat-shortcut-map, --include-chat-status-summary, and --include-chat-review-packet are only supported in local scaffold mode"
+if [ -n "$BACKEND" ] && { [ "$INCLUDE_RUNTIME_READINESS" = "1" ] || [ "$INCLUDE_DEVICE_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SESSION" = "1" ] || [ "$INCLUDE_CHAT_SURFACE_LAYOUT" = "1" ] || [ "$INCLUDE_CHAT_EMPTY_STATE" = "1" ] || [ "$INCLUDE_CHAT_LOCAL_ONLY_POLICY" = "1" ] || [ "$INCLUDE_CHAT_PREFERENCES" = "1" ] || [ "$INCLUDE_CHAT_SESSION_INDEX" = "1" ] || [ "$INCLUDE_CHAT_SESSION_STORE_POLICY" = "1" ] || [ "$INCLUDE_CHAT_SESSION_TITLE_POLICY" = "1" ] || [ "$INCLUDE_CHAT_MODEL_STATUS" = "1" ] || [ "$INCLUDE_CHAT_MODEL_SELECTION_POLICY" = "1" ] || [ "$INCLUDE_CHAT_CONTEXT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_MODEL_LOAD_REQUEST" = "1" ] || [ "$INCLUDE_CHAT_READINESS" = "1" ] || [ "$INCLUDE_CHAT_COMPOSER" = "1" ] || [ "$INCLUDE_CHAT_SEND_RESULT" = "1" ] || [ "$INCLUDE_CHAT_TRANSCRIPT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_AUDIT_EVENT" = "1" ] || [ "$INCLUDE_CHAT_ERROR_TAXONOMY" = "1" ] || [ "$INCLUDE_CHAT_RESPONSE_STREAM" = "1" ] || [ "$INCLUDE_CHAT_MESSAGE_LIST" = "1" ] || [ "$INCLUDE_CHAT_ACTION_BAR" = "1" ] || [ "$INCLUDE_CHAT_CLIPBOARD_POLICY" = "1" ] || [ "$INCLUDE_CHAT_REDACTION_POLICY" = "1" ] || [ "$INCLUDE_CHAT_ATTACHMENT_POLICY" = "1" ] || [ "$INCLUDE_CHAT_SHORTCUT_MAP" = "1" ] || [ "$INCLUDE_CHAT_STATUS_SUMMARY" = "1" ] || [ "$INCLUDE_CHAT_REVIEW_PACKET" = "1" ] || [ "$INCLUDE_CHAT_GAP_MATRIX" = "1" ]; }; then
+    ERROR "--include-runtime-readiness, --include-device-session, --include-chat-session, --include-chat-surface-layout, --include-chat-empty-state, --include-chat-local-only-policy, --include-chat-preferences, --include-chat-session-index, --include-chat-session-store-policy, --include-chat-session-title-policy, --include-chat-model-status, --include-chat-model-selection-policy, --include-chat-context-policy, --include-chat-model-load-request, --include-chat-readiness, --include-chat-composer, --include-chat-send-result, --include-chat-transcript-policy, --include-chat-audit-event, --include-chat-error-taxonomy, --include-chat-response-stream, --include-chat-message-list, --include-chat-action-bar, --include-chat-clipboard-policy, --include-chat-redaction-policy, --include-chat-attachment-policy, --include-chat-shortcut-map, --include-chat-status-summary, --include-chat-review-packet, and --include-chat-gap-matrix are only supported in local scaffold mode"
     exit 1
 fi
 
@@ -3606,7 +3758,14 @@ if [ -z "$BACKEND" ]; then
     NOTE "chat shortcuts: opt-in via --include-chat-shortcut-map (read-only disabled shortcut-map data)"
     NOTE "chat summary  : opt-in via --include-chat-status-summary (read-only aggregate status data)"
     NOTE "chat review   : opt-in via --include-chat-review-packet (read-only review packet data)"
+    NOTE "chat gaps     : opt-in via --include-chat-gap-matrix (read-only implementation gap data)"
     NOTE "editor bridge  : planned (VS Code / other IDEs)"
+
+    if [ "$INCLUDE_CHAT_GAP_MATRIX" = "1" ]; then
+        if ! print_chat_gap_matrix_summary; then
+            exit 1
+        fi
+    fi
 
     if [ "$INCLUDE_CHAT_REVIEW_PACKET" = "1" ]; then
         if ! print_chat_review_packet_summary; then

--- a/scripts/tests/chat_gap_matrix_contract_test.py
+++ b/scripts/tests/chat_gap_matrix_contract_test.py
@@ -1,0 +1,387 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Fixture tests for the standalone chat gap-matrix contract."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "contracts" / "chat_gap_matrix_contract.py"
+FIXTURE_PATH = (
+    ROOT
+    / "contracts"
+    / "fixtures"
+    / "chat-gap-matrix.gemma3n-e4b-kv260-placeholder.json"
+)
+SCRIPT_PATH = ROOT / "scripts" / "chat-gap-matrix-stub.sh"
+STATUS_TEST_PATH = ROOT / "scripts" / "tests" / "status-chat-gap-matrix.sh"
+README_PATH = ROOT / "README.md"
+TEST_PATH = Path(__file__).resolve()
+CI_PATH = ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location(
+        "chat_gap_matrix_contract",
+        MODULE_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def flatten(value) -> str:
+    return json.dumps(value, sort_keys=True)
+
+
+def iter_state_values(value):
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            if key == "state" or key.endswith("State") or key.endswith("Status"):
+                yield nested
+            yield from iter_state_values(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            yield from iter_state_values(nested)
+
+
+def iter_keys(value):
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            yield key
+            yield from iter_keys(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            yield from iter_keys(nested)
+
+
+def assert_no_private_or_generated_data(text: str) -> None:
+    forbidden_patterns = [
+        r"/home/[^\s\"']+",
+        r"/Users/[^\s\"']+",
+        r"[A-Za-z]:\\Users\\",
+        r"\b(?:api[_-]?key|authorization|bearer|client[_-]?secret|password|private[_-]?key|secret|token)\b\s*[:=]",
+        r"\.(?:gguf|safetensors|ckpt|pt|pth|onnx)\b",
+        r"(?:weights|model_weights|model-cache)/(?:[^\"'\s]+)",
+        r"(?:raw[_-]?full[_-]?logs|hardware[_-]?dump|generated[_-]?blob)\s*[:=]",
+    ]
+    for pattern in forbidden_patterns:
+        assert not re.search(pattern, text, re.IGNORECASE), pattern
+
+
+def assert_no_runtime_implementation_terms(source: str) -> None:
+    forbidden = [
+        "subprocess",
+        "os.system",
+        "popen",
+        "socket",
+        "urllib",
+        "requests",
+        "http.client",
+        "openai",
+        "anthropic",
+        "gemini",
+        "modelcontextprotocol",
+        "websocket",
+        "xmutil",
+        "xrt-smi",
+        "lsusb",
+        "dmesg",
+    ]
+    lowered = source.lower()
+    for term in forbidden:
+        assert term not in lowered, term
+
+
+def assert_no_provider_configs(value) -> None:
+    forbidden_keys = {
+        "apiKey",
+        "accessToken",
+        "refreshToken",
+        "authorization",
+        "bearerToken",
+        "provider",
+        "providers",
+        "providerConfig",
+        "providerConfigs",
+    }
+    for key in iter_keys(value):
+        assert key not in forbidden_keys, key
+
+
+def assert_no_unsupported_claims(text: str) -> None:
+    literal_claims = [
+        "production" + "-ready",
+        "marketplace" + "-ready",
+        "stable " + "API",
+        "stable " + "ABI",
+        "KV260 inference " + "works",
+        "Gemma 3N E4B " + "runs on KV260",
+        "20 tok/s " + "achieved",
+        "timing " + "closed",
+        "bitstream " + "ready",
+        "launcher executes " + "pccx-lab",
+        "IDE controls " + "launcher",
+        "AI provider integration " + "is live",
+    ]
+    lowered = text.lower()
+    for claim in literal_claims:
+        assert claim.lower() not in lowered, claim
+
+
+def test_chat_gap_matrix_matches_fixture_and_is_deterministic() -> None:
+    module = load_module()
+    generated = module.create_gemma3n_e4b_kv260_chat_gap_matrix()
+    fixture = json.loads(read_text(FIXTURE_PATH))
+
+    assert generated == fixture
+    assert module.chat_gap_matrix_json(generated) == (
+        module.chat_gap_matrix_json(generated)
+    )
+    assert module.chat_gap_matrix_json(generated).endswith("\n")
+    assert json.loads(module.chat_gap_matrix_json(generated)) == fixture
+
+
+def test_cli_stub_outputs_deterministic_json() -> None:
+    fixture = json.loads(read_text(FIXTURE_PATH))
+    command = [
+        "bash",
+        str(SCRIPT_PATH),
+        "--model",
+        "gemma3n-e4b",
+        "--target",
+        "kv260",
+    ]
+    first = subprocess.run(command, check=True, capture_output=True, text=True)
+    second = subprocess.run(command, check=True, capture_output=True, text=True)
+
+    assert first.stderr == ""
+    assert first.stdout == second.stdout
+    assert first.stdout.endswith("\n")
+    assert json.loads(first.stdout) == fixture
+
+
+def test_required_fields_and_allowed_states() -> None:
+    module = load_module()
+    matrix = module.create_gemma3n_e4b_kv260_chat_gap_matrix()
+    allowed = set(module.CHAT_GAP_MATRIX_STATE_VALUES)
+
+    assert tuple(matrix.keys()) == module.CHAT_GAP_MATRIX_FIELDS
+    assert matrix["schemaVersion"] == "pccx.chatGapMatrix.v0"
+
+    states = list(iter_state_values(matrix))
+    assert states
+    for state in states:
+        assert state in allowed, state
+
+    for row in matrix["gapRows"]:
+        assert tuple(row.keys()) == module.GAP_ROW_FIELDS
+    for ref in matrix["dependencyRefs"]:
+        assert tuple(ref.keys()) == module.DEPENDENCY_REF_FIELDS
+    for criteria in matrix["exitCriteria"]:
+        assert tuple(criteria.keys()) == module.EXIT_CRITERIA_FIELDS
+    for reason in matrix["blockedReasons"]:
+        assert tuple(reason.keys()) == module.BLOCKED_REASON_FIELDS
+
+
+def test_chat_gap_matrix_tracks_unresolved_blockers_without_closing_them() -> None:
+    matrix = load_module().create_gemma3n_e4b_kv260_chat_gap_matrix()
+    rows = {row["gapId"]: row for row in matrix["gapRows"]}
+    refs = {ref["refId"]: ref for ref in matrix["dependencyRefs"]}
+    criteria = {item["criteriaId"]: item for item in matrix["exitCriteria"]}
+    reasons = {reason["reasonId"]: reason for reason in matrix["blockedReasons"]}
+
+    assert matrix["matrixState"] == "available_as_data"
+    assert matrix["standaloneChatState"] == "blocked"
+    assert matrix["reviewState"] == "not_approved"
+    assert matrix["evidenceState"] == "requires_evidence"
+    assert matrix["readinessState"] == "blocked"
+    assert set(rows) == {
+        "runtime_device_evidence",
+        "model_asset_boundary",
+        "prompt_input_boundary",
+        "response_generation_boundary",
+        "session_store_boundary",
+        "transcript_export_boundary",
+        "privacy_content_policy",
+        "attachment_clipboard_boundary",
+        "audit_persistence_boundary",
+        "ui_enablement_boundary",
+    }
+    assert rows["runtime_device_evidence"]["state"] == "requires_evidence"
+    assert rows["model_asset_boundary"]["state"] == "not_loaded"
+    assert rows["prompt_input_boundary"]["sideEffectPolicy"] == (
+        "no_prompt_capture_or_input_acceptance"
+    )
+    assert rows["attachment_clipboard_boundary"]["sideEffectPolicy"] == (
+        "no_file_clipboard_or_directory_access"
+    )
+    assert set(refs) == {
+        "chat_review_packet",
+        "chat_status_summary",
+        "chat_readiness",
+        "chat_model_load_request",
+        "chat_session_store_policy",
+        "chat_redaction_policy",
+    }
+    assert refs["chat_review_packet"]["state"] == "not_approved"
+    assert refs["chat_status_summary"]["state"] == "summary_only"
+    assert set(criteria) == {
+        "runtime_and_device_evidence_accepted",
+        "model_and_session_boundaries_reviewed",
+        "content_privacy_boundaries_reviewed",
+    }
+    for item in criteria.values():
+        assert item["accepted"] is False
+    assert set(reasons) == {
+        "standalone_chat_not_enabled",
+        "review_packet_not_approved",
+        "runtime_evidence_absent",
+        "content_paths_disabled",
+    }
+
+
+def test_safety_flags_preserve_gap_matrix_only_boundary() -> None:
+    matrix = load_module().create_gemma3n_e4b_kv260_chat_gap_matrix()
+    flags = matrix["safetyFlags"]
+
+    assert flags["dataOnly"] is True
+    assert flags["readOnly"] is True
+    assert flags["deterministic"] is True
+    assert flags["gapMatrixOnly"] is True
+    assert flags["referencesCheckedFixturesOnly"] is True
+    assert flags["reviewPacketReferencedOnly"] is True
+    assert flags["statusSummaryReferencedOnly"] is True
+    for name in [
+        "gapClosed",
+        "approvalGranted",
+        "promptCapture",
+        "promptRead",
+        "promptContentIncluded",
+        "promptEchoed",
+        "inputAccepted",
+        "responseContentIncluded",
+        "responseGenerated",
+        "responseChunksEmitted",
+        "tokenCountMeasured",
+        "transcriptContentIncluded",
+        "messageBodiesIncluded",
+        "sessionStoreRead",
+        "sessionStoreWrite",
+        "sessionPersistence",
+        "summaryGenerated",
+        "transcriptExported",
+        "clipboardRead",
+        "clipboardWrite",
+        "attachmentReads",
+        "fileMetadataRead",
+        "fileContentRead",
+        "directoryScan",
+        "redactionRulesLoaded",
+        "contentScan",
+        "redactionApplied",
+        "auditLogWritten",
+        "configRead",
+        "environmentRead",
+        "providerConfigRead",
+        "modelAssetRead",
+        "modelPathIncluded",
+        "modelLoadAttempted",
+        "modelExecution",
+        "runtimeExecution",
+        "sendEnabled",
+        "readsArtifacts",
+        "writesArtifacts",
+        "kv260Access",
+        "hardwareAccess",
+        "networkCalls",
+        "providerCalls",
+        "cloudCalls",
+        "executesPccxLab",
+        "executesSystemverilogIde",
+        "commandDispatch",
+        "actionExecution",
+        "focusChanged",
+        "telemetry",
+        "writeBack",
+        "releaseOrTagAction",
+        "settingsChange",
+        "compatibilityClaim",
+    ]:
+        assert flags[name] is False, name
+
+
+def test_docs_and_sources_avoid_private_data_runtime_calls_or_overclaims() -> None:
+    module_source = read_text(MODULE_PATH)
+    script_source = read_text(SCRIPT_PATH)
+    status_test_source = read_text(STATUS_TEST_PATH)
+    matrix = load_module().create_gemma3n_e4b_kv260_chat_gap_matrix()
+    scan_text = "\n".join([
+        read_text(FIXTURE_PATH),
+        read_text(README_PATH),
+        flatten(matrix),
+        module_source,
+        script_source,
+        status_test_source,
+    ])
+    runtime_source = "\n".join([module_source, script_source])
+
+    assert_no_runtime_implementation_terms(runtime_source)
+    assert_no_private_or_generated_data(scan_text)
+    assert_no_provider_configs(matrix)
+    assert_no_unsupported_claims(scan_text)
+
+
+def test_source_headers_for_touched_code_files() -> None:
+    expected_headers = {
+        MODULE_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        SCRIPT_PATH: [
+            "#!/usr/bin/env bash",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        STATUS_TEST_PATH: [
+            "#!/usr/bin/env bash",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        TEST_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        CI_PATH: [
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+    }
+
+    for path, header in expected_headers.items():
+        assert read_text(path).splitlines()[: len(header)] == header, path
+
+
+test_chat_gap_matrix_matches_fixture_and_is_deterministic()
+test_cli_stub_outputs_deterministic_json()
+test_required_fields_and_allowed_states()
+test_chat_gap_matrix_tracks_unresolved_blockers_without_closing_them()
+test_safety_flags_preserve_gap_matrix_only_boundary()
+test_docs_and_sources_avoid_private_data_runtime_calls_or_overclaims()
+test_source_headers_for_touched_code_files()
+
+print("chat gap matrix contract tests ok")

--- a/scripts/tests/status-chat-gap-matrix.sh
+++ b/scripts/tests/status-chat-gap-matrix.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+# scripts/tests/status-chat-gap-matrix.sh - status chat gap-matrix tests.
+#
+# Usage: bash scripts/tests/status-chat-gap-matrix.sh [path/to/status-stub.sh]
+
+set -eu
+
+PASS() { printf '[PASS]  %s\n' "$*"; }
+FAIL() { printf '[FAIL] %s\n' "$*" >&2; }
+HEAD() { printf '\n=== %s ===\n' "$*"; }
+
+STUB="${1:-scripts/status-stub.sh}"
+
+if [ ! -x "$STUB" ]; then
+    chmod +x "$STUB"
+fi
+
+contains() {
+    case "$1" in
+        *"$2"*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+require_contains() {
+    local output="$1"
+    local expected="$2"
+    if ! contains "$output" "$expected"; then
+        FAIL "expected output to contain: $expected"
+        printf '%s\n' "$output" >&2
+        exit 1
+    fi
+}
+
+require_not_contains() {
+    local output="$1"
+    local forbidden="$2"
+    if contains "$output" "$forbidden"; then
+        FAIL "output contained forbidden text: $forbidden"
+        printf '%s\n' "$output" >&2
+        exit 1
+    fi
+}
+
+HEAD "1: status can include chat gap matrix"
+OUTPUT="$("$STUB" --include-chat-gap-matrix)"
+require_contains "$OUTPUT" "=== chat gap matrix ==="
+require_contains "$OUTPUT" "source     : scripts/chat-gap-matrix-stub.sh --model gemma3n-e4b --target kv260"
+require_contains "$OUTPUT" "boundary   : read-only data; no prompt/session-store/model/runtime/provider/hardware/lab/IDE/artifact execution"
+require_contains "$OUTPUT" "target     : kv260"
+require_contains "$OUTPUT" "model      : gemma3n-e4b"
+require_contains "$OUTPUT" "matrix     : available_as_data"
+require_contains "$OUTPUT" "standalone : blocked"
+require_contains "$OUTPUT" "review    : not_approved"
+require_contains "$OUTPUT" "evidence  : requires_evidence"
+require_contains "$OUTPUT" "readiness : blocked"
+PASS "chat gap-matrix section is present and conservative"
+
+HEAD "2: gaps, dependencies, and exit criteria are summarized"
+require_contains "$OUTPUT" "gaps       : runtime_device_evidence=requires_evidence:blocker"
+require_contains "$OUTPUT" "model_asset_boundary=not_loaded:blocker"
+require_contains "$OUTPUT" "prompt_input_boundary=disabled:blocker"
+require_contains "$OUTPUT" "response_generation_boundary=disabled:blocker"
+require_contains "$OUTPUT" "session_store_boundary=not_configured:blocker"
+require_contains "$OUTPUT" "transcript_export_boundary=disabled:blocker"
+require_contains "$OUTPUT" "privacy_content_policy=requires_review:blocker"
+require_contains "$OUTPUT" "attachment_clipboard_boundary=disabled:blocker"
+require_contains "$OUTPUT" "audit_persistence_boundary=not_configured:blocker"
+require_contains "$OUTPUT" "ui_enablement_boundary=blocked:blocker"
+require_contains "$OUTPUT" "refs       : chat_review_packet=not_approved"
+require_contains "$OUTPUT" "chat_status_summary=summary_only"
+require_contains "$OUTPUT" "chat_readiness=blocked"
+require_contains "$OUTPUT" "chat_model_load_request=blocked"
+require_contains "$OUTPUT" "chat_session_store_policy=not_configured"
+require_contains "$OUTPUT" "chat_redaction_policy=summary_only"
+require_contains "$OUTPUT" "criteria   : runtime_and_device_evidence_accepted=requires_evidence:false"
+require_contains "$OUTPUT" "model_and_session_boundaries_reviewed=not_approved:false"
+require_contains "$OUTPUT" "content_privacy_boundaries_reviewed=requires_review:false"
+require_contains "$OUTPUT" "blocked    : standalone_chat_not_enabled=blocked"
+require_contains "$OUTPUT" "review_packet_not_approved=not_approved"
+require_contains "$OUTPUT" "runtime_evidence_absent=requires_evidence"
+require_contains "$OUTPUT" "content_paths_disabled=disabled"
+PASS "gap matrix blockers and references are summarized"
+
+HEAD "3: safety flags stay data-only and non-executing"
+require_contains "$OUTPUT" "readOnly=true"
+require_contains "$OUTPUT" "dataOnly=true"
+require_contains "$OUTPUT" "deterministic=true"
+require_contains "$OUTPUT" "gapMatrixOnly=true"
+require_contains "$OUTPUT" "referencesCheckedFixturesOnly=true"
+require_contains "$OUTPUT" "reviewPacketReferencedOnly=true"
+require_contains "$OUTPUT" "statusSummaryReferencedOnly=true"
+require_contains "$OUTPUT" "gapClosed=false"
+require_contains "$OUTPUT" "approvalGranted=false"
+require_contains "$OUTPUT" "promptCapture=false"
+require_contains "$OUTPUT" "promptRead=false"
+require_contains "$OUTPUT" "promptContentIncluded=false"
+require_contains "$OUTPUT" "promptEchoed=false"
+require_contains "$OUTPUT" "inputAccepted=false"
+require_contains "$OUTPUT" "responseContentIncluded=false"
+require_contains "$OUTPUT" "responseGenerated=false"
+require_contains "$OUTPUT" "responseChunksEmitted=false"
+require_contains "$OUTPUT" "tokenCountMeasured=false"
+require_contains "$OUTPUT" "transcriptContentIncluded=false"
+require_contains "$OUTPUT" "messageBodiesIncluded=false"
+require_contains "$OUTPUT" "sessionStoreRead=false"
+require_contains "$OUTPUT" "sessionStoreWrite=false"
+require_contains "$OUTPUT" "sessionPersistence=false"
+require_contains "$OUTPUT" "summaryGenerated=false"
+require_contains "$OUTPUT" "transcriptExported=false"
+require_contains "$OUTPUT" "clipboardRead=false"
+require_contains "$OUTPUT" "clipboardWrite=false"
+require_contains "$OUTPUT" "attachmentReads=false"
+require_contains "$OUTPUT" "fileMetadataRead=false"
+require_contains "$OUTPUT" "fileContentRead=false"
+require_contains "$OUTPUT" "directoryScan=false"
+require_contains "$OUTPUT" "redactionRulesLoaded=false"
+require_contains "$OUTPUT" "contentScan=false"
+require_contains "$OUTPUT" "redactionApplied=false"
+require_contains "$OUTPUT" "auditLogWritten=false"
+require_contains "$OUTPUT" "modelAssetRead=false"
+require_contains "$OUTPUT" "modelLoadAttempted=false"
+require_contains "$OUTPUT" "modelExecution=false"
+require_contains "$OUTPUT" "runtimeExecution=false"
+require_contains "$OUTPUT" "sendEnabled=false"
+require_contains "$OUTPUT" "readsArtifacts=false"
+require_contains "$OUTPUT" "writesArtifacts=false"
+require_contains "$OUTPUT" "kv260Access=false"
+require_contains "$OUTPUT" "hardwareAccess=false"
+require_contains "$OUTPUT" "networkCalls=false"
+require_contains "$OUTPUT" "providerCalls=false"
+require_contains "$OUTPUT" "cloudCalls=false"
+require_contains "$OUTPUT" "executesPccxLab=false"
+require_contains "$OUTPUT" "executesSystemverilogIde=false"
+require_contains "$OUTPUT" "commandDispatch=false"
+require_contains "$OUTPUT" "actionExecution=false"
+require_contains "$OUTPUT" "focusChanged=false"
+PASS "execution-related flags remain false"
+
+HEAD "4: output is deterministic"
+OUTPUT_AGAIN="$("$STUB" --include-chat-gap-matrix)"
+if [ "$OUTPUT" != "$OUTPUT_AGAIN" ]; then
+    FAIL "status chat gap-matrix output changed between runs"
+    exit 1
+fi
+PASS "status chat gap-matrix output is deterministic"
+
+HEAD "5: chat gap-matrix option does not combine with pccx-lab backend"
+if "$STUB" --include-chat-gap-matrix --backend pccx-lab >/dev/null 2>&1; then
+    FAIL "expected combined chat-gap-matrix/backend mode to fail"
+    exit 1
+fi
+PASS "chat gap-matrix remains separate from backend execution"
+
+HEAD "6: output avoids known overclaims"
+FORBIDDEN_PREFIX="KV260 inference"
+FORBIDDEN_CLAIM="${FORBIDDEN_PREFIX} works"
+require_not_contains "$OUTPUT" "$FORBIDDEN_CLAIM"
+THROUGHPUT_PREFIX="20 tok/s"
+THROUGHPUT_CLAIM="${THROUGHPUT_PREFIX} achieved"
+require_not_contains "$OUTPUT" "$THROUGHPUT_CLAIM"
+PASS "no chat gap-matrix or throughput overclaim in status output"
+
+printf '\n[DONE]  all status-chat-gap-matrix tests passed\n'


### PR DESCRIPTION
## Summary
- Add a checked data-only `pccx.chatGapMatrix.v0` contract and fixture for remaining standalone chat blocker rows.
- Add `scripts/chat-gap-matrix-stub.sh` plus `status-stub.sh --include-chat-gap-matrix` output.
- Wire focused contract/status tests, README usage, and CI coverage.

Refs #9.

## Validation
- `python3 scripts/tests/chat_gap_matrix_contract_test.py`
- `bash scripts/tests/status-chat-gap-matrix.sh scripts/status-stub.sh`
- `bash scripts/chat-gap-matrix-stub.sh --model gemma3n-e4b --target kv260`
- `bash scripts/status-stub.sh --include-chat-gap-matrix`
- `python3 -m py_compile contracts/*.py scripts/tests/*.py`
- `python3 -m json.tool contracts/fixtures/chat-gap-matrix.gemma3n-e4b-kv260-placeholder.json`
- `find scripts -type f -name "*.sh" -not -name "*.snapshot" -exec bash -n {} +`
- all Python contract tests under `scripts/tests/*_test.py`
- all status shell tests under `scripts/tests/status-*.sh`
- `./scripts/check.sh`
- `./scripts/check-device-stub.sh`, `./scripts/install-stub.sh`, `./scripts/launch-stub.sh --dry-run`, `./scripts/chat-stub.sh --dry-run --prompt hello`
- local forbidden-claim scan
- `git diff --check`
- `git diff --cached --check`

## Boundary
This is a static local data boundary only. It does not close the standalone chat issue, approve review gates, capture/read prompts, read transcripts or session stores, generate summaries, read clipboard or file data, write audit events, read model assets, load models, execute runtime paths, call providers or networks, invoke pccx-lab or IDE paths, touch hardware/KV260, change settings, publish releases/tags, or make runtime, hardware, marketplace, stable API, or stable ABI claims.