### PR TITLE
feat(kv260): add data-only readiness scaffold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,6 +325,8 @@ jobs:
         run: python3 scripts/tests/device_session_status_contract_test.py
       - name: run runtime readiness contract tests
         run: python3 scripts/tests/runtime_readiness_contract_test.py
+      - name: run KV260 readiness scaffold tests
+        run: python3 scripts/tests/kv260_readiness_scaffold_test.py
       - name: run chat/session contract tests
         run: python3 scripts/tests/chat_session_contract_test.py
       - name: run chat model status contract tests

--- a/contracts/kv260_readiness_scaffold.py
+++ b/contracts/kv260_readiness_scaffold.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Typed, data-only KV260 readiness scaffold.
+
+This module defines launcher-side interfaces for future KV260 readiness work.
+It does not open target sessions, execute target commands, read model assets,
+access MMIO, load bitstreams, or contact provider services.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Iterator, Mapping, Protocol, Sequence
+
+
+UCA_REG_INSTR_LO = 0x00
+UCA_REG_INSTR_HI = 0x04
+UCA_REG_STATUS = 0x08
+UCA_STAT_BUSY = 1 << 0
+UCA_STAT_DONE = 1 << 1
+
+
+class NpuOpcode(Enum):
+    """pccx v002 opcode nibble mirrored from sibling `isa_pkg.sv`."""
+
+    GEMV = 0x0
+    GEMM = 0x1
+    MEMCPY = 0x2
+    MEMSET = 0x3
+    CVO = 0x4
+
+
+@dataclass(frozen=True)
+class KV260Connection:
+    """KV260 target configuration presence without value disclosure.
+
+    `from_env()` reads `KVFPGA_HOST`, `KVFPGA_USER`, and `KVFPGA_PASSWORD`.
+    The configured-value flags are public. Raw values are stored only for a
+    future reviewed connection boundary and are excluded from repr/compare.
+    """
+
+    host_configured: bool
+    user_configured: bool
+    password_configured: bool
+    _host: str | None = field(default=None, repr=False, compare=False)
+    _user: str | None = field(default=None, repr=False, compare=False)
+    _password: str | None = field(default=None, repr=False, compare=False)
+
+    @classmethod
+    def from_env(cls, env: Mapping[str, str] | None = None) -> "KV260Connection":
+        source = os.environ if env is None else env
+        host = source.get("KVFPGA_HOST")
+        user = source.get("KVFPGA_USER")
+        password = source.get("KVFPGA_PASSWORD")
+        return cls(
+            host_configured=bool(host),
+            user_configured=bool(user),
+            password_configured=bool(password),
+            _host=host,
+            _user=user,
+            _password=password,
+        )
+
+    def is_configured(self) -> bool:
+        return (
+            self.host_configured
+            and self.user_configured
+            and self.password_configured
+        )
+
+    def is_reachable(self) -> bool:
+        raise NotImplementedError("data-only scaffold; no target access")
+
+    def kernel_uname(self) -> str:
+        raise NotImplementedError("data-only scaffold; no target command")
+
+    def xrt_present(self) -> bool:
+        raise NotImplementedError("data-only scaffold; no target command")
+
+    def xmutil_listapps(self) -> Sequence[str]:
+        raise NotImplementedError("data-only scaffold; no target command")
+
+
+@dataclass(frozen=True)
+class NPUStatus:
+    """Read-only snapshot shape for future launcher status panels."""
+
+    bitstream_loaded: bool
+    bitstream_uuid: str | None
+    axi_base_addr: int | None
+    axi_stat_register_value: int | None
+    last_error: str | None
+
+
+@dataclass(frozen=True)
+class HFWeightSource:
+    """External Hugging Face weight source descriptor.
+
+    The descriptor names a source but does not download, load, hash, or copy
+    weight files. Callers must supply any future evidence through reviewed
+    lower-layer tooling.
+    """
+
+    model_id: str
+    revision: str | None = None
+
+
+@dataclass(frozen=True)
+class LoadedHFWeights:
+    """Opaque marker for a future loaded-weight handoff."""
+
+    source: HFWeightSource
+
+
+@dataclass(frozen=True)
+class QuantizedW4Weights:
+    """Opaque marker for future 4-bit weight quantization output."""
+
+    source: HFWeightSource
+
+
+@dataclass(frozen=True)
+class QuantizedA8Weights:
+    """Opaque marker for future 8-bit activation quantization metadata."""
+
+    source: HFWeightSource
+
+
+@dataclass(frozen=True)
+class GemmaWeightManifest:
+    """Documented manifest emitted after future weight preparation.
+
+    Fields:
+    `schema_version`: Manifest schema identifier for compatibility gates.
+    `model_id`: External model identifier, for example a Gemma target id.
+    `source_revision`: Optional external revision string supplied by caller.
+    `weight_format`: Prepared weight precision, expected to describe W4.
+    `activation_format`: Prepared activation precision, expected to describe A8.
+    `tensor_count`: Count of tensors represented by the manifest.
+    `artifact_paths`: Relative artifact references supplied by a future reviewed
+    packager; this scaffold never creates, reads, or validates those paths.
+    `checksums`: Optional digest strings supplied by a future reviewed packager.
+    `evidence_refs`: Evidence identifiers required before runtime claims change.
+    `limitations`: Known gaps that keep the manifest data-only.
+    """
+
+    schema_version: str
+    model_id: str
+    source_revision: str | None
+    weight_format: str
+    activation_format: str
+    tensor_count: int
+    artifact_paths: tuple[str, ...]
+    checksums: Mapping[str, str]
+    evidence_refs: tuple[str, ...]
+    limitations: tuple[str, ...]
+
+
+class GemmaWeightPrep:
+    """Typed pipeline shell; every step is intentionally unimplemented."""
+
+    def load_hf(self, source: HFWeightSource) -> LoadedHFWeights:
+        raise NotImplementedError("data-only scaffold; no HF download or load")
+
+    def quantize_W4(self, weights: LoadedHFWeights) -> QuantizedW4Weights:
+        raise NotImplementedError("data-only scaffold; no quantization")
+
+    def quantize_A8(self, weights: QuantizedW4Weights) -> QuantizedA8Weights:
+        raise NotImplementedError("data-only scaffold; no quantization")
+
+    def emit_manifest(self, weights: QuantizedA8Weights) -> GemmaWeightManifest:
+        raise NotImplementedError("data-only scaffold; no artifact emission")
+
+
+@dataclass(frozen=True)
+class NpuCmd:
+    """AXI command mirror for the current sibling driver boundary.
+
+    The sibling KV260 repo uses a 64-bit VLIW instruction, written as two
+    32-bit AXI-Lite words: `UCA_REG_INSTR_LO` then `UCA_REG_INSTR_HI`.
+    The opcode nibble is mirrored from `isa_pkg.sv`; status bits are mirrored
+    from the sibling HAL/status handoff.
+    """
+
+    instruction: int
+
+    def __post_init__(self) -> None:
+        if not 0 <= self.instruction <= 0xFFFFFFFFFFFFFFFF:
+            raise ValueError("instruction must fit in 64 bits")
+
+    @property
+    def lo32(self) -> int:
+        return self.instruction & 0xFFFFFFFF
+
+    @property
+    def hi32(self) -> int:
+        return (self.instruction >> 32) & 0xFFFFFFFF
+
+
+@dataclass(frozen=True)
+class NpuStat:
+    """32-bit AXI status mirror: bit 0 busy, bit 1 done, bits 31:2 reserved."""
+
+    raw: int
+
+    def __post_init__(self) -> None:
+        if not 0 <= self.raw <= 0xFFFFFFFF:
+            raise ValueError("status must fit in 32 bits")
+
+    @property
+    def busy(self) -> bool:
+        return bool(self.raw & UCA_STAT_BUSY)
+
+    @property
+    def done(self) -> bool:
+        return bool(self.raw & UCA_STAT_DONE)
+
+    @property
+    def reserved(self) -> int:
+        return self.raw >> 2
+
+
+class AxiCmdChannel(Protocol):
+    """Readiness-time command channel shape without MMIO access."""
+
+    def issue(self, cmd: NpuCmd) -> None:
+        raise NotImplementedError("data-only scaffold; no AXI write")
+
+    def poll_stat(self) -> NpuStat:
+        raise NotImplementedError("data-only scaffold; no AXI read")
+
+
+@dataclass(frozen=True)
+class TensorChunk:
+    """Output tensor chunk descriptor supplied by a future runtime handoff."""
+
+    name: str
+    dtype: str
+    shape: tuple[int, ...]
+    data: bytes = field(repr=False)
+
+
+@dataclass(frozen=True)
+class OutputItem:
+    """One result-stream item: token text, tensor data, or control marker."""
+
+    index: int
+    token: str | None = None
+    tensor: TensorChunk | None = None
+    finish_reason: str | None = None
+
+
+class ResultStream(Protocol):
+    """Typed iterator over future output tokens or tensors."""
+
+    def __iter__(self) -> Iterator[OutputItem]:
+        raise NotImplementedError("data-only scaffold; no runtime stream")
+
+
+class EmptyResultStream:
+    """Deterministic empty stream for type-only tests and disabled UI states."""
+
+    def __iter__(self) -> Iterator[OutputItem]:
+        return iter(())

--- a/docs/KV260_DATA_ONLY_READINESS_SCAFFOLD.md
+++ b/docs/KV260_DATA_ONLY_READINESS_SCAFFOLD.md
@@ -1,0 +1,32 @@
+# KV260 Data-Only Readiness Scaffold
+
+This page documents the launcher-side readiness scaffold added for the
+planned KV260 path. It is data-only: it defines typed shapes for future
+connection checks, NPU status, Gemma weight preparation metadata, AXI command
+status, and result streams without touching a board or reading model assets.
+
+## Scope
+
+- `KV260Connection` records whether `KVFPGA_HOST`, `KVFPGA_USER`, and
+  `KVFPGA_PASSWORD` are present. It does not print those values.
+- `NPUStatus` is a read-only status snapshot with bitstream, AXI, and error
+  fields.
+- `GemmaWeightPrep` names the future `load_hf -> quantize_W4 -> quantize_A8
+  -> emit_manifest` flow. Each step raises `NotImplementedError`.
+- `GemmaWeightManifest` documents the future manifest shape without creating
+  artifacts or reading weight files.
+- `AxiCmdChannel` exposes `issue(cmd)` and `poll_stat()` as type-only methods.
+  The current mirror records the sibling driver's 64-bit instruction split
+  into low/high 32-bit words and the 32-bit status register shape.
+- `ResultStream` is a typed iterator over future token or tensor outputs.
+
+## Boundaries
+
+The scaffold does not open SSH, run target commands, scan networks, read XRT
+state, call `xmutil`, access MMIO, load a bitstream, download from Hugging
+Face, load or copy model weights, start inference, stream responses, or write
+artifacts.
+
+Readiness can move beyond these placeholders only after lower-layer evidence
+is supplied by reviewed FPGA/runtime work. Until then, this launcher surface
+must keep runtime and hardware claims blocked or target-only.

--- a/scripts/tests/kv260_readiness_scaffold_test.py
+++ b/scripts/tests/kv260_readiness_scaffold_test.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Type-only tests for the KV260 readiness scaffold."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "contracts" / "kv260_readiness_scaffold.py"
+DOC_PATH = ROOT / "docs" / "KV260_DATA_ONLY_READINESS_SCAFFOLD.md"
+TEST_PATH = Path(__file__).resolve()
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location(
+        "kv260_readiness_scaffold",
+        MODULE_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def assert_raises_not_implemented(func) -> None:
+    try:
+        func()
+    except NotImplementedError:
+        return
+    raise AssertionError("expected NotImplementedError")
+
+
+def test_connection_env_presence_only_and_skip_if_unset() -> None:
+    module = load_module()
+    env_names = ("KVFPGA_HOST", "KVFPGA_USER", "KVFPGA_PASSWORD")
+    if not all(os.environ.get(name) for name in env_names):
+        print("skip: KVFPGA_* env unset")
+
+    fake_env = {
+        "KVFPGA_HOST": "kv260.example.invalid",
+        "KVFPGA_USER": "kvuser",
+        "KVFPGA_PASSWORD": "redacted-test-password",
+    }
+    connection = module.KV260Connection.from_env(fake_env)
+    rendered = repr(connection)
+
+    assert connection.is_configured() is True
+    assert connection.host_configured is True
+    assert connection.user_configured is True
+    assert connection.password_configured is True
+    for value in fake_env.values():
+        assert value not in rendered
+
+    assert_raises_not_implemented(connection.is_reachable)
+    assert_raises_not_implemented(connection.kernel_uname)
+    assert_raises_not_implemented(connection.xrt_present)
+    assert_raises_not_implemented(connection.xmutil_listapps)
+
+
+def test_status_manifest_and_pipeline_shapes() -> None:
+    module = load_module()
+    status = module.NPUStatus(
+        bitstream_loaded=False,
+        bitstream_uuid=None,
+        axi_base_addr=None,
+        axi_stat_register_value=None,
+        last_error=None,
+    )
+    source = module.HFWeightSource(model_id="gemma3n-e4b", revision=None)
+    manifest = module.GemmaWeightManifest(
+        schema_version="pccx.gemmaWeightManifest.v0",
+        model_id=source.model_id,
+        source_revision=source.revision,
+        weight_format="W4",
+        activation_format="A8",
+        tensor_count=0,
+        artifact_paths=(),
+        checksums={},
+        evidence_refs=("future_weight_prep_evidence",),
+        limitations=("data_only_scaffold",),
+    )
+
+    assert status.bitstream_loaded is False
+    assert manifest.weight_format == "W4"
+    assert manifest.activation_format == "A8"
+
+    prep = module.GemmaWeightPrep()
+    assert_raises_not_implemented(lambda: prep.load_hf(source))
+    assert_raises_not_implemented(
+        lambda: prep.quantize_W4(module.LoadedHFWeights(source=source)),
+    )
+    assert_raises_not_implemented(
+        lambda: prep.quantize_A8(module.QuantizedW4Weights(source=source)),
+    )
+    assert_raises_not_implemented(
+        lambda: prep.emit_manifest(module.QuantizedA8Weights(source=source)),
+    )
+
+
+def test_axi_shapes_and_result_stream_are_typed_only() -> None:
+    module = load_module()
+    cmd = module.NpuCmd(0x4000000000000001)
+    busy = module.NpuStat(module.UCA_STAT_BUSY)
+    done = module.NpuStat(module.UCA_STAT_DONE)
+    empty = module.EmptyResultStream()
+
+    assert cmd.lo32 == 0x00000001
+    assert cmd.hi32 == 0x40000000
+    assert busy.busy is True
+    assert busy.done is False
+    assert done.busy is False
+    assert done.done is True
+    assert done.reserved == 0
+    assert list(empty) == []
+
+    try:
+        module.NpuCmd(0x1_0000_0000_0000_0000)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("expected NpuCmd width guard")
+
+    try:
+        module.NpuStat(0x1_0000_0000)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("expected NpuStat width guard")
+
+
+def test_source_does_not_contain_board_or_model_actions() -> None:
+    source = read_text(MODULE_PATH)
+    doc = read_text(DOC_PATH)
+    scan_text = "\n".join([source, doc])
+    forbidden_terms = [
+        "subprocess",
+        "os.system",
+        "popen",
+        "socket",
+        "paramiko",
+        "requests",
+        "urllib",
+        "transformers",
+        "huggingface_hub",
+        "mmap",
+        "/dev/mem",
+        "ssh ",
+        "scp ",
+    ]
+    for term in forbidden_terms:
+        assert term not in source.lower(), term
+
+    assert "print(" not in source
+    assert "logging." not in source
+    assert "redacted-test-password" not in scan_text
+
+    forbidden_claims = [
+        "production-ready",
+        "marketplace-ready",
+        "stable API",
+        "stable ABI",
+        "KV260 inference works",
+        "Gemma 3N E4B runs on KV260",
+        "20 tok/s achieved",
+        "timing closed",
+        "bitstream ready",
+    ]
+    lowered = scan_text.lower()
+    for claim in forbidden_claims:
+        assert claim.lower() not in lowered, claim
+
+
+def test_source_headers_for_touched_code_files() -> None:
+    expected_headers = {
+        MODULE_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        TEST_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+    }
+    for path, header in expected_headers.items():
+        assert read_text(path).splitlines()[: len(header)] == header, path
+
+
+test_connection_env_presence_only_and_skip_if_unset()
+test_status_manifest_and_pipeline_shapes()
+test_axi_shapes_and_result_stream_are_typed_only()
+test_source_does_not_contain_board_or_model_actions()
+test_source_headers_for_touched_code_files()
+
+print("kv260 readiness scaffold tests ok")


### PR DESCRIPTION
Refs pccxai/pccx-FPGA-NPU-LLM-kv260#82

## Summary
- Add typed Python readiness scaffold interfaces for KV260 connection configuration, read-only NPU status, Gemma weight-prep handoff, AXI command/status shapes, and result streaming.
- Document the data-only boundary for the planned KV260 launcher path.
- Add direct Python tests for type shapes, env-value non-disclosure, unimplemented board/runtime methods, width guards, and claim guards.

## Evidence
- python3 -m compileall -q contracts scripts/tests
- python3 scripts/tests/kv260_readiness_scaffold_test.py
- python3 scripts/tests/runtime_readiness_contract_test.py
- claim-scan clean

## Notes
- No board access, SSH, target command execution, HF download, model weight load/copy, MMIO access, bitstream load, provider call, or runtime stream is implemented.
- shellcheck is not installed in the local environment; per maintainer direction, this PR treats that as an environment limitation and gates this slice on Python-only verification.
