### PR TITLE
feat(kv260): add tty serial backend for KV260Connection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,6 +325,8 @@ jobs:
         run: python3 scripts/tests/device_session_status_contract_test.py
       - name: run runtime readiness contract tests
         run: python3 scripts/tests/runtime_readiness_contract_test.py
+      - name: run KV260 serial connection tests
+        run: python3 scripts/tests/kv260_serial_connection_test.py
       - name: run chat/session contract tests
         run: python3 scripts/tests/chat_session_contract_test.py
       - name: run chat model status contract tests

--- a/contracts/kv260_serial_connection.py
+++ b/contracts/kv260_serial_connection.py
@@ -1,0 +1,347 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""TTY serial backend for KV260 launcher-side status checks.
+
+The backend uses USB serial console access only. Credentials come from
+`KVFPGA_USER` and `KVFPGA_PASSWORD`; `KVFPGA_HOST` is intentionally ignored.
+Raw environment values are not exposed through repr or public status fields.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Mapping, Protocol, Sequence, runtime_checkable
+
+
+DEFAULT_BAUDRATE = 115200
+DEFAULT_PROMPT_TIMEOUT = 4.0
+DEFAULT_COMMAND_TIMEOUT = 12.0
+DEFAULT_WRITE_TIMEOUT = 1.0
+READ_CHUNK_SIZE = 1024
+END_MARKER = "__PCCX_KV260_SERIAL_DONE__"
+
+LOGIN_PROMPT = re.compile(rb"(?im)(?:^|\r?\n)[^\r\n]*login:\s*$")
+PASSWORD_PROMPT = re.compile(rb"(?im)(?:^|\r?\n)[^\r\n]*password:\s*$")
+SHELL_PROMPT = re.compile(rb"(?m)(?:^|\r?\n)[^\r\n]*[$#]\s*$")
+COMMAND_DONE = re.compile((END_MARKER + r":(\d+)").encode("ascii"))
+
+
+class KV260SerialError(RuntimeError):
+    """Base error for serial backend failures."""
+
+
+class KV260SerialUnavailable(KV260SerialError):
+    """Raised when a tty port or pyserial backend is unavailable."""
+
+
+@runtime_checkable
+class KV260ConnectionProtocol(Protocol):
+    """Method contract shared by KV260 connection backends."""
+
+    def is_reachable(self) -> bool:
+        """Return whether a serial console prompt can be reached."""
+
+    def kernel_uname(self) -> str:
+        """Return `uname -a` from the KV260 serial session."""
+
+    def xrt_present(self) -> bool:
+        """Return whether XRT tooling or libraries are visible on the target."""
+
+    def xmutil_listapps(self) -> Sequence[str]:
+        """Return `xmutil listapps` output lines from the target."""
+
+
+@dataclass(frozen=True)
+class SerialCommandResult:
+    """Target command output with shell exit status."""
+
+    exit_status: int
+    output: str
+
+
+SerialFactory = Callable[..., Any]
+
+
+def kv260_tty_candidates(env: Mapping[str, str] | None = None) -> tuple[str, ...]:
+    """Return candidate KV260 serial tty paths, with env override first."""
+
+    source = os.environ if env is None else env
+    override = source.get("KVFPGA_TTY")
+    if override:
+        return (override,)
+
+    candidates: list[str] = []
+    by_id = Path("/dev/serial/by-id")
+    if by_id.is_dir():
+        for path in sorted(by_id.iterdir()):
+            if "kv260" in path.name.lower():
+                candidates.append(str(path))
+
+    candidates.extend(str(path) for path in sorted(Path("/dev").glob("ttyUSB*")))
+    return tuple(dict.fromkeys(candidates))
+
+
+def detect_kv260_tty(env: Mapping[str, str] | None = None) -> str | None:
+    """Return the first configured or auto-detected KV260 serial tty path."""
+
+    candidates = kv260_tty_candidates(env)
+    return candidates[0] if candidates else None
+
+
+@dataclass
+class KV260SerialConnection:
+    """USB tty serial implementation of the KV260 connection method contract."""
+
+    tty_configured: bool
+    user_configured: bool
+    password_configured: bool
+    baudrate: int = DEFAULT_BAUDRATE
+    prompt_timeout: float = DEFAULT_PROMPT_TIMEOUT
+    command_timeout: float = DEFAULT_COMMAND_TIMEOUT
+    write_timeout: float = DEFAULT_WRITE_TIMEOUT
+    _tty: str | None = field(default=None, repr=False, compare=False)
+    _user: str | None = field(default=None, repr=False, compare=False)
+    _password: str | None = field(default=None, repr=False, compare=False)
+    _serial_factory: SerialFactory | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+    _active_serial: Any | None = field(default=None, repr=False, compare=False)
+
+    @classmethod
+    def from_env(
+        cls,
+        env: Mapping[str, str] | None = None,
+        serial_factory: SerialFactory | None = None,
+    ) -> "KV260SerialConnection":
+        source = os.environ if env is None else env
+        tty = source.get("KVFPGA_TTY")
+        user = source.get("KVFPGA_USER")
+        password = source.get("KVFPGA_PASSWORD")
+        return cls(
+            tty_configured=bool(tty),
+            user_configured=bool(user),
+            password_configured=bool(password),
+            _tty=tty,
+            _user=user,
+            _password=password,
+            _serial_factory=serial_factory,
+        )
+
+    def is_configured(self) -> bool:
+        """Return whether required serial credentials are present."""
+
+        return self.user_configured and self.password_configured
+
+    def is_reachable(self) -> bool:
+        """Open the tty, send a newline, and check for login or shell prompt."""
+
+        serial_session = None
+        try:
+            serial_session = self._open_serial()
+            self._write(serial_session, b"\r\n")
+            prompt, _buffer = self._read_until_prompt(
+                serial_session,
+                timeout=self.prompt_timeout,
+            )
+            return prompt is not None
+        except (OSError, KV260SerialError):
+            return False
+        finally:
+            self._close_serial(serial_session)
+
+    def kernel_uname(self) -> str:
+        with self as connection:
+            result = connection._run_command("uname -a")
+        if result.exit_status != 0:
+            raise KV260SerialError("uname command failed")
+        return result.output.strip()
+
+    def xrt_present(self) -> bool:
+        command = (
+            "command -v xrt-smi >/dev/null 2>&1 || "
+            "command -v xbutil >/dev/null 2>&1 || "
+            "test -e /usr/lib/libxrt_core.so || "
+            "test -e /usr/lib/aarch64-linux-gnu/libxrt_core.so"
+        )
+        with self as connection:
+            result = connection._run_command(command)
+        return result.exit_status == 0
+
+    def xmutil_listapps(self) -> Sequence[str]:
+        with self as connection:
+            result = connection._run_command("xmutil listapps")
+        if result.exit_status != 0:
+            return ()
+        return tuple(line for line in result.output.splitlines() if line.strip())
+
+    def __enter__(self) -> "KV260SerialConnection":
+        serial_session = self._open_serial()
+        try:
+            self._login(serial_session)
+        except Exception:
+            self._close_serial(serial_session)
+            raise
+        self._active_serial = serial_session
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        self.logout()
+
+    def logout(self) -> None:
+        serial_session = self._active_serial
+        self._active_serial = None
+        if serial_session is None:
+            return
+        try:
+            self._write(serial_session, b"exit\r\n")
+        finally:
+            self._close_serial(serial_session)
+
+    def _open_serial(self) -> Any:
+        tty = self._tty or detect_kv260_tty()
+        if not tty:
+            raise KV260SerialUnavailable("no KV260 serial tty detected")
+
+        factory = self._serial_factory
+        if factory is None:
+            try:
+                import serial  # type: ignore[import-not-found]
+            except ImportError as exc:
+                raise KV260SerialUnavailable("pyserial is not installed") from exc
+            factory = serial.Serial
+
+        return factory(
+            port=tty,
+            baudrate=self.baudrate,
+            timeout=0.1,
+            write_timeout=self.write_timeout,
+        )
+
+    def _login(self, serial_session: Any) -> None:
+        if not self._user or not self._password:
+            raise KV260SerialUnavailable("KVFPGA serial credentials are incomplete")
+
+        self._write(serial_session, b"\r\n")
+        prompt, _buffer = self._read_until_prompt(
+            serial_session,
+            timeout=self.prompt_timeout,
+        )
+        if prompt == "login":
+            self._write_line(serial_session, self._user)
+            prompt, _buffer = self._read_until_prompt(
+                serial_session,
+                timeout=self.prompt_timeout,
+            )
+        if prompt == "password":
+            self._write_line(serial_session, self._password)
+            prompt, _buffer = self._read_until_prompt(
+                serial_session,
+                timeout=self.prompt_timeout,
+            )
+        if prompt != "shell":
+            raise KV260SerialError("serial shell prompt was not reached")
+
+    def _run_command(self, command: str) -> SerialCommandResult:
+        serial_session = self._active_serial
+        if serial_session is None:
+            raise KV260SerialError("serial session is not open")
+
+        wrapped = f"{command}; printf '\\n{END_MARKER}:%s\\n' \"$?\""
+        self._write_line(serial_session, wrapped)
+        raw = self._read_until_pattern(
+            serial_session,
+            COMMAND_DONE,
+            timeout=self.command_timeout,
+        )
+        match = COMMAND_DONE.search(raw)
+        if match is None:
+            raise KV260SerialError("command completion marker was not observed")
+
+        exit_status = int(match.group(1).decode("ascii"))
+        output = self._clean_command_output(command, raw[: match.start()])
+        return SerialCommandResult(exit_status=exit_status, output=output)
+
+    def _read_until_prompt(
+        self,
+        serial_session: Any,
+        timeout: float,
+    ) -> tuple[str | None, bytes]:
+        deadline = time.monotonic() + timeout
+        buffer = bytearray()
+        while time.monotonic() < deadline:
+            chunk = serial_session.read(READ_CHUNK_SIZE)
+            if chunk:
+                buffer.extend(chunk)
+                data = bytes(buffer)
+                if LOGIN_PROMPT.search(data):
+                    return "login", data
+                if PASSWORD_PROMPT.search(data):
+                    return "password", data
+                if SHELL_PROMPT.search(data):
+                    return "shell", data
+            else:
+                time.sleep(0.02)
+        return None, bytes(buffer)
+
+    def _read_until_pattern(
+        self,
+        serial_session: Any,
+        pattern: re.Pattern[bytes],
+        timeout: float,
+    ) -> bytes:
+        deadline = time.monotonic() + timeout
+        buffer = bytearray()
+        while time.monotonic() < deadline:
+            chunk = serial_session.read(READ_CHUNK_SIZE)
+            if chunk:
+                buffer.extend(chunk)
+                data = bytes(buffer)
+                if pattern.search(data):
+                    return data
+            else:
+                time.sleep(0.02)
+        raise KV260SerialError("serial read timed out")
+
+    def _write_line(self, serial_session: Any, line: str) -> None:
+        self._write(serial_session, line.encode("utf-8") + b"\r\n")
+
+    def _write(self, serial_session: Any, payload: bytes) -> None:
+        serial_session.write(payload)
+        flush = getattr(serial_session, "flush", None)
+        if flush is not None:
+            flush()
+
+    def _clean_command_output(self, command: str, raw: bytes) -> str:
+        text = raw.decode("utf-8", errors="replace").replace("\r", "")
+        lines = text.split("\n")
+        cleaned: list[str] = []
+        for line in lines:
+            stripped = line.strip()
+            if not stripped:
+                continue
+            if stripped == command or stripped.startswith(f"{command}; "):
+                continue
+            if (
+                command in stripped
+                and "printf" in stripped
+                and END_MARKER in stripped
+            ):
+                continue
+            if stripped.endswith("$") or stripped.endswith("#"):
+                continue
+            cleaned.append(line.rstrip())
+        return "\n".join(cleaned)
+
+    def _close_serial(self, serial_session: Any | None) -> None:
+        if serial_session is None:
+            return
+        close = getattr(serial_session, "close", None)
+        if close is not None:
+            close()

--- a/scripts/tests/kv260_serial_connection_test.py
+++ b/scripts/tests/kv260_serial_connection_test.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Tests for the KV260 USB tty serial connection backend."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "contracts" / "kv260_serial_connection.py"
+TEST_PATH = Path(__file__).resolve()
+TEST_PASSWORD_VALUE = "kv260-" + "serial-" + "secret-for-test"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location(
+        "kv260_serial_connection",
+        MODULE_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+class FakeSerial:
+    instances: list["FakeSerial"] = []
+
+    def __init__(self, *args, **kwargs) -> None:
+        self.args = args
+        self.kwargs = kwargs
+        self.writes: list[bytes] = []
+        self.closed = False
+        self.reads = list(type(self).reads)
+        type(self).instances.append(self)
+
+    reads: list[bytes] = []
+
+    def read(self, _size: int) -> bytes:
+        if self.reads:
+            return self.reads.pop(0)
+        return b""
+
+    def write(self, payload: bytes) -> int:
+        self.writes.append(payload)
+        return len(payload)
+
+    def flush(self) -> None:
+        return None
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def reset_fake(reads: list[bytes]) -> None:
+    FakeSerial.instances = []
+    FakeSerial.reads = reads
+
+
+def test_type_contract_and_env_presence_only() -> None:
+    module = load_module()
+    fake_env = {
+        "KVFPGA_HOST": "ignored-host.example.invalid",
+        "KVFPGA_TTY": "/dev/ttyUSB-kv260-test",
+        "KVFPGA_USER": "kv260-user-for-test",
+        "KVFPGA_PASSWORD": TEST_PASSWORD_VALUE,
+    }
+    connection = module.KV260SerialConnection.from_env(
+        fake_env,
+        serial_factory=FakeSerial,
+    )
+    rendered = repr(connection)
+
+    assert isinstance(connection, module.KV260ConnectionProtocol)
+    assert connection.is_configured() is True
+    assert connection.tty_configured is True
+    assert connection.user_configured is True
+    assert connection.password_configured is True
+    assert "ignored-host" not in rendered
+    assert fake_env["KVFPGA_TTY"] not in rendered
+    assert fake_env["KVFPGA_USER"] not in rendered
+    assert fake_env["KVFPGA_PASSWORD"] not in rendered
+
+
+def test_tty_override_and_auto_detect_helpers() -> None:
+    module = load_module()
+
+    assert module.kv260_tty_candidates({"KVFPGA_TTY": "/tmp/tty-kv260"}) == (
+        "/tmp/tty-kv260",
+    )
+    assert module.detect_kv260_tty({"KVFPGA_TTY": "/tmp/tty-kv260"}) == (
+        "/tmp/tty-kv260"
+    )
+    assert isinstance(module.kv260_tty_candidates({}), tuple)
+
+
+def test_reachable_accepts_login_or_shell_prompt() -> None:
+    module = load_module()
+    fake_env = {"KVFPGA_TTY": "/tmp/tty-kv260"}
+
+    reset_fake([b"kv260 login: "])
+    login_connection = module.KV260SerialConnection.from_env(
+        fake_env,
+        serial_factory=FakeSerial,
+    )
+    assert login_connection.is_reachable() is True
+    assert FakeSerial.instances[-1].closed is True
+
+    reset_fake([b"root@kv260:~$ "])
+    shell_connection = module.KV260SerialConnection.from_env(
+        fake_env,
+        serial_factory=FakeSerial,
+    )
+    assert shell_connection.is_reachable() is True
+    assert FakeSerial.instances[-1].closed is True
+
+
+def test_login_uname_and_logout_over_serial() -> None:
+    module = load_module()
+    fake_env = {
+        "KVFPGA_TTY": "/tmp/tty-kv260",
+        "KVFPGA_USER": "kv260-user-for-test",
+        "KVFPGA_PASSWORD": TEST_PASSWORD_VALUE,
+    }
+    reset_fake(
+        [
+            b"kv260 login: ",
+            b"Password: ",
+            b"root@kv260:~$ ",
+            (
+                b"root@kv260:~$ uname -a; printf "
+                b"'\\n__PCCX_KV260_SERIAL_DONE__:%s\\n' \"$?\"\r\n"
+                b"Linux kv260 6.6.0-test #1 SMP PREEMPT aarch64 GNU/Linux\r\n"
+                b"__PCCX_KV260_SERIAL_DONE__:0\r\n"
+                b"root@kv260:~$ "
+            ),
+        ],
+    )
+    connection = module.KV260SerialConnection.from_env(
+        fake_env,
+        serial_factory=FakeSerial,
+    )
+
+    assert connection.kernel_uname() == (
+        "Linux kv260 6.6.0-test #1 SMP PREEMPT aarch64 GNU/Linux"
+    )
+    writes = b"".join(FakeSerial.instances[-1].writes)
+    assert b"uname -a" in writes
+    assert writes.endswith(b"exit\r\n")
+    assert FakeSerial.instances[-1].closed is True
+
+
+def test_xrt_present_and_xmutil_listapps_use_serial_commands() -> None:
+    module = load_module()
+    fake_env = {
+        "KVFPGA_TTY": "/tmp/tty-kv260",
+        "KVFPGA_USER": "kv260-user-for-test",
+        "KVFPGA_PASSWORD": TEST_PASSWORD_VALUE,
+    }
+
+    reset_fake([b"$ ", b"__PCCX_KV260_SERIAL_DONE__:0\r\n$ "])
+    connection = module.KV260SerialConnection.from_env(
+        fake_env,
+        serial_factory=FakeSerial,
+    )
+    assert connection.xrt_present() is True
+
+    reset_fake(
+        [
+            b"$ ",
+            (
+                b"$ xmutil listapps; printf "
+                b"'\\n__PCCX_KV260_SERIAL_DONE__:%s\\n' \"$?\"\r\n"
+                b"accelerated_app\r\n"
+                b"diagnostic_app\r\n"
+                b"__PCCX_KV260_SERIAL_DONE__:0\r\n$ "
+            ),
+        ],
+    )
+    listapps_connection = module.KV260SerialConnection.from_env(
+        fake_env,
+        serial_factory=FakeSerial,
+    )
+    assert listapps_connection.xmutil_listapps() == (
+        "accelerated_app",
+        "diagnostic_app",
+    )
+
+
+def test_live_serial_probe_skips_gracefully_without_tty() -> None:
+    module = load_module()
+    tty = module.detect_kv260_tty()
+    if tty is None:
+        print("skip: no KV260 tty device detected")
+        return
+    try:
+        import serial  # type: ignore[import-not-found]  # noqa: F401
+    except ImportError:
+        print("skip: pyserial is not installed")
+        return
+    if not os.environ.get("KVFPGA_USER") or not os.environ.get("KVFPGA_PASSWORD"):
+        print("skip: KVFPGA serial credentials are incomplete")
+        return
+
+    connection = module.KV260SerialConnection.from_env()
+    assert isinstance(connection.is_reachable(), bool)
+
+
+def test_source_has_no_credential_leaks_or_unsupported_paths() -> None:
+    source = read_text(MODULE_PATH)
+    test_source = read_text(TEST_PATH)
+    scan_text = source
+
+    forbidden_terms = [
+        "param" + "iko",
+        "s" + "cp ",
+        "subprocess",
+        "os.system",
+        "popen",
+        "socket",
+        "requests",
+        "urllib",
+        "transformers",
+        "huggingface_hub",
+        "/dev/mem",
+    ]
+    lowered_source = source.lower()
+    for term in forbidden_terms:
+        assert term not in lowered_source, term
+
+    assert "print(" not in source
+    assert "logging." not in source
+    assert TEST_PASSWORD_VALUE not in source
+    assert ("serial-" + "secret-for-test") not in test_source
+
+    forbidden_claims = [
+        "production-" + "ready",
+        "marketplace-" + "ready",
+        "stable " + "API",
+        "stable " + "ABI",
+        "KV260 inference " + "works",
+        "Gemma 3N E4B " + "runs on KV260",
+        "20 tok/s " + "achieved",
+        "timing " + "closed",
+        "bitstream " + "ready",
+    ]
+    lowered = scan_text.lower()
+    for claim in forbidden_claims:
+        assert claim.lower() not in lowered, claim
+
+    assert not re.search(r"\bssh\s+[^\"']+", source, re.IGNORECASE)
+
+
+def test_source_headers_for_touched_python_files() -> None:
+    expected_headers = {
+        MODULE_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        TEST_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+    }
+    for path, header in expected_headers.items():
+        assert read_text(path).splitlines()[: len(header)] == header, path
+
+
+test_type_contract_and_env_presence_only()
+test_tty_override_and_auto_detect_helpers()
+test_reachable_accepts_login_or_shell_prompt()
+test_login_uname_and_logout_over_serial()
+test_xrt_present_and_xmutil_listapps_use_serial_commands()
+test_live_serial_probe_skips_gracefully_without_tty()
+test_source_has_no_credential_leaks_or_unsupported_paths()
+test_source_headers_for_touched_python_files()
+
+print("kv260 serial connection tests ok")


### PR DESCRIPTION
Refs pccxai/pccx-llm-launcher#70

## Summary
- Add a USB tty serial KV260 connection backend matching the KV260 connection method contract: reachability probe, uname, XRT presence, and xmutil listapps.
- Read KVFPGA_TTY, KVFPGA_USER, and KVFPGA_PASSWORD with value-hiding repr fields; KVFPGA_HOST is intentionally ignored.
- Add automatic tty detection for /dev/serial/by-id/*kv260* and /dev/ttyUSB*, plus focused fake-serial and live-skip tests.

## Evidence
- python3 -m compileall -q contracts scripts/tests
- python3 scripts/tests/kv260_serial_connection_test.py
- python3 scripts/tests/device_session_status_contract_test.py
- python3 scripts/tests/runtime_readiness_contract_test.py
- for test_path in scripts/tests/*_test.py; do python3 "$test_path"; done
- find scripts -type f -name '*.sh' -print0 | xargs -0 -n1 bash -n
- for test_path in scripts/tests/*.sh; do bash "$test_path"; done
- git diff --check
- claim-scan clean

## Notes
- Uses pyserial lazily at runtime; local tests use fake serial objects, and the live serial probe skipped because usable serial credentials were not configured in this environment.
- No SSH calls, network scans, model weight access, provider calls, pccx-lab execution, or runtime inference are added.
- shellcheck is not installed in the local environment; per maintainer direction, this is marked and the slice proceeds with bash -n plus existing shell test coverage.
