### PR TITLE
feat(e2e): wire dummy_e2e to capture client

### DIFF
--- a/scripts/pccx-launcher
+++ b/scripts/pccx-launcher
@@ -44,9 +44,11 @@ def main(argv: list[str] | None = None) -> int:
     if args.command == "dummy-e2e":
         stream = dummy_e2e(args.seed)
         if args.capture is not None:
-            with TraceCaptureClient(file_path=args.capture) as client:
-                for frame in dummy_e2e_trace_frames(stream):
-                    client.write_frame(frame)
+            client = TraceCaptureClient(file_path=args.capture)
+            try:
+                client.capture(dummy_e2e_trace_frames(stream))
+            finally:
+                client.close()
         sys.stdout.write(format_dummy_e2e_summary(stream))
         return 0
     raise AssertionError(f"unhandled command: {args.command}")

--- a/scripts/tests/trace_capture_client_test.py
+++ b/scripts/tests/trace_capture_client_test.py
@@ -149,6 +149,38 @@ def test_cli_dummy_e2e_capture_writes_v2_framed_fixture_file() -> None:
     assert [frame["frame_idx"] for frame in frames] == [0, 1, 2]
 
 
+def test_cli_dummy_e2e_capture_smoke_tmp_x_jsonl() -> None:
+    capture_path = Path("/tmp/x.jsonl")
+    capture_path.unlink(missing_ok=True)
+    try:
+        out = subprocess.run(
+            [
+                str(CLI_PATH),
+                "dummy-e2e",
+                "--seed",
+                "42",
+                "--capture",
+                str(capture_path),
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        assert out.stderr == ""
+        assert capture_path.exists()
+        lines = split_capture(read_text(capture_path))
+
+        assert lines[0] == PCCX_TRACE_BEGIN_MARKER
+        expected_frames = dummy_e2e_trace_frames(dummy_e2e(42))
+        assert len(lines[1:-1]) == len(expected_frames)
+        assert lines[-1] == f"===PCCX_TRACE_END seq={len(lines[1:-1])}==="
+        for index, line in enumerate(lines[1:-1]):
+            assert_valid_v2_frame(line, seq=index)
+    finally:
+        capture_path.unlink(missing_ok=True)
+
+
 def test_trace_capture_source_headers_and_no_runtime_claims() -> None:
     expected_headers = {
         MODULE_PATH: [
@@ -175,6 +207,7 @@ test_trace_capture_client_writes_stdout_style_text_sink()
 test_trace_capture_client_writes_bytes_serial_sink_without_real_serial()
 test_dummy_e2e_trace_frames_are_v2_capture_ready()
 test_cli_dummy_e2e_capture_writes_v2_framed_fixture_file()
+test_cli_dummy_e2e_capture_smoke_tmp_x_jsonl()
 test_trace_capture_source_headers_and_no_runtime_claims()
 
 print("trace capture client tests ok")


### PR DESCRIPTION
## Summary
- route dummy-e2e capture through TraceCaptureClient.capture()
- add /tmp/x.jsonl smoke coverage for begin marker, frame count, CRC-checked frames, and end marker

## Verification
- python3 scripts/tests/trace_capture_client_test.py
- python3 scripts/tests/dummy_e2e_contract_test.py
- find scripts/tests -name '*.py' -print -exec python3 {} \;
- python3 -m compileall -q contracts scripts
- git diff --check
- scripts/pccx-launcher dummy-e2e --seed 42 --capture /tmp/x.jsonl

Refs #73, #74, #75, #78