### PR TITLE
feat(gemma): weight prep stage 1 — contract + dummy manifest

### DIFF
--- a/contracts/gemma_weight_prep_contract.py
+++ b/contracts/gemma_weight_prep_contract.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Stage-1 Gemma weight-prep contract and deterministic dummy manifest.
+
+This module is a data-only contract for the future Gemma weight-preparation
+pipeline. Stage 1 intentionally avoids Hugging Face downloads, filesystem
+weight loads, and real W4 quantization. The dummy path exists only to exercise
+manifest shape, invariants, and deterministic test coverage.
+"""
+
+from __future__ import annotations
+
+import math
+import random
+from dataclasses import dataclass
+
+
+SCHEMA_VERSION = "pccx.gemmaWeightPrepManifest.v1"
+DUMMY_MODEL_ID = "gemma3n-e4b-dummy"
+DUMMY_TILE_ID = "gemma3n_e4b_layer0_attn_q_proj_tile0_dummy"
+DUMMY_SCALE_ID = "gemma3n_e4b_layer0_attn_q_proj_tile0_scale_dummy"
+DUMMY_SOURCE_SHAPE = (4, 8)
+DUMMY_TILE_SHAPE = (4, 8)
+
+
+def _product(shape: tuple[int, ...]) -> int:
+    total = 1
+    for dim in shape:
+        total *= dim
+    return total
+
+
+@dataclass(frozen=True)
+class Scale:
+    """Per-tile scale metadata for a placeholder W4 tile.
+
+    Invariants:
+    - `scale_id` is non-empty and unique within its manifest.
+    - `tile_id` points to exactly one `WeightTile` in the same manifest.
+    - `dtype` and `quantization_label` carry `_dummy` to prevent real-W4 claims.
+    - `shape` contains positive dimensions and matches the value count.
+    - `values` are finite positive placeholders, not calibrated scales.
+    """
+
+    scale_id: str
+    tile_id: str
+    dtype: str
+    shape: tuple[int, ...]
+    values: tuple[float, ...]
+    quantization_label: str
+
+    def __post_init__(self) -> None:
+        if not self.scale_id:
+            raise ValueError("scale_id must be non-empty")
+        if not self.tile_id:
+            raise ValueError("tile_id must be non-empty")
+        if not self.dtype.endswith("_dummy"):
+            raise ValueError("dtype must be labelled _dummy")
+        if not self.quantization_label.endswith("_dummy"):
+            raise ValueError("quantization_label must be labelled _dummy")
+        if not self.shape or any(dim <= 0 for dim in self.shape):
+            raise ValueError("shape must contain positive dimensions")
+        if len(self.values) != _product(self.shape):
+            raise ValueError("values must match shape element count")
+        if any((not math.isfinite(value)) or value <= 0.0 for value in self.values):
+            raise ValueError("scale values must be finite and positive")
+
+
+@dataclass(frozen=True)
+class WeightTile:
+    """Packed placeholder W4 tile derived from BF16-shaped dummy data.
+
+    Invariants:
+    - `tile_id` is non-empty and unique within its manifest.
+    - `source_dtype` and `packed_dtype` carry `_dummy` labels.
+    - `source_shape` and `tile_shape` have the same rank and positive dimensions.
+    - `packed_nibbles` has two placeholder W4 nibbles per byte, rounded up.
+    - `scale_id` points to exactly one `Scale` in the same manifest.
+    - The bytes are deterministic dummy payload, not a real W4 algorithm output.
+    """
+
+    tile_id: str
+    source_dtype: str
+    source_shape: tuple[int, ...]
+    tile_shape: tuple[int, ...]
+    packed_dtype: str
+    quantization_label: str
+    packed_nibbles: bytes
+    scale_id: str
+
+    def __post_init__(self) -> None:
+        if not self.tile_id:
+            raise ValueError("tile_id must be non-empty")
+        if not self.source_dtype.endswith("_dummy"):
+            raise ValueError("source_dtype must be labelled _dummy")
+        if not self.packed_dtype.endswith("_dummy"):
+            raise ValueError("packed_dtype must be labelled _dummy")
+        if not self.quantization_label.endswith("_dummy"):
+            raise ValueError("quantization_label must be labelled _dummy")
+        if not self.source_shape or any(dim <= 0 for dim in self.source_shape):
+            raise ValueError("source_shape must contain positive dimensions")
+        if len(self.tile_shape) != len(self.source_shape):
+            raise ValueError("tile_shape must have the same rank as source_shape")
+        if any(dim <= 0 for dim in self.tile_shape):
+            raise ValueError("tile_shape must contain positive dimensions")
+        if any(
+            tile_dim > source_dim
+            for tile_dim, source_dim in zip(self.tile_shape, self.source_shape)
+        ):
+            raise ValueError("tile_shape cannot exceed source_shape")
+        if not self.scale_id:
+            raise ValueError("scale_id must be non-empty")
+
+        expected_bytes = (_product(self.tile_shape) + 1) // 2
+        if len(self.packed_nibbles) != expected_bytes:
+            raise ValueError("packed_nibbles must match placeholder W4 byte count")
+
+
+@dataclass(frozen=True)
+class Manifest:
+    """Data-only Gemma weight-prep manifest.
+
+    Invariants:
+    - `schema_version` is `SCHEMA_VERSION`.
+    - `seed` records the deterministic dummy RNG seed.
+    - `weight_format`, `source_dtype`, `pipeline_label`, and artifact ids carry
+      `_dummy` labels.
+    - Tile and scale identifiers are unique, non-empty, and cross-referenced.
+    - `real_algo_stage` is `stage2`; stage 1 must not claim real W4 support.
+    - `hf_touched` is always false; this contract never reads HF cache/assets.
+    """
+
+    schema_version: str
+    manifest_id: str
+    model_id: str
+    seed: int
+    source_dtype: str
+    weight_format: str
+    pipeline_label: str
+    tiles: tuple[WeightTile, ...]
+    scales: tuple[Scale, ...]
+    artifact_ids: tuple[str, ...]
+    evidence_refs: tuple[str, ...]
+    limitations: tuple[str, ...]
+    real_algo_stage: str
+    hf_touched: bool
+
+    def __post_init__(self) -> None:
+        if self.schema_version != SCHEMA_VERSION:
+            raise ValueError("schema_version mismatch")
+        if not self.manifest_id:
+            raise ValueError("manifest_id must be non-empty")
+        if not self.model_id:
+            raise ValueError("model_id must be non-empty")
+        if not isinstance(self.seed, int):
+            raise ValueError("seed must be an int")
+        if not self.source_dtype.endswith("_dummy"):
+            raise ValueError("source_dtype must be labelled _dummy")
+        if not self.weight_format.endswith("_dummy"):
+            raise ValueError("weight_format must be labelled _dummy")
+        if not self.pipeline_label.endswith("_dummy"):
+            raise ValueError("pipeline_label must be labelled _dummy")
+        if not self.tiles:
+            raise ValueError("manifest must contain at least one tile")
+        if not self.scales:
+            raise ValueError("manifest must contain at least one scale")
+        if any(not artifact_id.endswith("_dummy") for artifact_id in self.artifact_ids):
+            raise ValueError("artifact ids must be labelled _dummy")
+        if self.real_algo_stage != "stage2":
+            raise ValueError("real_algo_stage must be stage2")
+        if self.hf_touched is not False:
+            raise ValueError("hf_touched must be false")
+
+        tile_ids = tuple(tile.tile_id for tile in self.tiles)
+        scale_ids = tuple(scale.scale_id for scale in self.scales)
+        if len(set(tile_ids)) != len(tile_ids):
+            raise ValueError("tile ids must be unique")
+        if len(set(scale_ids)) != len(scale_ids):
+            raise ValueError("scale ids must be unique")
+
+        scales_by_tile = {scale.tile_id for scale in self.scales}
+        for tile in self.tiles:
+            if tile.scale_id not in scale_ids:
+                raise ValueError("tile scale_id must reference a manifest scale")
+            if tile.tile_id not in scales_by_tile:
+                raise ValueError("each tile must have a matching scale")
+
+
+class GemmaWeightPrep:
+    """Stage-1 Gemma weight-prep boundary.
+
+    `prepare_dummy()` is the only implemented pipeline. The real W4 algorithm
+    belongs in stage 2 and remains explicitly unimplemented here.
+    """
+
+    def prepare_dummy(self, seed: int) -> Manifest:
+        """Create a deterministic dummy manifest without loading real weights."""
+
+        rng = random.Random(seed)
+        bf16_words = tuple(rng.getrandbits(16) for _ in range(_product(DUMMY_SOURCE_SHAPE)))
+        packed = self._placeholder_w4_quantize_dummy(bf16_words)
+        scale = Scale(
+            scale_id=DUMMY_SCALE_ID,
+            tile_id=DUMMY_TILE_ID,
+            dtype="float32_dummy",
+            shape=(1,),
+            values=(1.0,),
+            quantization_label="w4_placeholder_scale_dummy",
+        )
+        tile = WeightTile(
+            tile_id=DUMMY_TILE_ID,
+            source_dtype="bf16_dummy",
+            source_shape=DUMMY_SOURCE_SHAPE,
+            tile_shape=DUMMY_TILE_SHAPE,
+            packed_dtype="uint4_packed_dummy",
+            quantization_label="w4_placeholder_quantize_dummy",
+            packed_nibbles=packed,
+            scale_id=scale.scale_id,
+        )
+        return Manifest(
+            schema_version=SCHEMA_VERSION,
+            manifest_id=f"gemma_weight_prep_seed_{seed}_dummy",
+            model_id=DUMMY_MODEL_ID,
+            seed=seed,
+            source_dtype="bf16_dummy",
+            weight_format="w4_placeholder_dummy",
+            pipeline_label="prepare_dummy",
+            tiles=(tile,),
+            scales=(scale,),
+            artifact_ids=("gemma_weight_tile_0_memory_only_dummy",),
+            evidence_refs=("stage1_dummy_manifest_test",),
+            limitations=(
+                "dummy_data_only",
+                "real_w4_algo_in_stage2",
+                "no_hf_download_or_weight_load",
+            ),
+            real_algo_stage="stage2",
+            hf_touched=False,
+        )
+
+    def prepare_real_w4(self) -> Manifest:
+        raise NotImplementedError("real algo in stage 2")
+
+    @staticmethod
+    def _placeholder_w4_quantize_dummy(bf16_words: tuple[int, ...]) -> bytes:
+        """Pack deterministic dummy nibbles; this is not real W4 quantization."""
+
+        nibbles = tuple((word >> 8) & 0x0F for word in bf16_words)
+        packed = bytearray()
+        for index in range(0, len(nibbles), 2):
+            lo = nibbles[index]
+            hi = nibbles[index + 1] if index + 1 < len(nibbles) else 0
+            packed.append(lo | (hi << 4))
+        return bytes(packed)

--- a/scripts/tests/gemma_weight_prep_contract_test.py
+++ b/scripts/tests/gemma_weight_prep_contract_test.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Tests for the stage-1 Gemma weight-prep contract."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "contracts" / "gemma_weight_prep_contract.py"
+TEST_PATH = Path(__file__).resolve()
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location(
+        "gemma_weight_prep_contract",
+        MODULE_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_prepare_dummy_seed_42_manifest_invariants() -> None:
+    module = load_module()
+    manifest = module.GemmaWeightPrep().prepare_dummy(42)
+
+    assert isinstance(manifest, module.Manifest)
+    assert manifest.schema_version == module.SCHEMA_VERSION
+    assert manifest.manifest_id == "gemma_weight_prep_seed_42_dummy"
+    assert manifest.model_id == module.DUMMY_MODEL_ID
+    assert manifest.seed == 42
+    assert manifest.source_dtype == "bf16_dummy"
+    assert manifest.weight_format == "w4_placeholder_dummy"
+    assert manifest.pipeline_label == "prepare_dummy"
+    assert manifest.real_algo_stage == "stage2"
+    assert manifest.hf_touched is False
+    assert "real_w4_algo_in_stage2" in manifest.limitations
+    assert "no_hf_download_or_weight_load" in manifest.limitations
+
+    assert len(manifest.tiles) == 1
+    assert len(manifest.scales) == 1
+    tile = manifest.tiles[0]
+    scale = manifest.scales[0]
+    assert isinstance(tile, module.WeightTile)
+    assert isinstance(scale, module.Scale)
+    assert tile.tile_id.endswith("_dummy")
+    assert scale.scale_id.endswith("_dummy")
+    assert tile.source_dtype == "bf16_dummy"
+    assert tile.source_shape == module.DUMMY_SOURCE_SHAPE
+    assert tile.tile_shape == module.DUMMY_TILE_SHAPE
+    assert tile.packed_dtype == "uint4_packed_dummy"
+    assert tile.quantization_label == "w4_placeholder_quantize_dummy"
+    assert scale.quantization_label == "w4_placeholder_scale_dummy"
+    assert tile.scale_id == scale.scale_id
+    assert scale.tile_id == tile.tile_id
+
+    expected_byte_count = (4 * 8 + 1) // 2
+    assert len(tile.packed_nibbles) == expected_byte_count
+    assert tile.packed_nibbles.hex() == "c3d6e639acddb4768c77b7a1f67236bb"
+    assert manifest.artifact_ids == ("gemma_weight_tile_0_memory_only_dummy",)
+    assert all(artifact.endswith("_dummy") for artifact in manifest.artifact_ids)
+
+
+def test_prepare_dummy_is_deterministic_and_seeded() -> None:
+    module = load_module()
+    prep = module.GemmaWeightPrep()
+    manifest_a = prep.prepare_dummy(42)
+    manifest_b = prep.prepare_dummy(42)
+    manifest_c = prep.prepare_dummy(43)
+
+    assert manifest_a == manifest_b
+    assert manifest_a.tiles[0].packed_nibbles != manifest_c.tiles[0].packed_nibbles
+
+
+def test_real_w4_algo_is_stage_2_only() -> None:
+    module = load_module()
+    try:
+        module.GemmaWeightPrep().prepare_real_w4()
+    except NotImplementedError as exc:
+        assert "real algo in stage 2" in str(exc)
+    else:
+        raise AssertionError("expected real W4 path to remain unimplemented")
+
+
+def test_source_has_claim_and_hf_guards() -> None:
+    source = read_text(MODULE_PATH)
+    lowered_source = source.lower()
+
+    forbidden_runtime_terms = [
+        "transformers",
+        "huggingface_hub",
+        "hf_hub_download",
+        ".safetensors",
+        ".gguf",
+        ".pt",
+        ".pth",
+        "open(",
+        "read_bytes",
+        "read_text",
+        "requests",
+        "urllib",
+        "subprocess",
+        "socket",
+    ]
+    for term in forbidden_runtime_terms:
+        assert term not in lowered_source, term
+
+    forbidden_claims = [
+        "production-ready",
+        "marketplace-ready",
+        "stable API",
+        "stable ABI",
+        "KV260 inference works",
+        "Gemma 3N E4B runs on KV260",
+        "20 tok/s achieved",
+        "timing closed",
+        "bitstream ready",
+    ]
+    scan_text = source.lower()
+    for claim in forbidden_claims:
+        assert claim.lower() not in scan_text, claim
+
+
+def test_source_headers_for_touched_code_files() -> None:
+    expected_headers = {
+        MODULE_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        TEST_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+    }
+    for path, header in expected_headers.items():
+        assert read_text(path).splitlines()[: len(header)] == header, path
+
+
+test_prepare_dummy_seed_42_manifest_invariants()
+test_prepare_dummy_is_deterministic_and_seeded()
+test_real_w4_algo_is_stage_2_only()
+test_source_has_claim_and_hf_guards()
+test_source_headers_for_touched_code_files()
+
+print("gemma weight prep contract tests ok")


### PR DESCRIPTION
Refs #70

## Summary
- Add a typed stage-1 Gemma weight-prep contract with documented `WeightTile`, `Scale`, and `Manifest` invariants.
- Implement `GemmaWeightPrep.prepare_dummy(seed: int) -> Manifest` using a seeded RNG, BF16-shaped dummy words, and `_dummy`-labelled placeholder W4 packing.
- Add a direct e2e-style test for `prepare_dummy(42)` that checks manifest invariants and deterministic dummy payload bytes.

## Evidence
- python3 scripts/tests/gemma_weight_prep_contract_test.py
- python3 -m compileall -q contracts scripts/tests
- for test_path in scripts/tests/*_test.py; do python3 "$test_path"; done
- find scripts -type f -name "*.sh" -print0 | xargs -0 -n1 bash -n
- for test_path in scripts/tests/*.sh; do bash "$test_path"; done
- git diff --cached --check
- claim-scan clean on changed contract surface
- HF/weight-load scan clean on changed contract surface

## Notes
- Real W4 algorithm remains stage 2 and is explicitly unimplemented.
- No HF download, HF cache access, filesystem weight load, board access, provider call, or runtime inference is added.
- shellcheck is not installed in this environment; per lane instruction, marked and proceeded with bash -n plus existing shell tests.
