### PR TITLE
feat(trace): add capture client emitting v2 framing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,6 +334,8 @@ jobs:
         run: python3 scripts/tests/axi_cmd_mock_backend_test.py
       - name: run dummy e2e contract tests
         run: python3 scripts/tests/dummy_e2e_contract_test.py
+      - name: run trace capture client tests
+        run: python3 scripts/tests/trace_capture_client_test.py
       - name: run chat/session contract tests
         run: python3 scripts/tests/chat_session_contract_test.py
       - name: run chat model status contract tests

--- a/contracts/dummy_e2e_contract.py
+++ b/contracts/dummy_e2e_contract.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 
 from contracts.axi_cmd_channel import AxiCmdMockBackend, NpuCmd, NpuStat
 from contracts.gemma_weight_prep_contract import GemmaWeightPrep, Manifest
+from contracts.trace_capture_client import TraceCaptureFrame
 
 
 SCHEMA_VERSION = "pccx.dummyE2EResultStream.v0"
@@ -134,6 +135,21 @@ def format_dummy_e2e_summary(stream: ResultStream) -> str:
             "offline: board=false ssh=false hf=false network=false",
         ),
     ) + "\n"
+
+
+def dummy_e2e_trace_frames(stream: ResultStream) -> tuple[TraceCaptureFrame, ...]:
+    """Map the offline command trace into lab v2 serial trace frames."""
+
+    return tuple(
+        TraceCaptureFrame(
+            frame_idx=index,
+            axi_stat=trace.mmio_stat,
+            engine_completion=trace.status.completion_count & 0xFF,
+            cycles=(index + 1) * 128,
+            err=None,
+        )
+        for index, trace in enumerate(stream.command_trace)
+    )
 
 
 def _scripted_commands(

--- a/contracts/trace_capture_client.py
+++ b/contracts/trace_capture_client.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Launcher-side trace capture client for lab-compatible v2 framing.
+
+The client emits line-delimited serial trace framing compatible with
+``pccxai/pccx-lab#163``. It writes only caller-provided frame data and does not
+open a board connection, inspect the environment, or execute a runtime.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import zlib
+from dataclasses import dataclass
+from os import PathLike
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+
+PCCX_TRACE_BEGIN_MARKER = "===PCCX_TRACE_BEGIN seq=0==="
+PCCX_TRACE_END_PREFIX = "===PCCX_TRACE_END seq="
+PCCX_TRACE_MARKER_SUFFIX = "==="
+
+
+@runtime_checkable
+class TextTraceSink(Protocol):
+    def write(self, text: str) -> object:
+        ...
+
+    def flush(self) -> object:
+        ...
+
+
+@runtime_checkable
+class BinaryTraceSink(Protocol):
+    def write(self, data: bytes) -> object:
+        ...
+
+    def flush(self) -> object:
+        ...
+
+
+TraceSink = TextTraceSink | BinaryTraceSink
+
+
+class Closeable(Protocol):
+    def close(self) -> object:
+        ...
+
+
+@dataclass(frozen=True)
+class TraceCaptureFrame:
+    """One v2 serial trace frame before CRC decoration."""
+
+    frame_idx: int
+    axi_stat: int
+    engine_completion: int
+    cycles: int
+    err: str | None = None
+
+
+class TraceCaptureClient:
+    """Write v2-framed trace JSON lines to stdout, a file, or a serial sink."""
+
+    def __init__(
+        self,
+        serial_port: TraceSink | str | PathLike[str] | None = None,
+        file_path: str | PathLike[str] | None = None,
+    ) -> None:
+        if serial_port is not None and file_path is not None:
+            raise ValueError("configure either serial_port or file_path, not both")
+
+        self._owned_sink: Closeable | None = None
+        self._begun = False
+        self._next_seq = 0
+        self._ended = False
+
+        if file_path is not None:
+            path = Path(file_path)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            self._sink: TraceSink = path.open("w", encoding="utf-8", newline="\n")
+            self._owned_sink = self._sink
+        elif isinstance(serial_port, (str, PathLike)):
+            self._sink = Path(serial_port).open("wb")
+            self._owned_sink = self._sink
+        elif serial_port is not None:
+            self._sink = serial_port
+        else:
+            self._sink = sys.stdout
+
+    def __enter__(self) -> "TraceCaptureClient":
+        self.begin()
+        return self
+
+    def __exit__(self, _exc_type: object, _exc: object, _tb: object) -> None:
+        self.close()
+
+    def begin(self) -> None:
+        """Emit the v2 begin marker."""
+
+        if self._begun:
+            raise RuntimeError("trace capture has already begun")
+        self._write_line(PCCX_TRACE_BEGIN_MARKER)
+        self._begun = True
+
+    def write_frame(self, frame: TraceCaptureFrame) -> None:
+        """Emit one v2 JSON frame with an IEEE CRC32."""
+
+        if self._ended:
+            raise RuntimeError("cannot write frames after trace capture ended")
+        if not self._begun:
+            self.begin()
+        payload = _crc_payload(
+            seq=self._next_seq,
+            frame_idx=frame.frame_idx,
+            axi_stat=frame.axi_stat,
+            engine_completion=frame.engine_completion,
+            cycles=frame.cycles,
+            err=frame.err,
+        )
+        crc32 = serial_frame_crc32(
+            seq=self._next_seq,
+            frame_idx=frame.frame_idx,
+            axi_stat=frame.axi_stat,
+            engine_completion=frame.engine_completion,
+            cycles=frame.cycles,
+            err=frame.err,
+        )
+        line = _compact_json({**payload, "crc32": crc32})
+        self._write_line(line)
+        self._next_seq += 1
+
+    def end(self) -> None:
+        """Emit the v2 end marker using the next expected sequence number."""
+
+        if not self._ended:
+            if not self._begun:
+                self.begin()
+            self._write_line(
+                f"{PCCX_TRACE_END_PREFIX}{self._next_seq}{PCCX_TRACE_MARKER_SUFFIX}",
+            )
+            self._ended = True
+
+    def capture(self, frames: tuple[TraceCaptureFrame, ...]) -> None:
+        """Emit begin marker, all frames, and end marker."""
+
+        self.begin()
+        for frame in frames:
+            self.write_frame(frame)
+        self.end()
+
+    def close(self) -> None:
+        """Finish the trace and close an owned file target."""
+
+        self.end()
+        self._flush()
+        if self._owned_sink is not None:
+            self._owned_sink.close()
+
+    @property
+    def next_seq(self) -> int:
+        return self._next_seq
+
+    def _write_line(self, line: str) -> None:
+        text = f"{line}\n"
+        try:
+            self._sink.write(text)  # type: ignore[arg-type]
+        except TypeError:
+            self._sink.write(text.encode("utf-8"))  # type: ignore[arg-type]
+        self._flush()
+
+    def _flush(self) -> None:
+        self._sink.flush()
+
+
+def serial_frame_crc32(
+    seq: int,
+    frame_idx: int,
+    axi_stat: int,
+    engine_completion: int,
+    cycles: int,
+    err: str | None,
+) -> int:
+    """Return lab-compatible IEEE CRC32 over the canonical v2 payload."""
+
+    payload = _compact_json(
+        _crc_payload(
+            seq=seq,
+            frame_idx=frame_idx,
+            axi_stat=axi_stat,
+            engine_completion=engine_completion,
+            cycles=cycles,
+            err=err,
+        ),
+    ).encode("utf-8")
+    return zlib.crc32(payload) & 0xFFFF_FFFF
+
+
+def _crc_payload(
+    seq: int,
+    frame_idx: int,
+    axi_stat: int,
+    engine_completion: int,
+    cycles: int,
+    err: str | None,
+) -> dict[str, int | str | None]:
+    return {
+        "seq": _u64("seq", seq),
+        "frame_idx": _u32("frame_idx", frame_idx),
+        "axi_stat": _u32("axi_stat", axi_stat),
+        "engine_completion": _u8("engine_completion", engine_completion),
+        "cycles": _u64("cycles", cycles),
+        "err": err,
+    }
+
+
+def _compact_json(payload: dict[str, int | str | None]) -> str:
+    return json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+
+
+def _u8(name: str, value: int) -> int:
+    if not 0 <= value <= 0xFF:
+        raise ValueError(f"{name} must fit u8")
+    return value
+
+
+def _u32(name: str, value: int) -> int:
+    if not 0 <= value <= 0xFFFF_FFFF:
+        raise ValueError(f"{name} must fit u32")
+    return value
+
+
+def _u64(name: str, value: int) -> int:
+    if not 0 <= value <= 0xFFFF_FFFF_FFFF_FFFF:
+        raise ValueError(f"{name} must fit u64")
+    return value

--- a/scripts/pccx-launcher
+++ b/scripts/pccx-launcher
@@ -14,7 +14,12 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from contracts.dummy_e2e_contract import dummy_e2e, format_dummy_e2e_summary
+from contracts.dummy_e2e_contract import (
+    dummy_e2e,
+    dummy_e2e_trace_frames,
+    format_dummy_e2e_summary,
+)
+from contracts.trace_capture_client import TraceCaptureClient
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
@@ -26,6 +31,10 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         help="run the offline dummy manifest -> AXI mock -> ResultStream path",
     )
     dummy.add_argument("--seed", required=True, type=int, help="deterministic seed")
+    dummy.add_argument(
+        "--capture",
+        help="write lab-compatible v2 framed trace lines to this file",
+    )
 
     return parser.parse_args(argv)
 
@@ -33,7 +42,12 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(sys.argv[1:] if argv is None else argv)
     if args.command == "dummy-e2e":
-        sys.stdout.write(format_dummy_e2e_summary(dummy_e2e(args.seed)))
+        stream = dummy_e2e(args.seed)
+        if args.capture is not None:
+            with TraceCaptureClient(file_path=args.capture) as client:
+                for frame in dummy_e2e_trace_frames(stream):
+                    client.write_frame(frame)
+        sys.stdout.write(format_dummy_e2e_summary(stream))
         return 0
     raise AssertionError(f"unhandled command: {args.command}")
 

--- a/scripts/tests/trace_capture_client_test.py
+++ b/scripts/tests/trace_capture_client_test.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Type-focused tests for launcher trace capture framing."""
+
+from __future__ import annotations
+
+import io
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from contracts.dummy_e2e_contract import dummy_e2e, dummy_e2e_trace_frames
+from contracts.trace_capture_client import (
+    PCCX_TRACE_BEGIN_MARKER,
+    TraceCaptureClient,
+    TraceCaptureFrame,
+    serial_frame_crc32,
+)
+
+
+CLI_PATH = ROOT / "scripts" / "pccx-launcher"
+MODULE_PATH = ROOT / "contracts" / "trace_capture_client.py"
+TEST_PATH = Path(__file__).resolve()
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def split_capture(text: str) -> list[str]:
+    return text.splitlines()
+
+
+def assert_valid_v2_frame(line: str, seq: int) -> dict[str, object]:
+    frame = json.loads(line)
+
+    assert frame["seq"] == seq
+    assert set(frame) == {
+        "seq",
+        "frame_idx",
+        "axi_stat",
+        "engine_completion",
+        "cycles",
+        "err",
+        "crc32",
+    }
+    assert frame["crc32"] == serial_frame_crc32(
+        seq=int(frame["seq"]),
+        frame_idx=int(frame["frame_idx"]),
+        axi_stat=int(frame["axi_stat"]),
+        engine_completion=int(frame["engine_completion"]),
+        cycles=int(frame["cycles"]),
+        err=frame["err"] if isinstance(frame["err"], str) else None,
+    )
+    return frame
+
+
+def test_crc32_matches_lab_v2_contract_fixture() -> None:
+    assert serial_frame_crc32(0, 0, 1, 3, 128, None) == 230_227_294
+
+
+def test_trace_capture_client_writes_stdout_style_text_sink() -> None:
+    sink = io.StringIO()
+    client = TraceCaptureClient(serial_port=sink)
+    client.capture(
+        (
+            TraceCaptureFrame(
+                frame_idx=0,
+                axi_stat=1,
+                engine_completion=3,
+                cycles=128,
+            ),
+        ),
+    )
+
+    lines = split_capture(sink.getvalue())
+    assert lines[0] == PCCX_TRACE_BEGIN_MARKER
+    assert_valid_v2_frame(lines[1], seq=0)
+    assert lines[2] == "===PCCX_TRACE_END seq=1==="
+
+
+def test_trace_capture_client_writes_bytes_serial_sink_without_real_serial() -> None:
+    sink = io.BytesIO()
+    client = TraceCaptureClient(serial_port=sink)
+    client.capture(
+        (
+            TraceCaptureFrame(
+                frame_idx=7,
+                axi_stat=9,
+                engine_completion=1,
+                cycles=512,
+                err="fixture warning",
+            ),
+        ),
+    )
+
+    lines = split_capture(sink.getvalue().decode("utf-8"))
+    frame = assert_valid_v2_frame(lines[1], seq=0)
+    assert frame["frame_idx"] == 7
+    assert frame["err"] == "fixture warning"
+
+
+def test_dummy_e2e_trace_frames_are_v2_capture_ready() -> None:
+    stream = dummy_e2e(42)
+    frames = dummy_e2e_trace_frames(stream)
+
+    assert len(frames) == len(stream.command_trace)
+    assert tuple(frame.frame_idx for frame in frames) == (0, 1, 2)
+    assert tuple(frame.axi_stat for frame in frames) == tuple(
+        trace.mmio_stat for trace in stream.command_trace
+    )
+    assert tuple(frame.engine_completion for frame in frames) == (1, 2, 3)
+    assert tuple(frame.cycles for frame in frames) == (128, 256, 384)
+
+
+def test_cli_dummy_e2e_capture_writes_v2_framed_fixture_file() -> None:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        capture_path = Path(temp_dir) / "dummy-e2e.trace.jsonl"
+        out = subprocess.run(
+            [
+                str(CLI_PATH),
+                "dummy-e2e",
+                "--seed",
+                "42",
+                "--capture",
+                str(capture_path),
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        assert out.stderr == ""
+        assert "dummy_e2e: ok\n" in out.stdout
+        lines = split_capture(read_text(capture_path))
+
+    assert lines[0] == PCCX_TRACE_BEGIN_MARKER
+    assert lines[-1] == "===PCCX_TRACE_END seq=3==="
+    assert len(lines) == 5
+    frames = [assert_valid_v2_frame(line, seq=index) for index, line in enumerate(lines[1:-1])]
+    assert [frame["frame_idx"] for frame in frames] == [0, 1, 2]
+
+
+def test_trace_capture_source_headers_and_no_runtime_claims() -> None:
+    expected_headers = {
+        MODULE_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        TEST_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+    }
+    for path, header in expected_headers.items():
+        assert read_text(path).splitlines()[: len(header)] == header, path
+
+    lowered = read_text(MODULE_PATH).lower()
+    for term in ("os.environ", "getenv", "requests", "urllib", "socket", "paramiko", "fabric"):
+        assert term not in lowered, term
+
+
+test_crc32_matches_lab_v2_contract_fixture()
+test_trace_capture_client_writes_stdout_style_text_sink()
+test_trace_capture_client_writes_bytes_serial_sink_without_real_serial()
+test_dummy_e2e_trace_frames_are_v2_capture_ready()
+test_cli_dummy_e2e_capture_writes_v2_framed_fixture_file()
+test_trace_capture_source_headers_and_no_runtime_claims()
+
+print("trace capture client tests ok")


### PR DESCRIPTION
## Summary
- add TraceCaptureClient for pccx-lab#163 v2 serial framing markers and CRC32 JSON lines
- wire pccx-launcher dummy-e2e --capture <path> to emit replay fixtures from the offline command trace
- add type-focused capture tests with text/file/bytes-backed serial sinks and no real serial device

## Verification
- python3 scripts/tests/trace_capture_client_test.py
- python3 scripts/tests/dummy_e2e_contract_test.py
- python3 -m py_compile contracts/trace_capture_client.py contracts/dummy_e2e_contract.py scripts/tests/trace_capture_client_test.py scripts/tests/dummy_e2e_contract_test.py scripts/pccx-launcher
- bash -n scripts/*.sh scripts/tests/*.sh
- git diff --check
- claim-scan clean

Refs #75
Refs pccxai/pccx-lab#163
Refs pccxai/pccx-lab#165