### PR TITLE
feat(kv260): add board-less mock connection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -327,6 +327,8 @@ jobs:
         run: python3 scripts/tests/runtime_readiness_contract_test.py
       - name: run KV260 serial connection tests
         run: python3 scripts/tests/kv260_serial_connection_test.py
+      - name: run KV260 connection mock tests
+        run: python3 scripts/tests/kv260_connection_mock_test.py
       - name: run chat/session contract tests
         run: python3 scripts/tests/chat_session_contract_test.py
       - name: run chat model status contract tests

--- a/contracts/kv260_connection_mock.py
+++ b/contracts/kv260_connection_mock.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Board-less KV260 connection mock for launcher-side integration tests.
+
+The mock implements the same method contract as ``KV260SerialConnection`` but
+keeps all board state in memory. Scenario fixtures are local test data only;
+loading them never opens a tty, starts a process, or probes host devices.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from contracts.kv260_serial_connection import KV260ConnectionProtocol
+
+
+SCENARIO_DIR = (
+    Path(__file__).resolve().parents[1] / "tests" / "fixtures" / "scenarios"
+)
+SCENARIO_EXTENSIONS = (".yaml", ".json")
+
+
+class KV260ConnectionMockScenarioError(ValueError):
+    """Raised when a mock scenario fixture is missing or invalid."""
+
+
+@dataclass(frozen=True)
+class KV260MockBoardState:
+    """In-memory KV260 board state returned by the mock connection."""
+
+    kernel_uname: str
+    xrt_present: bool
+    xrt_version: str
+    xmutil_listapps: tuple[str, ...]
+
+    @classmethod
+    def from_mapping(cls, payload: Mapping[str, Any]) -> "KV260MockBoardState":
+        kernel_uname = _require_string(payload, "kernel_uname")
+        xrt_version = _optional_string(payload, "xrt_version")
+        xrt_present = _optional_bool(payload, "xrt_present")
+        if xrt_present is None:
+            xrt_present = bool(xrt_version)
+
+        return cls(
+            kernel_uname=kernel_uname,
+            xrt_present=xrt_present,
+            xrt_version=xrt_version,
+            xmutil_listapps=_require_string_tuple(payload, "xmutil_listapps"),
+        )
+
+
+@dataclass(frozen=True)
+class KV260ConnectionMock(KV260ConnectionProtocol):
+    """Board-less implementation of the KV260 connection method contract."""
+
+    state: KV260MockBoardState
+
+    @classmethod
+    def from_scenario(
+        cls,
+        name: str,
+        scenario_dir: Path | None = None,
+    ) -> "KV260ConnectionMock":
+        """Load a named scenario from tests/fixtures/scenarios."""
+
+        if not name or Path(name).name != name:
+            raise KV260ConnectionMockScenarioError("scenario name must be a file stem")
+
+        directory = SCENARIO_DIR if scenario_dir is None else scenario_dir
+        path = _scenario_path(directory, name)
+        payload = _load_fixture(path)
+        return cls(KV260MockBoardState.from_mapping(payload))
+
+    @classmethod
+    def from_state(
+        cls,
+        *,
+        kernel_uname: str,
+        xrt_present: bool | None = None,
+        xrt_version: str = "",
+        xmutil_listapps: Sequence[str] = (),
+    ) -> "KV260ConnectionMock":
+        """Build a mock directly from in-memory state."""
+
+        state = KV260MockBoardState.from_mapping(
+            {
+                "kernel_uname": kernel_uname,
+                "xrt_present": xrt_present,
+                "xrt_version": xrt_version,
+                "xmutil_listapps": list(xmutil_listapps),
+            },
+        )
+        return cls(state)
+
+    def is_reachable(self) -> bool:
+        """Return true for board-less tests without touching hardware."""
+
+        return True
+
+    def kernel_uname(self) -> str:
+        """Return the configured mock ``uname -a`` string."""
+
+        return self.state.kernel_uname
+
+    def xrt_present(self) -> bool:
+        """Return the configured mock XRT availability."""
+
+        return self.state.xrt_present
+
+    def xrt_version(self) -> str:
+        """Return the configured mock XRT version string."""
+
+        return self.state.xrt_version
+
+    def xmutil_listapps(self) -> Sequence[str]:
+        """Return the configured mock ``xmutil listapps`` output lines."""
+
+        return self.state.xmutil_listapps
+
+
+def _scenario_path(directory: Path, name: str) -> Path:
+    for extension in SCENARIO_EXTENSIONS:
+        candidate = directory / f"{name}{extension}"
+        if candidate.is_file():
+            return candidate
+    expected = ", ".join(f"{name}{extension}" for extension in SCENARIO_EXTENSIONS)
+    raise KV260ConnectionMockScenarioError(f"scenario fixture not found: {expected}")
+
+
+def _load_fixture(path: Path) -> Mapping[str, Any]:
+    if path.suffix == ".json":
+        with path.open(encoding="utf-8") as fh:
+            payload = json.load(fh)
+    elif path.suffix == ".yaml":
+        payload = _load_simple_yaml(path)
+    else:
+        raise KV260ConnectionMockScenarioError(
+            f"unsupported scenario extension: {path.suffix}",
+        )
+
+    if not isinstance(payload, Mapping):
+        raise KV260ConnectionMockScenarioError("scenario fixture must be an object")
+    return payload
+
+
+def _load_simple_yaml(path: Path) -> Mapping[str, Any]:
+    parsed: dict[str, Any] = {}
+    pending_key: str | None = None
+    pending_list: list[Any] = []
+
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        if not raw_line.strip() or raw_line.lstrip().startswith("#"):
+            continue
+
+        line = raw_line.rstrip()
+        stripped = line.strip()
+        if stripped.startswith("- "):
+            if pending_key is None:
+                raise KV260ConnectionMockScenarioError("list item without key")
+            pending_list.append(_parse_scalar(stripped[2:]))
+            continue
+
+        if pending_key is not None:
+            parsed[pending_key] = tuple(pending_list)
+            pending_key = None
+            pending_list = []
+
+        if ":" not in stripped:
+            raise KV260ConnectionMockScenarioError(f"invalid yaml line: {raw_line}")
+        key, value = stripped.split(":", 1)
+        key = key.strip()
+        value = value.strip()
+        if not key:
+            raise KV260ConnectionMockScenarioError("empty yaml key")
+        if value:
+            parsed[key] = _parse_scalar(value)
+        else:
+            pending_key = key
+            pending_list = []
+
+    if pending_key is not None:
+        parsed[pending_key] = tuple(pending_list)
+
+    return parsed
+
+
+def _parse_scalar(value: str) -> Any:
+    lowered = value.lower()
+    if lowered == "true":
+        return True
+    if lowered == "false":
+        return False
+    if lowered in {"null", "none", "~"}:
+        return None
+    if value == "[]":
+        return ()
+    if value.startswith(('"', "'")) and value.endswith(value[0]):
+        if value[0] == '"':
+            return json.loads(value)
+        return value[1:-1]
+    return value
+
+
+def _require_string(payload: Mapping[str, Any], key: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value:
+        raise KV260ConnectionMockScenarioError(f"{key} must be a non-empty string")
+    return value
+
+
+def _optional_string(payload: Mapping[str, Any], key: str) -> str:
+    value = payload.get(key, "")
+    if value is None:
+        return ""
+    if not isinstance(value, str):
+        raise KV260ConnectionMockScenarioError(f"{key} must be a string")
+    return value
+
+
+def _optional_bool(payload: Mapping[str, Any], key: str) -> bool | None:
+    value = payload.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, bool):
+        raise KV260ConnectionMockScenarioError(f"{key} must be a bool")
+    return value
+
+
+def _require_string_tuple(payload: Mapping[str, Any], key: str) -> tuple[str, ...]:
+    value = payload.get(key)
+    if value is None:
+        raise KV260ConnectionMockScenarioError(f"{key} must be present")
+    if isinstance(value, str) or not isinstance(value, Sequence):
+        raise KV260ConnectionMockScenarioError(f"{key} must be a list of strings")
+    values = tuple(value)
+    if not all(isinstance(item, str) and item for item in values):
+        raise KV260ConnectionMockScenarioError(f"{key} must be a list of strings")
+    return values

--- a/scripts/tests/kv260_connection_mock_test.py
+++ b/scripts/tests/kv260_connection_mock_test.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Unit tests for the board-less KV260 connection mock."""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "contracts" / "kv260_connection_mock.py"
+SERIAL_MODULE_PATH = ROOT / "contracts" / "kv260_serial_connection.py"
+TEST_PATH = Path(__file__).resolve()
+SCENARIO_DIR = ROOT / "tests" / "fixtures" / "scenarios"
+
+
+def load_module():
+    sys.path.insert(0, str(ROOT))
+    serial_spec = importlib.util.spec_from_file_location(
+        "contracts.kv260_serial_connection",
+        SERIAL_MODULE_PATH,
+    )
+    serial_module = importlib.util.module_from_spec(serial_spec)
+    assert serial_spec.loader is not None
+    sys.modules[serial_spec.name] = serial_module
+    serial_spec.loader.exec_module(serial_module)
+
+    spec = importlib.util.spec_from_file_location(
+        "contracts.kv260_connection_mock",
+        MODULE_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module, serial_module
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def assert_raises(error_type, callback) -> None:
+    try:
+        callback()
+    except error_type:
+        return
+    raise AssertionError(f"expected {error_type.__name__}")
+
+
+def test_happy_path_scenario_implements_serial_connection_protocol() -> None:
+    module, serial_module = load_module()
+
+    connection = module.KV260ConnectionMock.from_scenario("happy_path")
+
+    assert isinstance(connection, serial_module.KV260ConnectionProtocol)
+    assert connection.is_reachable() is True
+    assert connection.kernel_uname() == (
+        "Linux kv260-happy 6.6.0-pccx-mock #1 SMP PREEMPT aarch64 GNU/Linux"
+    )
+    assert connection.xrt_present() is True
+    assert connection.xrt_version() == "XRT mock 2.16.0"
+    assert connection.xmutil_listapps() == (
+        "app: pccx-npu",
+        "app: diagnostics",
+        "app: shell",
+    )
+
+
+def test_xrt_missing_scenario_keeps_board_reachable_without_xrt() -> None:
+    module, _serial_module = load_module()
+
+    connection = module.KV260ConnectionMock.from_scenario("xrt_missing")
+
+    assert connection.is_reachable() is True
+    assert connection.kernel_uname() == (
+        "Linux kv260-no-xrt 6.6.0-pccx-mock #1 SMP PREEMPT aarch64 GNU/Linux"
+    )
+    assert connection.xrt_present() is False
+    assert connection.xrt_version() == ""
+    assert connection.xmutil_listapps() == ()
+
+
+def test_partial_apps_scenario_returns_configured_listapps_subset() -> None:
+    module, _serial_module = load_module()
+
+    connection = module.KV260ConnectionMock.from_scenario("partial_apps")
+
+    assert connection.is_reachable() is True
+    assert connection.xrt_present() is True
+    assert connection.xrt_version() == "XRT mock 2.16.0-partial"
+    assert connection.xmutil_listapps() == ("app: pccx-npu",)
+
+
+def test_direct_state_builder_defaults_xrt_presence_from_version() -> None:
+    module, _serial_module = load_module()
+
+    connection = module.KV260ConnectionMock.from_state(
+        kernel_uname="Linux kv260-direct 6.6.0-pccx-mock aarch64",
+        xrt_version="XRT mock direct",
+        xmutil_listapps=["app: direct"],
+    )
+
+    assert connection.is_reachable() is True
+    assert connection.kernel_uname() == "Linux kv260-direct 6.6.0-pccx-mock aarch64"
+    assert connection.xrt_present() is True
+    assert connection.xrt_version() == "XRT mock direct"
+    assert connection.xmutil_listapps() == ("app: direct",)
+
+
+def test_scenario_loader_rejects_missing_or_path_like_names() -> None:
+    module, _serial_module = load_module()
+
+    assert_raises(
+        module.KV260ConnectionMockScenarioError,
+        lambda: module.KV260ConnectionMock.from_scenario("../happy_path"),
+    )
+    assert_raises(
+        module.KV260ConnectionMockScenarioError,
+        lambda: module.KV260ConnectionMock.from_scenario("missing"),
+    )
+
+
+def test_expected_scenario_fixture_count() -> None:
+    scenario_files = sorted(
+        path
+        for path in SCENARIO_DIR.iterdir()
+        if path.suffix in {".yaml", ".json"}
+    )
+
+    assert [path.stem for path in scenario_files] == [
+        "happy_path",
+        "partial_apps",
+        "xrt_missing",
+    ]
+
+
+def test_source_has_no_board_calls_or_credential_leaks() -> None:
+    source = read_text(MODULE_PATH)
+    test_source = read_text(TEST_PATH)
+    fixture_source = "\n".join(read_text(path) for path in SCENARIO_DIR.iterdir())
+    scan_text = "\n".join([source, fixture_source])
+
+    forbidden_terms = [
+        "param" + "iko",
+        "s" + "cp ",
+        "subprocess",
+        "os.system",
+        "popen",
+        "socket",
+        "requests",
+        "urllib",
+        "serial.Serial",
+        "/dev/",
+        "/dev/mem",
+        "KVFPGA_PASSWORD",
+        "KVFPGA_USER",
+        "KVFPGA_HOST",
+    ]
+    lowered_source = source.lower()
+    for term in forbidden_terms:
+        assert term.lower() not in lowered_source, term
+
+    assert "print(" not in source
+    assert "logging." not in source
+    assert ("raw " + "credential") not in test_source.lower()
+
+    forbidden_claims = [
+        "production-" + "ready",
+        "marketplace-" + "ready",
+        "stable " + "API",
+        "stable " + "ABI",
+        "KV260 inference " + "works",
+        "Gemma 3N E4B " + "runs on KV260",
+        "20 tok/s " + "achieved",
+        "timing " + "closed",
+        "bitstream " + "ready",
+    ]
+    lowered = scan_text.lower()
+    for claim in forbidden_claims:
+        assert claim.lower() not in lowered, claim
+
+    assert not re.search(r"\bssh\s+[^\"']+", source, re.IGNORECASE)
+
+
+def test_source_headers_for_touched_python_files() -> None:
+    expected_headers = {
+        MODULE_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        TEST_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+    }
+    for path, header in expected_headers.items():
+        assert read_text(path).splitlines()[: len(header)] == header, path
+
+
+test_happy_path_scenario_implements_serial_connection_protocol()
+test_xrt_missing_scenario_keeps_board_reachable_without_xrt()
+test_partial_apps_scenario_returns_configured_listapps_subset()
+test_direct_state_builder_defaults_xrt_presence_from_version()
+test_scenario_loader_rejects_missing_or_path_like_names()
+test_expected_scenario_fixture_count()
+test_source_has_no_board_calls_or_credential_leaks()
+test_source_headers_for_touched_python_files()
+
+print("kv260 connection mock tests ok")

--- a/tests/fixtures/scenarios/happy_path.yaml
+++ b/tests/fixtures/scenarios/happy_path.yaml
@@ -1,0 +1,7 @@
+kernel_uname: "Linux kv260-happy 6.6.0-pccx-mock #1 SMP PREEMPT aarch64 GNU/Linux"
+xrt_present: true
+xrt_version: "XRT mock 2.16.0"
+xmutil_listapps:
+  - "app: pccx-npu"
+  - "app: diagnostics"
+  - "app: shell"

--- a/tests/fixtures/scenarios/partial_apps.yaml
+++ b/tests/fixtures/scenarios/partial_apps.yaml
@@ -1,0 +1,5 @@
+kernel_uname: "Linux kv260-partial 6.6.0-pccx-mock #1 SMP PREEMPT aarch64 GNU/Linux"
+xrt_present: true
+xrt_version: "XRT mock 2.16.0-partial"
+xmutil_listapps:
+  - "app: pccx-npu"

--- a/tests/fixtures/scenarios/xrt_missing.json
+++ b/tests/fixtures/scenarios/xrt_missing.json
@@ -1,0 +1,6 @@
+{
+  "kernel_uname": "Linux kv260-no-xrt 6.6.0-pccx-mock #1 SMP PREEMPT aarch64 GNU/Linux",
+  "xrt_present": false,
+  "xrt_version": "",
+  "xmutil_listapps": []
+}


### PR DESCRIPTION
## Summary
- add KV260ConnectionMock backed by in-memory board state
- load named YAML/JSON scenarios from tests/fixtures/scenarios
- add happy_path, xrt_missing, and partial_apps scenario fixtures with standalone tests

## Verification
- python3 scripts/tests/kv260_connection_mock_test.py
- python3 -m compileall -q contracts scripts/tests
- git diff --cached --check
- claim-scan clean
- all standalone Python tests ok

Refs #70, #72, #74.