### PR TITLE
feat(launcher): add offline dummy end-to-end run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,8 @@ jobs:
                    scripts/chat-gap-matrix-stub.sh \
                    scripts/chat-evidence-manifest-stub.sh \
                    scripts/chat-surface-preview.sh \
-                   scripts/chat-stub.sh; do
+                   scripts/chat-stub.sh \
+                   scripts/pccx-launcher; do
             [ -f "$f" ] && chmod +x "$f" || true
           done
       - name: run scripts/check.sh
@@ -307,6 +308,8 @@ jobs:
         run: ./scripts/chat-surface-preview.sh --model gemma3n-e4b --target kv260
       - name: run scripts/chat-stub.sh --dry-run
         run: ./scripts/chat-stub.sh --dry-run --prompt "hello"
+      - name: run pccx-launcher dummy-e2e
+        run: ./scripts/pccx-launcher dummy-e2e --seed 42
       - name: chat-stub refuses without --dry-run
         run: |
           set -e
@@ -325,8 +328,12 @@ jobs:
         run: python3 scripts/tests/device_session_status_contract_test.py
       - name: run runtime readiness contract tests
         run: python3 scripts/tests/runtime_readiness_contract_test.py
+      - name: run Gemma weight prep contract tests
+        run: python3 scripts/tests/gemma_weight_prep_contract_test.py
       - name: run AXI command mock backend tests
         run: python3 scripts/tests/axi_cmd_mock_backend_test.py
+      - name: run dummy e2e contract tests
+        run: python3 scripts/tests/dummy_e2e_contract_test.py
       - name: run chat/session contract tests
         run: python3 scripts/tests/chat_session_contract_test.py
       - name: run chat model status contract tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,6 +325,8 @@ jobs:
         run: python3 scripts/tests/device_session_status_contract_test.py
       - name: run runtime readiness contract tests
         run: python3 scripts/tests/runtime_readiness_contract_test.py
+      - name: run AXI command mock backend tests
+        run: python3 scripts/tests/axi_cmd_mock_backend_test.py
       - name: run chat/session contract tests
         run: python3 scripts/tests/chat_session_contract_test.py
       - name: run chat model status contract tests

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ and verify host-side prerequisites before the real engine lands.
 | [`scripts/chat-transcript-policy-stub.sh`](./scripts/chat-transcript-policy-stub.sh) | Data-only chat transcript policy JSON for the Gemma 3N E4B + KV260 target. Reports retention, export, storage, and privacy policy state without reading, generating, storing, persisting, summarizing, or exporting prompt/response/transcript content. |
 | [`scripts/chat-audit-event-stub.sh`](./scripts/chat-audit-event-stub.sh) | Data-only chat audit-event JSON for the Gemma 3N E4B + KV260 target. Reports blocked send metadata, redaction policy, absent prompt/response/transcript content, and disabled audit persistence. |
 | [`scripts/chat-error-taxonomy-stub.sh`](./scripts/chat-error-taxonomy-stub.sh) | Data-only chat error taxonomy JSON for the Gemma 3N E4B + KV260 target. Groups blocked readiness, model/runtime, session, and policy errors without reading prompts, providers, configs, model paths, logs, stores, or artifacts. |
+| [`scripts/pccx-launcher`](./scripts/pccx-launcher) | Local launcher CLI dispatcher. `pccx-launcher dummy-e2e --seed N` runs the offline dummy manifest to AXI mock to fake ResultStream path without board, SSH, HF, or network access. |
 | [`scripts/chat-surface-preview.sh`](./scripts/chat-surface-preview.sh) | Read-only terminal preview of the standalone chat surface. Renders the checked chat/session contract as blocked UI state without accepting prompts, executing a model, or writing artifacts. |
 | [`scripts/launch-stub.sh`](./scripts/launch-stub.sh) | Dry-run preview of the intended launch sequence. Requires `--dry-run`; exits 1 without it. |
 | [`scripts/chat-stub.sh`](./scripts/chat-stub.sh) | Dry-run chat stub. Requires `--dry-run`; exits 1 without it. Accepts `--prompt "..."` or stdin. No model is executed. |
@@ -195,6 +196,7 @@ bash scripts/chat-status-summary-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-review-packet-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-gap-matrix-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-evidence-manifest-stub.sh --model gemma3n-e4b --target kv260
+scripts/pccx-launcher dummy-e2e --seed 42
 bash scripts/chat-surface-preview.sh --model gemma3n-e4b --target kv260
 bash scripts/launch-stub.sh --dry-run
 bash scripts/chat-stub.sh --dry-run --prompt "hello"

--- a/contracts/axi_cmd_channel.py
+++ b/contracts/axi_cmd_channel.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Offline AXI command-channel contract and mock backend.
+
+This module is intentionally local-only. It models the command and status
+registers in memory so tests can exercise launcher-side command flow without a
+board, device file, driver, or runtime transport.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from threading import RLock
+from typing import Deque, Iterable, Protocol
+
+
+MMIO_CMD = "MMIO_CMD"
+MMIO_STAT = "MMIO_STAT"
+UINT32_MASK = 0xFFFF_FFFF
+
+
+@dataclass(frozen=True)
+class NpuCmd:
+    """Command payload written to the modeled MMIO_CMD register."""
+
+    opcode: int
+    arg0: int = 0
+    arg1: int = 0
+    arg2: int = 0
+    flags: int = 0
+
+    def __post_init__(self) -> None:
+        for field_name in ("opcode", "arg0", "arg1", "arg2", "flags"):
+            value = getattr(self, field_name)
+            if not isinstance(value, int):
+                raise TypeError(f"{field_name} must be an int")
+            if value < 0:
+                raise ValueError(f"{field_name} must be non-negative")
+
+    def register_value(self) -> int:
+        """Return a deterministic 32-bit representation for MMIO_CMD."""
+
+        packed = (
+            (self.opcode & 0xFF)
+            | ((self.flags & 0xFF) << 8)
+            | ((self.arg0 & 0xFF) << 16)
+            | ((self.arg1 & 0xFF) << 24)
+        )
+        return (packed ^ (self.arg2 & UINT32_MASK)) & UINT32_MASK
+
+
+@dataclass(frozen=True)
+class NpuStat:
+    """Status payload read from the modeled MMIO_STAT register."""
+
+    completion_count: int = 0
+    last_opcode: int = 0
+    busy: bool = False
+    error: bool = False
+    status_code: int = 0
+
+    def __post_init__(self) -> None:
+        for field_name in ("completion_count", "last_opcode", "status_code"):
+            value = getattr(self, field_name)
+            if not isinstance(value, int):
+                raise TypeError(f"{field_name} must be an int")
+            if value < 0:
+                raise ValueError(f"{field_name} must be non-negative")
+        for field_name in ("busy", "error"):
+            if not isinstance(getattr(self, field_name), bool):
+                raise TypeError(f"{field_name} must be a bool")
+
+    def register_value(self) -> int:
+        """Return a deterministic 32-bit representation for MMIO_STAT."""
+
+        value = (
+            (self.completion_count & 0xFFFF) << 16
+            | ((self.status_code & 0x3F) << 8)
+            | ((self.last_opcode & 0x3F) << 2)
+            | (0x2 if self.error else 0)
+            | (0x1 if self.busy else 0)
+        )
+        return value & UINT32_MASK
+
+
+class AxiCmdChannel(Protocol):
+    """Minimal command-channel interface used by launcher-side tests."""
+
+    def issue(self, cmd: NpuCmd) -> None:
+        """Issue a command to the channel."""
+
+    def poll_stat(self) -> NpuStat:
+        """Read the current command-channel status."""
+
+
+class ScriptedReplyMismatch(AssertionError):
+    """Raised when a scripted mock backend observes an unexpected command."""
+
+
+class AxiCmdMockBackend:
+    """Thread-safe in-memory AXI command backend for offline tests."""
+
+    def __init__(
+        self,
+        scripted_replies: Iterable[tuple[NpuCmd, NpuStat]] | None = None,
+    ) -> None:
+        self._lock = RLock()
+        self._registers = {MMIO_CMD: 0, MMIO_STAT: 0}
+        self._scripted_replies: Deque[tuple[NpuCmd, NpuStat]] = deque(
+            scripted_replies or (),
+        )
+        self._last_cmd: NpuCmd | None = None
+        self._last_stat = NpuStat()
+        self._completion_count = 0
+        self._closed = False
+
+    def __enter__(self) -> "AxiCmdMockBackend":
+        with self._lock:
+            self._closed = False
+            return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        self.close()
+
+    @property
+    def completion_count(self) -> int:
+        with self._lock:
+            return self._completion_count
+
+    @property
+    def last_cmd(self) -> NpuCmd | None:
+        with self._lock:
+            return self._last_cmd
+
+    @property
+    def remaining_scripted_replies(self) -> int:
+        with self._lock:
+            return len(self._scripted_replies)
+
+    def close(self) -> None:
+        with self._lock:
+            self._closed = True
+
+    def issue(self, cmd: NpuCmd) -> None:
+        if not isinstance(cmd, NpuCmd):
+            raise TypeError("cmd must be an NpuCmd")
+
+        with self._lock:
+            self._ensure_open()
+            scripted_stat = self._consume_scripted_reply(cmd)
+            self._completion_count += 1
+            self._last_cmd = cmd
+            self._last_stat = scripted_stat or self._default_stat_for(cmd)
+            self._registers[MMIO_CMD] = cmd.register_value()
+            self._registers[MMIO_STAT] = self._last_stat.register_value()
+
+    def poll_stat(self) -> NpuStat:
+        with self._lock:
+            self._ensure_open()
+            self._registers[MMIO_STAT] = self._last_stat.register_value()
+            return self._last_stat
+
+    def snapshot_registers(self) -> dict[str, int]:
+        with self._lock:
+            return dict(self._registers)
+
+    def assert_script_consumed(self) -> None:
+        with self._lock:
+            remaining = len(self._scripted_replies)
+            if remaining:
+                raise ScriptedReplyMismatch(
+                    f"{remaining} scripted AXI command replies were not used",
+                )
+
+    def _consume_scripted_reply(self, cmd: NpuCmd) -> NpuStat | None:
+        if not self._scripted_replies:
+            return None
+
+        expected_cmd, expected_stat = self._scripted_replies[0]
+        if cmd != expected_cmd:
+            raise ScriptedReplyMismatch(
+                f"expected command {expected_cmd!r}, got {cmd!r}",
+            )
+        self._scripted_replies.popleft()
+        return expected_stat
+
+    def _default_stat_for(self, cmd: NpuCmd) -> NpuStat:
+        return NpuStat(
+            completion_count=self._completion_count,
+            last_opcode=cmd.opcode,
+            busy=False,
+            error=False,
+            status_code=0,
+        )
+
+    def _ensure_open(self) -> None:
+        if self._closed:
+            raise RuntimeError("AxiCmdMockBackend is closed")

--- a/contracts/dummy_e2e_contract.py
+++ b/contracts/dummy_e2e_contract.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Offline dummy end-to-end launcher run.
+
+This contract wires the stage-1 dummy Gemma weight manifest into the offline
+AXI command mock backend and emits fake token chunks as a ResultStream. It does
+not touch a board, open SSH, read Hugging Face assets, read configuration, or
+start a real runtime.
+"""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+
+from contracts.axi_cmd_channel import AxiCmdMockBackend, NpuCmd, NpuStat
+from contracts.gemma_weight_prep_contract import GemmaWeightPrep, Manifest
+
+
+SCHEMA_VERSION = "pccx.dummyE2EResultStream.v0"
+TOKEN_COUNT = 6
+
+
+@dataclass(frozen=True)
+class CommandTrace:
+    """One scripted command issued to the offline AXI mock backend."""
+
+    name: str
+    command: NpuCmd
+    status: NpuStat
+    mmio_cmd: int
+    mmio_stat: int
+
+
+@dataclass(frozen=True)
+class FakeToken:
+    """One deterministic fake token emitted by the dummy ResultStream."""
+
+    index: int
+    text: str
+
+
+@dataclass(frozen=True)
+class ResultStream:
+    """Deterministic, offline-only fake token stream for launcher tests."""
+
+    schema_version: str
+    stream_id: str
+    seed: int
+    manifest_id: str
+    model_id: str
+    command_trace: tuple[CommandTrace, ...]
+    tokens: tuple[FakeToken, ...]
+    completed: bool
+    limitations: tuple[str, ...]
+    safety_flags: tuple[tuple[str, bool], ...]
+
+    @property
+    def token_count(self) -> int:
+        return len(self.tokens)
+
+    @property
+    def text(self) -> str:
+        return " ".join(token.text for token in self.tokens)
+
+
+def dummy_e2e(seed: int) -> ResultStream:
+    """Run the offline dummy manifest -> AXI mock -> ResultStream path."""
+
+    manifest = GemmaWeightPrep().prepare_dummy(seed)
+    commands = _scripted_commands(seed, manifest)
+
+    traces: list[CommandTrace] = []
+    with AxiCmdMockBackend(_scripted_replies(commands)) as backend:
+        for name, command, _status in commands:
+            backend.issue(command)
+            status = backend.poll_stat()
+            registers = backend.snapshot_registers()
+            traces.append(
+                CommandTrace(
+                    name=name,
+                    command=command,
+                    status=status,
+                    mmio_cmd=registers["MMIO_CMD"],
+                    mmio_stat=registers["MMIO_STAT"],
+                ),
+            )
+        backend.assert_script_consumed()
+
+    return ResultStream(
+        schema_version=SCHEMA_VERSION,
+        stream_id=f"dummy_e2e_seed_{seed}",
+        seed=seed,
+        manifest_id=manifest.manifest_id,
+        model_id=manifest.model_id,
+        command_trace=tuple(traces),
+        tokens=_fake_tokens(seed, manifest),
+        completed=True,
+        limitations=(
+            "dummy_manifest_only",
+            "fake_tokens_only",
+            "no_board_access",
+            "no_ssh",
+            "no_hf_download_or_weight_load",
+        ),
+        safety_flags=(
+            ("offlineOnly", True),
+            ("deterministic", True),
+            ("dummyManifestOnly", True),
+            ("fakeTokensOnly", True),
+            ("boardAccess", False),
+            ("sshExecution", False),
+            ("hfTouched", False),
+            ("networkCalls", False),
+            ("environmentRead", False),
+            ("modelExecution", False),
+        ),
+    )
+
+
+def format_dummy_e2e_summary(stream: ResultStream) -> str:
+    """Render concise CLI output for the dummy-e2e subcommand."""
+
+    return "\n".join(
+        (
+            "dummy_e2e: ok",
+            f"seed: {stream.seed}",
+            f"manifest: {stream.manifest_id}",
+            f"commands: {len(stream.command_trace)}",
+            f"stream: {stream.stream_id}",
+            f"tokens: {stream.token_count}",
+            f"text: {stream.text}",
+            "offline: board=false ssh=false hf=false network=false",
+        ),
+    ) + "\n"
+
+
+def _scripted_commands(
+    seed: int,
+    manifest: Manifest,
+) -> tuple[tuple[str, NpuCmd, NpuStat], ...]:
+    packed_head = int.from_bytes(manifest.tiles[0].packed_nibbles[:4], "little")
+    seed_byte = seed & 0xFF
+    tile_count = len(manifest.tiles)
+    token_count = TOKEN_COUNT
+    return (
+        (
+            "load_dummy_manifest",
+            NpuCmd(opcode=1, arg0=seed_byte, arg1=tile_count, arg2=packed_head, flags=1),
+            NpuStat(completion_count=1, last_opcode=1, status_code=0),
+        ),
+        (
+            "prime_fake_stream",
+            NpuCmd(opcode=2, arg0=token_count, arg1=seed_byte, arg2=packed_head, flags=2),
+            NpuStat(completion_count=2, last_opcode=2, status_code=0),
+        ),
+        (
+            "finish_fake_stream",
+            NpuCmd(opcode=3, arg0=token_count, arg1=tile_count, arg2=packed_head, flags=4),
+            NpuStat(completion_count=3, last_opcode=3, status_code=0),
+        ),
+    )
+
+
+def _scripted_replies(
+    commands: tuple[tuple[str, NpuCmd, NpuStat], ...],
+) -> tuple[tuple[NpuCmd, NpuStat], ...]:
+    return tuple((command, status) for _name, command, status in commands)
+
+
+def _fake_tokens(seed: int, manifest: Manifest) -> tuple[FakeToken, ...]:
+    vocabulary = (
+        "dummy",
+        "gemma",
+        "axi",
+        "stream",
+        "offline",
+        "tile",
+        "mock",
+        "result",
+    )
+    packed_seed = int.from_bytes(manifest.tiles[0].packed_nibbles[-4:], "little")
+    rng = random.Random((seed << 32) ^ packed_seed)
+    return tuple(
+        FakeToken(index=index, text=f"{rng.choice(vocabulary)}_{rng.randrange(16):x}")
+        for index in range(TOKEN_COUNT)
+    )

--- a/contracts/gemma_weight_prep_contract.py
+++ b/contracts/gemma_weight_prep_contract.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Stage-1 Gemma weight-prep contract and deterministic dummy manifest.
+
+This module is a data-only contract for the future Gemma weight-preparation
+pipeline. Stage 1 intentionally avoids Hugging Face downloads, filesystem
+weight loads, and real W4 quantization. The dummy path exists only to exercise
+manifest shape, invariants, and deterministic test coverage.
+"""
+
+from __future__ import annotations
+
+import math
+import random
+from dataclasses import dataclass
+
+
+SCHEMA_VERSION = "pccx.gemmaWeightPrepManifest.v1"
+DUMMY_MODEL_ID = "gemma3n-e4b-dummy"
+DUMMY_TILE_ID = "gemma3n_e4b_layer0_attn_q_proj_tile0_dummy"
+DUMMY_SCALE_ID = "gemma3n_e4b_layer0_attn_q_proj_tile0_scale_dummy"
+DUMMY_SOURCE_SHAPE = (4, 8)
+DUMMY_TILE_SHAPE = (4, 8)
+
+
+def _product(shape: tuple[int, ...]) -> int:
+    total = 1
+    for dim in shape:
+        total *= dim
+    return total
+
+
+@dataclass(frozen=True)
+class Scale:
+    """Per-tile scale metadata for a placeholder W4 tile.
+
+    Invariants:
+    - `scale_id` is non-empty and unique within its manifest.
+    - `tile_id` points to exactly one `WeightTile` in the same manifest.
+    - `dtype` and `quantization_label` carry `_dummy` to prevent real-W4 claims.
+    - `shape` contains positive dimensions and matches the value count.
+    - `values` are finite positive placeholders, not calibrated scales.
+    """
+
+    scale_id: str
+    tile_id: str
+    dtype: str
+    shape: tuple[int, ...]
+    values: tuple[float, ...]
+    quantization_label: str
+
+    def __post_init__(self) -> None:
+        if not self.scale_id:
+            raise ValueError("scale_id must be non-empty")
+        if not self.tile_id:
+            raise ValueError("tile_id must be non-empty")
+        if not self.dtype.endswith("_dummy"):
+            raise ValueError("dtype must be labelled _dummy")
+        if not self.quantization_label.endswith("_dummy"):
+            raise ValueError("quantization_label must be labelled _dummy")
+        if not self.shape or any(dim <= 0 for dim in self.shape):
+            raise ValueError("shape must contain positive dimensions")
+        if len(self.values) != _product(self.shape):
+            raise ValueError("values must match shape element count")
+        if any((not math.isfinite(value)) or value <= 0.0 for value in self.values):
+            raise ValueError("scale values must be finite and positive")
+
+
+@dataclass(frozen=True)
+class WeightTile:
+    """Packed placeholder W4 tile derived from BF16-shaped dummy data.
+
+    Invariants:
+    - `tile_id` is non-empty and unique within its manifest.
+    - `source_dtype` and `packed_dtype` carry `_dummy` labels.
+    - `source_shape` and `tile_shape` have the same rank and positive dimensions.
+    - `packed_nibbles` has two placeholder W4 nibbles per byte, rounded up.
+    - `scale_id` points to exactly one `Scale` in the same manifest.
+    - The bytes are deterministic dummy payload, not a real W4 algorithm output.
+    """
+
+    tile_id: str
+    source_dtype: str
+    source_shape: tuple[int, ...]
+    tile_shape: tuple[int, ...]
+    packed_dtype: str
+    quantization_label: str
+    packed_nibbles: bytes
+    scale_id: str
+
+    def __post_init__(self) -> None:
+        if not self.tile_id:
+            raise ValueError("tile_id must be non-empty")
+        if not self.source_dtype.endswith("_dummy"):
+            raise ValueError("source_dtype must be labelled _dummy")
+        if not self.packed_dtype.endswith("_dummy"):
+            raise ValueError("packed_dtype must be labelled _dummy")
+        if not self.quantization_label.endswith("_dummy"):
+            raise ValueError("quantization_label must be labelled _dummy")
+        if not self.source_shape or any(dim <= 0 for dim in self.source_shape):
+            raise ValueError("source_shape must contain positive dimensions")
+        if len(self.tile_shape) != len(self.source_shape):
+            raise ValueError("tile_shape must have the same rank as source_shape")
+        if any(dim <= 0 for dim in self.tile_shape):
+            raise ValueError("tile_shape must contain positive dimensions")
+        if any(
+            tile_dim > source_dim
+            for tile_dim, source_dim in zip(self.tile_shape, self.source_shape)
+        ):
+            raise ValueError("tile_shape cannot exceed source_shape")
+        if not self.scale_id:
+            raise ValueError("scale_id must be non-empty")
+
+        expected_bytes = (_product(self.tile_shape) + 1) // 2
+        if len(self.packed_nibbles) != expected_bytes:
+            raise ValueError("packed_nibbles must match placeholder W4 byte count")
+
+
+@dataclass(frozen=True)
+class Manifest:
+    """Data-only Gemma weight-prep manifest.
+
+    Invariants:
+    - `schema_version` is `SCHEMA_VERSION`.
+    - `seed` records the deterministic dummy RNG seed.
+    - `weight_format`, `source_dtype`, `pipeline_label`, and artifact ids carry
+      `_dummy` labels.
+    - Tile and scale identifiers are unique, non-empty, and cross-referenced.
+    - `real_algo_stage` is `stage2`; stage 1 must not claim real W4 support.
+    - `hf_touched` is always false; this contract never reads HF cache/assets.
+    """
+
+    schema_version: str
+    manifest_id: str
+    model_id: str
+    seed: int
+    source_dtype: str
+    weight_format: str
+    pipeline_label: str
+    tiles: tuple[WeightTile, ...]
+    scales: tuple[Scale, ...]
+    artifact_ids: tuple[str, ...]
+    evidence_refs: tuple[str, ...]
+    limitations: tuple[str, ...]
+    real_algo_stage: str
+    hf_touched: bool
+
+    def __post_init__(self) -> None:
+        if self.schema_version != SCHEMA_VERSION:
+            raise ValueError("schema_version mismatch")
+        if not self.manifest_id:
+            raise ValueError("manifest_id must be non-empty")
+        if not self.model_id:
+            raise ValueError("model_id must be non-empty")
+        if not isinstance(self.seed, int):
+            raise ValueError("seed must be an int")
+        if not self.source_dtype.endswith("_dummy"):
+            raise ValueError("source_dtype must be labelled _dummy")
+        if not self.weight_format.endswith("_dummy"):
+            raise ValueError("weight_format must be labelled _dummy")
+        if not self.pipeline_label.endswith("_dummy"):
+            raise ValueError("pipeline_label must be labelled _dummy")
+        if not self.tiles:
+            raise ValueError("manifest must contain at least one tile")
+        if not self.scales:
+            raise ValueError("manifest must contain at least one scale")
+        if any(not artifact_id.endswith("_dummy") for artifact_id in self.artifact_ids):
+            raise ValueError("artifact ids must be labelled _dummy")
+        if self.real_algo_stage != "stage2":
+            raise ValueError("real_algo_stage must be stage2")
+        if self.hf_touched is not False:
+            raise ValueError("hf_touched must be false")
+
+        tile_ids = tuple(tile.tile_id for tile in self.tiles)
+        scale_ids = tuple(scale.scale_id for scale in self.scales)
+        if len(set(tile_ids)) != len(tile_ids):
+            raise ValueError("tile ids must be unique")
+        if len(set(scale_ids)) != len(scale_ids):
+            raise ValueError("scale ids must be unique")
+
+        scales_by_tile = {scale.tile_id for scale in self.scales}
+        for tile in self.tiles:
+            if tile.scale_id not in scale_ids:
+                raise ValueError("tile scale_id must reference a manifest scale")
+            if tile.tile_id not in scales_by_tile:
+                raise ValueError("each tile must have a matching scale")
+
+
+class GemmaWeightPrep:
+    """Stage-1 Gemma weight-prep boundary.
+
+    `prepare_dummy()` is the only implemented pipeline. The real W4 algorithm
+    belongs in stage 2 and remains explicitly unimplemented here.
+    """
+
+    def prepare_dummy(self, seed: int) -> Manifest:
+        """Create a deterministic dummy manifest without loading real weights."""
+
+        rng = random.Random(seed)
+        bf16_words = tuple(rng.getrandbits(16) for _ in range(_product(DUMMY_SOURCE_SHAPE)))
+        packed = self._placeholder_w4_quantize_dummy(bf16_words)
+        scale = Scale(
+            scale_id=DUMMY_SCALE_ID,
+            tile_id=DUMMY_TILE_ID,
+            dtype="float32_dummy",
+            shape=(1,),
+            values=(1.0,),
+            quantization_label="w4_placeholder_scale_dummy",
+        )
+        tile = WeightTile(
+            tile_id=DUMMY_TILE_ID,
+            source_dtype="bf16_dummy",
+            source_shape=DUMMY_SOURCE_SHAPE,
+            tile_shape=DUMMY_TILE_SHAPE,
+            packed_dtype="uint4_packed_dummy",
+            quantization_label="w4_placeholder_quantize_dummy",
+            packed_nibbles=packed,
+            scale_id=scale.scale_id,
+        )
+        return Manifest(
+            schema_version=SCHEMA_VERSION,
+            manifest_id=f"gemma_weight_prep_seed_{seed}_dummy",
+            model_id=DUMMY_MODEL_ID,
+            seed=seed,
+            source_dtype="bf16_dummy",
+            weight_format="w4_placeholder_dummy",
+            pipeline_label="prepare_dummy",
+            tiles=(tile,),
+            scales=(scale,),
+            artifact_ids=("gemma_weight_tile_0_memory_only_dummy",),
+            evidence_refs=("stage1_dummy_manifest_test",),
+            limitations=(
+                "dummy_data_only",
+                "real_w4_algo_in_stage2",
+                "no_hf_download_or_weight_load",
+            ),
+            real_algo_stage="stage2",
+            hf_touched=False,
+        )
+
+    def prepare_real_w4(self) -> Manifest:
+        raise NotImplementedError("real algo in stage 2")
+
+    @staticmethod
+    def _placeholder_w4_quantize_dummy(bf16_words: tuple[int, ...]) -> bytes:
+        """Pack deterministic dummy nibbles; this is not real W4 quantization."""
+
+        nibbles = tuple((word >> 8) & 0x0F for word in bf16_words)
+        packed = bytearray()
+        for index in range(0, len(nibbles), 2):
+            lo = nibbles[index]
+            hi = nibbles[index + 1] if index + 1 < len(nibbles) else 0
+            packed.append(lo | (hi << 4))
+        return bytes(packed)

--- a/scripts/pccx-launcher
+++ b/scripts/pccx-launcher
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Small launcher CLI dispatcher for local contract utilities."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from contracts.dummy_e2e_contract import dummy_e2e, format_dummy_e2e_summary
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(prog="pccx-launcher")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    dummy = subparsers.add_parser(
+        "dummy-e2e",
+        help="run the offline dummy manifest -> AXI mock -> ResultStream path",
+    )
+    dummy.add_argument("--seed", required=True, type=int, help="deterministic seed")
+
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    if args.command == "dummy-e2e":
+        sys.stdout.write(format_dummy_e2e_summary(dummy_e2e(args.seed)))
+        return 0
+    raise AssertionError(f"unhandled command: {args.command}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/axi_cmd_mock_backend_test.py
+++ b/scripts/tests/axi_cmd_mock_backend_test.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Unit tests for the offline AXI command-channel mock backend."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "contracts" / "axi_cmd_channel.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location(
+        "axi_cmd_channel",
+        MODULE_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def assert_raises(error_type, callback) -> None:
+    try:
+        callback()
+    except error_type:
+        return
+    raise AssertionError(f"expected {error_type.__name__}")
+
+
+def test_basic_issue_poll_cycle_updates_register_model() -> None:
+    module = load_module()
+    cmd = module.NpuCmd(opcode=3, arg0=4, arg1=5, arg2=6, flags=7)
+
+    backend = module.AxiCmdMockBackend()
+    assert backend.snapshot_registers() == {
+        module.MMIO_CMD: 0,
+        module.MMIO_STAT: module.NpuStat().register_value(),
+    }
+
+    with backend as channel:
+        channel.issue(cmd)
+        first = channel.poll_stat()
+        second = channel.poll_stat()
+        registers = channel.snapshot_registers()
+
+    assert first == second
+    assert first == module.NpuStat(completion_count=1, last_opcode=3)
+    assert backend.completion_count == 1
+    assert backend.last_cmd == cmd
+    assert registers[module.MMIO_CMD] == cmd.register_value()
+    assert registers[module.MMIO_STAT] == first.register_value()
+    assert_raises(RuntimeError, lambda: backend.poll_stat())
+
+
+def test_multiple_issue_cycles_increment_fake_completion_counter() -> None:
+    module = load_module()
+
+    with module.AxiCmdMockBackend() as channel:
+        channel.issue(module.NpuCmd(opcode=1))
+        assert channel.poll_stat() == module.NpuStat(
+            completion_count=1,
+            last_opcode=1,
+        )
+
+        channel.issue(module.NpuCmd(opcode=2, arg0=10))
+        assert channel.poll_stat() == module.NpuStat(
+            completion_count=2,
+            last_opcode=2,
+        )
+
+
+def test_scripted_reply_mode_verifies_commands_and_returns_expected_status() -> None:
+    module = load_module()
+    first_cmd = module.NpuCmd(opcode=9, arg0=1)
+    second_cmd = module.NpuCmd(opcode=10, arg0=2)
+    first_stat = module.NpuStat(
+        completion_count=1,
+        last_opcode=9,
+        status_code=7,
+    )
+    second_stat = module.NpuStat(
+        completion_count=2,
+        last_opcode=10,
+        error=True,
+        status_code=12,
+    )
+
+    with module.AxiCmdMockBackend(
+        scripted_replies=[
+            (first_cmd, first_stat),
+            (second_cmd, second_stat),
+        ],
+    ) as channel:
+        channel.issue(first_cmd)
+        assert channel.poll_stat() == first_stat
+        assert channel.remaining_scripted_replies == 1
+
+        channel.issue(second_cmd)
+        assert channel.poll_stat() == second_stat
+        assert channel.completion_count == 2
+        assert channel.remaining_scripted_replies == 0
+        channel.assert_script_consumed()
+
+
+def test_scripted_reply_mode_rejects_unexpected_command_without_side_effect() -> None:
+    module = load_module()
+    expected_cmd = module.NpuCmd(opcode=1)
+    unexpected_cmd = module.NpuCmd(opcode=2)
+    expected_stat = module.NpuStat(completion_count=1, last_opcode=1)
+
+    with module.AxiCmdMockBackend(
+        scripted_replies=[(expected_cmd, expected_stat)],
+    ) as channel:
+        assert_raises(
+            module.ScriptedReplyMismatch,
+            lambda: channel.issue(unexpected_cmd),
+        )
+        assert channel.completion_count == 0
+        assert channel.remaining_scripted_replies == 1
+        assert channel.snapshot_registers() == {
+            module.MMIO_CMD: 0,
+            module.MMIO_STAT: module.NpuStat().register_value(),
+        }
+
+
+def test_issue_and_poll_are_safe_under_concurrent_test_use() -> None:
+    module = load_module()
+
+    with module.AxiCmdMockBackend() as channel:
+
+        def issue_and_poll(index: int):
+            channel.issue(module.NpuCmd(opcode=index + 1))
+            return channel.poll_stat()
+
+        with ThreadPoolExecutor(max_workers=4) as executor:
+            stats = list(executor.map(issue_and_poll, range(8)))
+
+        assert channel.completion_count == 8
+        assert len(stats) == 8
+        assert all(isinstance(stat, module.NpuStat) for stat in stats)
+        assert channel.poll_stat().completion_count == 8
+
+
+test_basic_issue_poll_cycle_updates_register_model()
+test_multiple_issue_cycles_increment_fake_completion_counter()
+test_scripted_reply_mode_verifies_commands_and_returns_expected_status()
+test_scripted_reply_mode_rejects_unexpected_command_without_side_effect()
+test_issue_and_poll_are_safe_under_concurrent_test_use()
+
+print("AXI command mock backend tests ok")

--- a/scripts/tests/dummy_e2e_contract_test.py
+++ b/scripts/tests/dummy_e2e_contract_test.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Tests for the offline dummy end-to-end launcher run."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from contracts.dummy_e2e_contract import (
+    SCHEMA_VERSION,
+    TOKEN_COUNT,
+    ResultStream,
+    dummy_e2e,
+    format_dummy_e2e_summary,
+)
+
+
+MODULE_PATH = ROOT / "contracts" / "dummy_e2e_contract.py"
+CLI_PATH = ROOT / "scripts" / "pccx-launcher"
+TEST_PATH = Path(__file__).resolve()
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_dummy_e2e_is_deterministic_for_same_seed() -> None:
+    first = dummy_e2e(42)
+    second = dummy_e2e(42)
+    different = dummy_e2e(43)
+
+    assert first == second
+    assert format_dummy_e2e_summary(first) == format_dummy_e2e_summary(second)
+    assert first != different
+    assert first.tokens != different.tokens
+
+
+def test_dummy_e2e_wires_manifest_axi_mock_and_result_stream() -> None:
+    stream = dummy_e2e(7)
+
+    assert isinstance(stream, ResultStream)
+    assert stream.schema_version == SCHEMA_VERSION
+    assert stream.seed == 7
+    assert stream.manifest_id == "gemma_weight_prep_seed_7_dummy"
+    assert stream.completed is True
+    assert stream.token_count == TOKEN_COUNT
+    assert len(stream.command_trace) == 3
+    assert tuple(trace.name for trace in stream.command_trace) == (
+        "load_dummy_manifest",
+        "prime_fake_stream",
+        "finish_fake_stream",
+    )
+    assert tuple(trace.status.completion_count for trace in stream.command_trace) == (
+        1,
+        2,
+        3,
+    )
+    assert all(trace.mmio_cmd == trace.command.register_value() for trace in stream.command_trace)
+    assert all(trace.mmio_stat == trace.status.register_value() for trace in stream.command_trace)
+    assert tuple(token.index for token in stream.tokens) == tuple(range(TOKEN_COUNT))
+    assert stream.text == " ".join(token.text for token in stream.tokens)
+
+    flags = dict(stream.safety_flags)
+    assert flags["offlineOnly"] is True
+    assert flags["deterministic"] is True
+    assert flags["dummyManifestOnly"] is True
+    assert flags["fakeTokensOnly"] is True
+    assert flags["boardAccess"] is False
+    assert flags["sshExecution"] is False
+    assert flags["hfTouched"] is False
+    assert flags["networkCalls"] is False
+    assert flags["environmentRead"] is False
+    assert flags["modelExecution"] is False
+
+
+def test_cli_dummy_e2e_summary_is_concise_and_deterministic() -> None:
+    command = [str(CLI_PATH), "dummy-e2e", "--seed", "42"]
+    first = subprocess.run(command, check=True, capture_output=True, text=True)
+    second = subprocess.run(command, check=True, capture_output=True, text=True)
+
+    assert first.stderr == ""
+    assert first.stdout == second.stdout
+    assert first.stdout == format_dummy_e2e_summary(dummy_e2e(42))
+    assert first.stdout.endswith("\n")
+    assert "dummy_e2e: ok\n" in first.stdout
+    assert "seed: 42\n" in first.stdout
+    assert "tokens: 6\n" in first.stdout
+    assert "offline: board=false ssh=false hf=false network=false\n" in first.stdout
+
+
+def test_source_has_offline_claim_guard() -> None:
+    source = read_text(MODULE_PATH)
+    cli = read_text(CLI_PATH)
+    combined = source + "\n" + cli
+
+    forbidden_runtime_terms = [
+        "huggingface_hub",
+        "hf_hub_download",
+        ".safetensors",
+        ".gguf",
+        ".pt",
+        ".pth",
+        "requests",
+        "urllib",
+        "socket",
+        "subprocess",
+        "paramiko",
+        "fabric",
+        "os.environ",
+        "getenv",
+    ]
+    lowered = combined.lower()
+    for term in forbidden_runtime_terms:
+        assert term not in lowered, term
+
+    forbidden_private_patterns = [
+        r"/home/[^\s\"']+",
+        r"/Users/[^\s\"']+",
+        r"[A-Za-z]:\\Users\\",
+        r"\b(?:api[_-]?key|authorization|bearer|password|secret|token)\b\s*[:=]",
+    ]
+    summary = format_dummy_e2e_summary(dummy_e2e(42))
+    for pattern in forbidden_private_patterns:
+        assert not re.search(pattern, summary, re.IGNORECASE), pattern
+
+
+def test_source_headers_for_touched_code_files() -> None:
+    expected_headers = {
+        MODULE_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        CLI_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        TEST_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+    }
+    for path, header in expected_headers.items():
+        assert read_text(path).splitlines()[: len(header)] == header, path
+
+
+test_dummy_e2e_is_deterministic_for_same_seed()
+test_dummy_e2e_wires_manifest_axi_mock_and_result_stream()
+test_cli_dummy_e2e_summary_is_concise_and_deterministic()
+test_source_has_offline_claim_guard()
+test_source_headers_for_touched_code_files()
+
+print("dummy e2e contract tests ok")

--- a/scripts/tests/gemma_weight_prep_contract_test.py
+++ b/scripts/tests/gemma_weight_prep_contract_test.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Tests for the stage-1 Gemma weight-prep contract."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "contracts" / "gemma_weight_prep_contract.py"
+TEST_PATH = Path(__file__).resolve()
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location(
+        "gemma_weight_prep_contract",
+        MODULE_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_prepare_dummy_seed_42_manifest_invariants() -> None:
+    module = load_module()
+    manifest = module.GemmaWeightPrep().prepare_dummy(42)
+
+    assert isinstance(manifest, module.Manifest)
+    assert manifest.schema_version == module.SCHEMA_VERSION
+    assert manifest.manifest_id == "gemma_weight_prep_seed_42_dummy"
+    assert manifest.model_id == module.DUMMY_MODEL_ID
+    assert manifest.seed == 42
+    assert manifest.source_dtype == "bf16_dummy"
+    assert manifest.weight_format == "w4_placeholder_dummy"
+    assert manifest.pipeline_label == "prepare_dummy"
+    assert manifest.real_algo_stage == "stage2"
+    assert manifest.hf_touched is False
+    assert "real_w4_algo_in_stage2" in manifest.limitations
+    assert "no_hf_download_or_weight_load" in manifest.limitations
+
+    assert len(manifest.tiles) == 1
+    assert len(manifest.scales) == 1
+    tile = manifest.tiles[0]
+    scale = manifest.scales[0]
+    assert isinstance(tile, module.WeightTile)
+    assert isinstance(scale, module.Scale)
+    assert tile.tile_id.endswith("_dummy")
+    assert scale.scale_id.endswith("_dummy")
+    assert tile.source_dtype == "bf16_dummy"
+    assert tile.source_shape == module.DUMMY_SOURCE_SHAPE
+    assert tile.tile_shape == module.DUMMY_TILE_SHAPE
+    assert tile.packed_dtype == "uint4_packed_dummy"
+    assert tile.quantization_label == "w4_placeholder_quantize_dummy"
+    assert scale.quantization_label == "w4_placeholder_scale_dummy"
+    assert tile.scale_id == scale.scale_id
+    assert scale.tile_id == tile.tile_id
+
+    expected_byte_count = (4 * 8 + 1) // 2
+    assert len(tile.packed_nibbles) == expected_byte_count
+    assert tile.packed_nibbles.hex() == "c3d6e639acddb4768c77b7a1f67236bb"
+    assert manifest.artifact_ids == ("gemma_weight_tile_0_memory_only_dummy",)
+    assert all(artifact.endswith("_dummy") for artifact in manifest.artifact_ids)
+
+
+def test_prepare_dummy_is_deterministic_and_seeded() -> None:
+    module = load_module()
+    prep = module.GemmaWeightPrep()
+    manifest_a = prep.prepare_dummy(42)
+    manifest_b = prep.prepare_dummy(42)
+    manifest_c = prep.prepare_dummy(43)
+
+    assert manifest_a == manifest_b
+    assert manifest_a.tiles[0].packed_nibbles != manifest_c.tiles[0].packed_nibbles
+
+
+def test_real_w4_algo_is_stage_2_only() -> None:
+    module = load_module()
+    try:
+        module.GemmaWeightPrep().prepare_real_w4()
+    except NotImplementedError as exc:
+        assert "real algo in stage 2" in str(exc)
+    else:
+        raise AssertionError("expected real W4 path to remain unimplemented")
+
+
+def test_source_has_claim_and_hf_guards() -> None:
+    source = read_text(MODULE_PATH)
+    lowered_source = source.lower()
+
+    forbidden_runtime_terms = [
+        "transformers",
+        "huggingface_hub",
+        "hf_hub_download",
+        ".safetensors",
+        ".gguf",
+        ".pt",
+        ".pth",
+        "open(",
+        "read_bytes",
+        "read_text",
+        "requests",
+        "urllib",
+        "subprocess",
+        "socket",
+    ]
+    for term in forbidden_runtime_terms:
+        assert term not in lowered_source, term
+
+    forbidden_claims = [
+        "production-ready",
+        "marketplace-ready",
+        "stable API",
+        "stable ABI",
+        "KV260 inference works",
+        "Gemma 3N E4B runs on KV260",
+        "20 tok/s achieved",
+        "timing closed",
+        "bitstream ready",
+    ]
+    scan_text = source.lower()
+    for claim in forbidden_claims:
+        assert claim.lower() not in scan_text, claim
+
+
+def test_source_headers_for_touched_code_files() -> None:
+    expected_headers = {
+        MODULE_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        TEST_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+    }
+    for path, header in expected_headers.items():
+        assert read_text(path).splitlines()[: len(header)] == header, path
+
+
+test_prepare_dummy_seed_42_manifest_invariants()
+test_prepare_dummy_is_deterministic_and_seeded()
+test_real_w4_algo_is_stage_2_only()
+test_source_has_claim_and_hf_guards()
+test_source_headers_for_touched_code_files()
+
+print("gemma weight prep contract tests ok")


### PR DESCRIPTION
Refs #70, #73, #74

## Summary
- Add dummy_e2e(seed) as an offline GemmaWeightPrep.prepare_dummy -> AxiCmdMockBackend -> ResultStream path.
- Add scripts/pccx-launcher dummy-e2e --seed N for a concise deterministic summary.
- Add determinism coverage for same seed output and offline claim guards.

## Tests
- python3 scripts/tests/dummy_e2e_contract_test.py
- python3 scripts/tests/gemma_weight_prep_contract_test.py
- python3 scripts/tests/axi_cmd_mock_backend_test.py
- python3 -m py_compile contracts/gemma_weight_prep_contract.py contracts/axi_cmd_channel.py contracts/dummy_e2e_contract.py scripts/pccx-launcher scripts/tests/gemma_weight_prep_contract_test.py scripts/tests/axi_cmd_mock_backend_test.py scripts/tests/dummy_e2e_contract_test.py
- bash -n \scripts/chat-accessibility-stub.sh
scripts/chat-action-bar-stub.sh
scripts/chat-attachment-policy-stub.sh
scripts/chat-audit-event-stub.sh
scripts/chat-clipboard-policy-stub.sh
scripts/chat-composer-stub.sh
scripts/chat-context-policy-stub.sh
scripts/chat-empty-state-stub.sh
scripts/chat-error-taxonomy-stub.sh
scripts/chat-evidence-manifest-stub.sh
scripts/chat-gap-matrix-stub.sh
scripts/chat-local-only-policy-stub.sh
scripts/chat-message-list-stub.sh
scripts/chat-model-load-request-stub.sh
scripts/chat-model-selection-policy-stub.sh
scripts/chat-model-status-stub.sh
scripts/chat-preferences-stub.sh
scripts/chat-readiness-stub.sh
scripts/chat-redaction-policy-stub.sh
scripts/chat-response-stream-stub.sh
scripts/chat-review-packet-stub.sh
scripts/chat-send-result-stub.sh
scripts/chat-session-index-stub.sh
scripts/chat-session-lifecycle-stub.sh
scripts/chat-session-store-policy-stub.sh
scripts/chat-session-stub.sh
scripts/chat-session-title-policy-stub.sh
scripts/chat-shortcut-map-stub.sh
scripts/chat-status-summary-stub.sh
scripts/chat-stub.sh
scripts/chat-surface-layout-stub.sh
scripts/chat-surface-preview.sh
scripts/chat-transcript-policy-stub.sh
scripts/check-device-stub.sh
scripts/check.sh
scripts/device-session-status-stub.sh
scripts/install-stub.sh
scripts/launch-stub.sh
scripts/runtime-readiness-stub.sh
scripts/status-stub.sh
scripts/tests/status-backend.sh
scripts/tests/status-chat-accessibility.sh
scripts/tests/status-chat-action-bar.sh
scripts/tests/status-chat-attachment-policy.sh
scripts/tests/status-chat-audit-event.sh
scripts/tests/status-chat-clipboard-policy.sh
scripts/tests/status-chat-composer.sh
scripts/tests/status-chat-context-policy.sh
scripts/tests/status-chat-empty-state.sh
scripts/tests/status-chat-error-taxonomy.sh
scripts/tests/status-chat-evidence-manifest.sh
scripts/tests/status-chat-gap-matrix.sh
scripts/tests/status-chat-local-only-policy.sh
scripts/tests/status-chat-message-list.sh
scripts/tests/status-chat-model-load-request.sh
scripts/tests/status-chat-model-selection-policy.sh
scripts/tests/status-chat-model-status.sh
scripts/tests/status-chat-preferences.sh
scripts/tests/status-chat-readiness.sh
scripts/tests/status-chat-redaction-policy.sh
scripts/tests/status-chat-response-stream.sh
scripts/tests/status-chat-review-packet.sh
scripts/tests/status-chat-send-result.sh
scripts/tests/status-chat-session-index.sh
scripts/tests/status-chat-session-store-policy.sh
scripts/tests/status-chat-session-title-policy.sh
scripts/tests/status-chat-session.sh
scripts/tests/status-chat-shortcut-map.sh
scripts/tests/status-chat-status-summary.sh
scripts/tests/status-chat-surface-layout.sh
scripts/tests/status-chat-transcript-policy.sh
scripts/tests/status-device-session.sh
scripts/tests/status-readiness.sh
- claim-scan clean

Note: shellcheck was not available in the local worktree environment.