### PR TITLE
feat(axi): add mock backend for AxiCmdChannel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,6 +325,8 @@ jobs:
         run: python3 scripts/tests/device_session_status_contract_test.py
       - name: run runtime readiness contract tests
         run: python3 scripts/tests/runtime_readiness_contract_test.py
+      - name: run AXI command mock backend tests
+        run: python3 scripts/tests/axi_cmd_mock_backend_test.py
       - name: run chat/session contract tests
         run: python3 scripts/tests/chat_session_contract_test.py
       - name: run chat model status contract tests

--- a/contracts/axi_cmd_channel.py
+++ b/contracts/axi_cmd_channel.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Offline AXI command-channel contract and mock backend.
+
+This module is intentionally local-only. It models the command and status
+registers in memory so tests can exercise launcher-side command flow without a
+board, device file, driver, or runtime transport.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from threading import RLock
+from typing import Deque, Iterable, Protocol
+
+
+MMIO_CMD = "MMIO_CMD"
+MMIO_STAT = "MMIO_STAT"
+UINT32_MASK = 0xFFFF_FFFF
+
+
+@dataclass(frozen=True)
+class NpuCmd:
+    """Command payload written to the modeled MMIO_CMD register."""
+
+    opcode: int
+    arg0: int = 0
+    arg1: int = 0
+    arg2: int = 0
+    flags: int = 0
+
+    def __post_init__(self) -> None:
+        for field_name in ("opcode", "arg0", "arg1", "arg2", "flags"):
+            value = getattr(self, field_name)
+            if not isinstance(value, int):
+                raise TypeError(f"{field_name} must be an int")
+            if value < 0:
+                raise ValueError(f"{field_name} must be non-negative")
+
+    def register_value(self) -> int:
+        """Return a deterministic 32-bit representation for MMIO_CMD."""
+
+        packed = (
+            (self.opcode & 0xFF)
+            | ((self.flags & 0xFF) << 8)
+            | ((self.arg0 & 0xFF) << 16)
+            | ((self.arg1 & 0xFF) << 24)
+        )
+        return (packed ^ (self.arg2 & UINT32_MASK)) & UINT32_MASK
+
+
+@dataclass(frozen=True)
+class NpuStat:
+    """Status payload read from the modeled MMIO_STAT register."""
+
+    completion_count: int = 0
+    last_opcode: int = 0
+    busy: bool = False
+    error: bool = False
+    status_code: int = 0
+
+    def __post_init__(self) -> None:
+        for field_name in ("completion_count", "last_opcode", "status_code"):
+            value = getattr(self, field_name)
+            if not isinstance(value, int):
+                raise TypeError(f"{field_name} must be an int")
+            if value < 0:
+                raise ValueError(f"{field_name} must be non-negative")
+        for field_name in ("busy", "error"):
+            if not isinstance(getattr(self, field_name), bool):
+                raise TypeError(f"{field_name} must be a bool")
+
+    def register_value(self) -> int:
+        """Return a deterministic 32-bit representation for MMIO_STAT."""
+
+        value = (
+            (self.completion_count & 0xFFFF) << 16
+            | ((self.status_code & 0x3F) << 8)
+            | ((self.last_opcode & 0x3F) << 2)
+            | (0x2 if self.error else 0)
+            | (0x1 if self.busy else 0)
+        )
+        return value & UINT32_MASK
+
+
+class AxiCmdChannel(Protocol):
+    """Minimal command-channel interface used by launcher-side tests."""
+
+    def issue(self, cmd: NpuCmd) -> None:
+        """Issue a command to the channel."""
+
+    def poll_stat(self) -> NpuStat:
+        """Read the current command-channel status."""
+
+
+class ScriptedReplyMismatch(AssertionError):
+    """Raised when a scripted mock backend observes an unexpected command."""
+
+
+class AxiCmdMockBackend:
+    """Thread-safe in-memory AXI command backend for offline tests."""
+
+    def __init__(
+        self,
+        scripted_replies: Iterable[tuple[NpuCmd, NpuStat]] | None = None,
+    ) -> None:
+        self._lock = RLock()
+        self._registers = {MMIO_CMD: 0, MMIO_STAT: 0}
+        self._scripted_replies: Deque[tuple[NpuCmd, NpuStat]] = deque(
+            scripted_replies or (),
+        )
+        self._last_cmd: NpuCmd | None = None
+        self._last_stat = NpuStat()
+        self._completion_count = 0
+        self._closed = False
+
+    def __enter__(self) -> "AxiCmdMockBackend":
+        with self._lock:
+            self._closed = False
+            return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        self.close()
+
+    @property
+    def completion_count(self) -> int:
+        with self._lock:
+            return self._completion_count
+
+    @property
+    def last_cmd(self) -> NpuCmd | None:
+        with self._lock:
+            return self._last_cmd
+
+    @property
+    def remaining_scripted_replies(self) -> int:
+        with self._lock:
+            return len(self._scripted_replies)
+
+    def close(self) -> None:
+        with self._lock:
+            self._closed = True
+
+    def issue(self, cmd: NpuCmd) -> None:
+        if not isinstance(cmd, NpuCmd):
+            raise TypeError("cmd must be an NpuCmd")
+
+        with self._lock:
+            self._ensure_open()
+            scripted_stat = self._consume_scripted_reply(cmd)
+            self._completion_count += 1
+            self._last_cmd = cmd
+            self._last_stat = scripted_stat or self._default_stat_for(cmd)
+            self._registers[MMIO_CMD] = cmd.register_value()
+            self._registers[MMIO_STAT] = self._last_stat.register_value()
+
+    def poll_stat(self) -> NpuStat:
+        with self._lock:
+            self._ensure_open()
+            self._registers[MMIO_STAT] = self._last_stat.register_value()
+            return self._last_stat
+
+    def snapshot_registers(self) -> dict[str, int]:
+        with self._lock:
+            return dict(self._registers)
+
+    def assert_script_consumed(self) -> None:
+        with self._lock:
+            remaining = len(self._scripted_replies)
+            if remaining:
+                raise ScriptedReplyMismatch(
+                    f"{remaining} scripted AXI command replies were not used",
+                )
+
+    def _consume_scripted_reply(self, cmd: NpuCmd) -> NpuStat | None:
+        if not self._scripted_replies:
+            return None
+
+        expected_cmd, expected_stat = self._scripted_replies[0]
+        if cmd != expected_cmd:
+            raise ScriptedReplyMismatch(
+                f"expected command {expected_cmd!r}, got {cmd!r}",
+            )
+        self._scripted_replies.popleft()
+        return expected_stat
+
+    def _default_stat_for(self, cmd: NpuCmd) -> NpuStat:
+        return NpuStat(
+            completion_count=self._completion_count,
+            last_opcode=cmd.opcode,
+            busy=False,
+            error=False,
+            status_code=0,
+        )
+
+    def _ensure_open(self) -> None:
+        if self._closed:
+            raise RuntimeError("AxiCmdMockBackend is closed")

--- a/scripts/tests/axi_cmd_mock_backend_test.py
+++ b/scripts/tests/axi_cmd_mock_backend_test.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Unit tests for the offline AXI command-channel mock backend."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "contracts" / "axi_cmd_channel.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location(
+        "axi_cmd_channel",
+        MODULE_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def assert_raises(error_type, callback) -> None:
+    try:
+        callback()
+    except error_type:
+        return
+    raise AssertionError(f"expected {error_type.__name__}")
+
+
+def test_basic_issue_poll_cycle_updates_register_model() -> None:
+    module = load_module()
+    cmd = module.NpuCmd(opcode=3, arg0=4, arg1=5, arg2=6, flags=7)
+
+    backend = module.AxiCmdMockBackend()
+    assert backend.snapshot_registers() == {
+        module.MMIO_CMD: 0,
+        module.MMIO_STAT: module.NpuStat().register_value(),
+    }
+
+    with backend as channel:
+        channel.issue(cmd)
+        first = channel.poll_stat()
+        second = channel.poll_stat()
+        registers = channel.snapshot_registers()
+
+    assert first == second
+    assert first == module.NpuStat(completion_count=1, last_opcode=3)
+    assert backend.completion_count == 1
+    assert backend.last_cmd == cmd
+    assert registers[module.MMIO_CMD] == cmd.register_value()
+    assert registers[module.MMIO_STAT] == first.register_value()
+    assert_raises(RuntimeError, lambda: backend.poll_stat())
+
+
+def test_multiple_issue_cycles_increment_fake_completion_counter() -> None:
+    module = load_module()
+
+    with module.AxiCmdMockBackend() as channel:
+        channel.issue(module.NpuCmd(opcode=1))
+        assert channel.poll_stat() == module.NpuStat(
+            completion_count=1,
+            last_opcode=1,
+        )
+
+        channel.issue(module.NpuCmd(opcode=2, arg0=10))
+        assert channel.poll_stat() == module.NpuStat(
+            completion_count=2,
+            last_opcode=2,
+        )
+
+
+def test_scripted_reply_mode_verifies_commands_and_returns_expected_status() -> None:
+    module = load_module()
+    first_cmd = module.NpuCmd(opcode=9, arg0=1)
+    second_cmd = module.NpuCmd(opcode=10, arg0=2)
+    first_stat = module.NpuStat(
+        completion_count=1,
+        last_opcode=9,
+        status_code=7,
+    )
+    second_stat = module.NpuStat(
+        completion_count=2,
+        last_opcode=10,
+        error=True,
+        status_code=12,
+    )
+
+    with module.AxiCmdMockBackend(
+        scripted_replies=[
+            (first_cmd, first_stat),
+            (second_cmd, second_stat),
+        ],
+    ) as channel:
+        channel.issue(first_cmd)
+        assert channel.poll_stat() == first_stat
+        assert channel.remaining_scripted_replies == 1
+
+        channel.issue(second_cmd)
+        assert channel.poll_stat() == second_stat
+        assert channel.completion_count == 2
+        assert channel.remaining_scripted_replies == 0
+        channel.assert_script_consumed()
+
+
+def test_scripted_reply_mode_rejects_unexpected_command_without_side_effect() -> None:
+    module = load_module()
+    expected_cmd = module.NpuCmd(opcode=1)
+    unexpected_cmd = module.NpuCmd(opcode=2)
+    expected_stat = module.NpuStat(completion_count=1, last_opcode=1)
+
+    with module.AxiCmdMockBackend(
+        scripted_replies=[(expected_cmd, expected_stat)],
+    ) as channel:
+        assert_raises(
+            module.ScriptedReplyMismatch,
+            lambda: channel.issue(unexpected_cmd),
+        )
+        assert channel.completion_count == 0
+        assert channel.remaining_scripted_replies == 1
+        assert channel.snapshot_registers() == {
+            module.MMIO_CMD: 0,
+            module.MMIO_STAT: module.NpuStat().register_value(),
+        }
+
+
+def test_issue_and_poll_are_safe_under_concurrent_test_use() -> None:
+    module = load_module()
+
+    with module.AxiCmdMockBackend() as channel:
+
+        def issue_and_poll(index: int):
+            channel.issue(module.NpuCmd(opcode=index + 1))
+            return channel.poll_stat()
+
+        with ThreadPoolExecutor(max_workers=4) as executor:
+            stats = list(executor.map(issue_and_poll, range(8)))
+
+        assert channel.completion_count == 8
+        assert len(stats) == 8
+        assert all(isinstance(stat, module.NpuStat) for stat in stats)
+        assert channel.poll_stat().completion_count == 8
+
+
+test_basic_issue_poll_cycle_updates_register_model()
+test_multiple_issue_cycles_increment_fake_completion_counter()
+test_scripted_reply_mode_verifies_commands_and_returns_expected_status()
+test_scripted_reply_mode_rejects_unexpected_command_without_side_effect()
+test_issue_and_poll_are_safe_under_concurrent_test_use()
+
+print("AXI command mock backend tests ok")


### PR DESCRIPTION
Refs #70.\n\n## Summary\n- add an offline AxiCmdChannel contract module with NpuCmd, NpuStat, and AxiCmdMockBackend\n- model MMIO_CMD/MMIO_STAT in memory with deterministic issue/poll behavior and a fake completion counter\n- add scripted reply verification for ordered command/status pairs\n- wire the new unit test into CI\n\n## Validation\n- python3 scripts/tests/axi_cmd_mock_backend_test.py\n- find scripts/tests -maxdepth 1 -type f -name '*_test.py' -print0 | sort -z | xargs -0 -n1 python3\n- python3 -m compileall contracts scripts/tests\n- find scripts -type f -name '*.sh' -not -name '*.snapshot' -print0 | sort -z | xargs -0 -n1 bash -n\n- claim-scan clean\n\nNote: local shellcheck was not available in this container; CI installs shellcheck before running it.