### PR TITLE
test(integration): full-mock kv260 e2e harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,6 +325,8 @@ jobs:
         run: python3 scripts/tests/device_session_status_contract_test.py
       - name: run runtime readiness contract tests
         run: python3 scripts/tests/runtime_readiness_contract_test.py
+      - name: run KV260 serial connection tests
+        run: python3 scripts/tests/kv260_serial_connection_test.py
       - name: run chat/session contract tests
         run: python3 scripts/tests/chat_session_contract_test.py
       - name: run chat model status contract tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,6 +334,8 @@ jobs:
         run: python3 scripts/tests/axi_cmd_mock_backend_test.py
       - name: run dummy e2e contract tests
         run: python3 scripts/tests/dummy_e2e_contract_test.py
+      - name: run trace capture client tests
+        run: python3 scripts/tests/trace_capture_client_test.py
       - name: run chat/session contract tests
         run: python3 scripts/tests/chat_session_contract_test.py
       - name: run chat model status contract tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,6 +336,8 @@ jobs:
         run: python3 scripts/tests/dummy_e2e_contract_test.py
       - name: run trace capture client tests
         run: python3 scripts/tests/trace_capture_client_test.py
+      - name: run full mock integration tests
+        run: python3 scripts/tests/full_mock_integration_test.py
       - name: run KV260 serial connection tests
         run: python3 scripts/tests/kv260_serial_connection_test.py
       - name: run KV260 connection mock tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,8 @@ jobs:
                    scripts/chat-gap-matrix-stub.sh \
                    scripts/chat-evidence-manifest-stub.sh \
                    scripts/chat-surface-preview.sh \
-                   scripts/chat-stub.sh; do
+                   scripts/chat-stub.sh \
+                   scripts/pccx-launcher; do
             [ -f "$f" ] && chmod +x "$f" || true
           done
       - name: run scripts/check.sh
@@ -307,6 +308,8 @@ jobs:
         run: ./scripts/chat-surface-preview.sh --model gemma3n-e4b --target kv260
       - name: run scripts/chat-stub.sh --dry-run
         run: ./scripts/chat-stub.sh --dry-run --prompt "hello"
+      - name: run pccx-launcher dummy-e2e
+        run: ./scripts/pccx-launcher dummy-e2e --seed 42
       - name: chat-stub refuses without --dry-run
         run: |
           set -e
@@ -325,8 +328,12 @@ jobs:
         run: python3 scripts/tests/device_session_status_contract_test.py
       - name: run runtime readiness contract tests
         run: python3 scripts/tests/runtime_readiness_contract_test.py
+      - name: run Gemma weight prep contract tests
+        run: python3 scripts/tests/gemma_weight_prep_contract_test.py
       - name: run AXI command mock backend tests
         run: python3 scripts/tests/axi_cmd_mock_backend_test.py
+      - name: run dummy e2e contract tests
+        run: python3 scripts/tests/dummy_e2e_contract_test.py
       - name: run chat/session contract tests
         run: python3 scripts/tests/chat_session_contract_test.py
       - name: run chat model status contract tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -327,6 +327,8 @@ jobs:
         run: python3 scripts/tests/runtime_readiness_contract_test.py
       - name: run KV260 serial connection tests
         run: python3 scripts/tests/kv260_serial_connection_test.py
+      - name: run KV260 connection mock tests
+        run: python3 scripts/tests/kv260_connection_mock_test.py
       - name: run chat/session contract tests
         run: python3 scripts/tests/chat_session_contract_test.py
       - name: run chat model status contract tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,6 +325,8 @@ jobs:
         run: python3 scripts/tests/device_session_status_contract_test.py
       - name: run runtime readiness contract tests
         run: python3 scripts/tests/runtime_readiness_contract_test.py
+      - name: run AXI command mock backend tests
+        run: python3 scripts/tests/axi_cmd_mock_backend_test.py
       - name: run chat/session contract tests
         run: python3 scripts/tests/chat_session_contract_test.py
       - name: run chat model status contract tests

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ and verify host-side prerequisites before the real engine lands.
 | [`scripts/chat-transcript-policy-stub.sh`](./scripts/chat-transcript-policy-stub.sh) | Data-only chat transcript policy JSON for the Gemma 3N E4B + KV260 target. Reports retention, export, storage, and privacy policy state without reading, generating, storing, persisting, summarizing, or exporting prompt/response/transcript content. |
 | [`scripts/chat-audit-event-stub.sh`](./scripts/chat-audit-event-stub.sh) | Data-only chat audit-event JSON for the Gemma 3N E4B + KV260 target. Reports blocked send metadata, redaction policy, absent prompt/response/transcript content, and disabled audit persistence. |
 | [`scripts/chat-error-taxonomy-stub.sh`](./scripts/chat-error-taxonomy-stub.sh) | Data-only chat error taxonomy JSON for the Gemma 3N E4B + KV260 target. Groups blocked readiness, model/runtime, session, and policy errors without reading prompts, providers, configs, model paths, logs, stores, or artifacts. |
+| [`scripts/pccx-launcher`](./scripts/pccx-launcher) | Local launcher CLI dispatcher. `pccx-launcher dummy-e2e --seed N` runs the offline dummy manifest to AXI mock to fake ResultStream path without board, SSH, HF, or network access. |
 | [`scripts/chat-surface-preview.sh`](./scripts/chat-surface-preview.sh) | Read-only terminal preview of the standalone chat surface. Renders the checked chat/session contract as blocked UI state without accepting prompts, executing a model, or writing artifacts. |
 | [`scripts/launch-stub.sh`](./scripts/launch-stub.sh) | Dry-run preview of the intended launch sequence. Requires `--dry-run`; exits 1 without it. |
 | [`scripts/chat-stub.sh`](./scripts/chat-stub.sh) | Dry-run chat stub. Requires `--dry-run`; exits 1 without it. Accepts `--prompt "..."` or stdin. No model is executed. |
@@ -195,6 +196,7 @@ bash scripts/chat-status-summary-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-review-packet-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-gap-matrix-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-evidence-manifest-stub.sh --model gemma3n-e4b --target kv260
+scripts/pccx-launcher dummy-e2e --seed 42
 bash scripts/chat-surface-preview.sh --model gemma3n-e4b --target kv260
 bash scripts/launch-stub.sh --dry-run
 bash scripts/chat-stub.sh --dry-run --prompt "hello"

--- a/contracts/axi_cmd_channel.py
+++ b/contracts/axi_cmd_channel.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Offline AXI command-channel contract and mock backend.
+
+This module is intentionally local-only. It models the command and status
+registers in memory so tests can exercise launcher-side command flow without a
+board, device file, driver, or runtime transport.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from threading import RLock
+from typing import Deque, Iterable, Protocol
+
+
+MMIO_CMD = "MMIO_CMD"
+MMIO_STAT = "MMIO_STAT"
+UINT32_MASK = 0xFFFF_FFFF
+
+
+@dataclass(frozen=True)
+class NpuCmd:
+    """Command payload written to the modeled MMIO_CMD register."""
+
+    opcode: int
+    arg0: int = 0
+    arg1: int = 0
+    arg2: int = 0
+    flags: int = 0
+
+    def __post_init__(self) -> None:
+        for field_name in ("opcode", "arg0", "arg1", "arg2", "flags"):
+            value = getattr(self, field_name)
+            if not isinstance(value, int):
+                raise TypeError(f"{field_name} must be an int")
+            if value < 0:
+                raise ValueError(f"{field_name} must be non-negative")
+
+    def register_value(self) -> int:
+        """Return a deterministic 32-bit representation for MMIO_CMD."""
+
+        packed = (
+            (self.opcode & 0xFF)
+            | ((self.flags & 0xFF) << 8)
+            | ((self.arg0 & 0xFF) << 16)
+            | ((self.arg1 & 0xFF) << 24)
+        )
+        return (packed ^ (self.arg2 & UINT32_MASK)) & UINT32_MASK
+
+
+@dataclass(frozen=True)
+class NpuStat:
+    """Status payload read from the modeled MMIO_STAT register."""
+
+    completion_count: int = 0
+    last_opcode: int = 0
+    busy: bool = False
+    error: bool = False
+    status_code: int = 0
+
+    def __post_init__(self) -> None:
+        for field_name in ("completion_count", "last_opcode", "status_code"):
+            value = getattr(self, field_name)
+            if not isinstance(value, int):
+                raise TypeError(f"{field_name} must be an int")
+            if value < 0:
+                raise ValueError(f"{field_name} must be non-negative")
+        for field_name in ("busy", "error"):
+            if not isinstance(getattr(self, field_name), bool):
+                raise TypeError(f"{field_name} must be a bool")
+
+    def register_value(self) -> int:
+        """Return a deterministic 32-bit representation for MMIO_STAT."""
+
+        value = (
+            (self.completion_count & 0xFFFF) << 16
+            | ((self.status_code & 0x3F) << 8)
+            | ((self.last_opcode & 0x3F) << 2)
+            | (0x2 if self.error else 0)
+            | (0x1 if self.busy else 0)
+        )
+        return value & UINT32_MASK
+
+
+class AxiCmdChannel(Protocol):
+    """Minimal command-channel interface used by launcher-side tests."""
+
+    def issue(self, cmd: NpuCmd) -> None:
+        """Issue a command to the channel."""
+
+    def poll_stat(self) -> NpuStat:
+        """Read the current command-channel status."""
+
+
+class ScriptedReplyMismatch(AssertionError):
+    """Raised when a scripted mock backend observes an unexpected command."""
+
+
+class AxiCmdMockBackend:
+    """Thread-safe in-memory AXI command backend for offline tests."""
+
+    def __init__(
+        self,
+        scripted_replies: Iterable[tuple[NpuCmd, NpuStat]] | None = None,
+    ) -> None:
+        self._lock = RLock()
+        self._registers = {MMIO_CMD: 0, MMIO_STAT: 0}
+        self._scripted_replies: Deque[tuple[NpuCmd, NpuStat]] = deque(
+            scripted_replies or (),
+        )
+        self._last_cmd: NpuCmd | None = None
+        self._last_stat = NpuStat()
+        self._completion_count = 0
+        self._closed = False
+
+    def __enter__(self) -> "AxiCmdMockBackend":
+        with self._lock:
+            self._closed = False
+            return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        self.close()
+
+    @property
+    def completion_count(self) -> int:
+        with self._lock:
+            return self._completion_count
+
+    @property
+    def last_cmd(self) -> NpuCmd | None:
+        with self._lock:
+            return self._last_cmd
+
+    @property
+    def remaining_scripted_replies(self) -> int:
+        with self._lock:
+            return len(self._scripted_replies)
+
+    def close(self) -> None:
+        with self._lock:
+            self._closed = True
+
+    def issue(self, cmd: NpuCmd) -> None:
+        if not isinstance(cmd, NpuCmd):
+            raise TypeError("cmd must be an NpuCmd")
+
+        with self._lock:
+            self._ensure_open()
+            scripted_stat = self._consume_scripted_reply(cmd)
+            self._completion_count += 1
+            self._last_cmd = cmd
+            self._last_stat = scripted_stat or self._default_stat_for(cmd)
+            self._registers[MMIO_CMD] = cmd.register_value()
+            self._registers[MMIO_STAT] = self._last_stat.register_value()
+
+    def poll_stat(self) -> NpuStat:
+        with self._lock:
+            self._ensure_open()
+            self._registers[MMIO_STAT] = self._last_stat.register_value()
+            return self._last_stat
+
+    def snapshot_registers(self) -> dict[str, int]:
+        with self._lock:
+            return dict(self._registers)
+
+    def assert_script_consumed(self) -> None:
+        with self._lock:
+            remaining = len(self._scripted_replies)
+            if remaining:
+                raise ScriptedReplyMismatch(
+                    f"{remaining} scripted AXI command replies were not used",
+                )
+
+    def _consume_scripted_reply(self, cmd: NpuCmd) -> NpuStat | None:
+        if not self._scripted_replies:
+            return None
+
+        expected_cmd, expected_stat = self._scripted_replies[0]
+        if cmd != expected_cmd:
+            raise ScriptedReplyMismatch(
+                f"expected command {expected_cmd!r}, got {cmd!r}",
+            )
+        self._scripted_replies.popleft()
+        return expected_stat
+
+    def _default_stat_for(self, cmd: NpuCmd) -> NpuStat:
+        return NpuStat(
+            completion_count=self._completion_count,
+            last_opcode=cmd.opcode,
+            busy=False,
+            error=False,
+            status_code=0,
+        )
+
+    def _ensure_open(self) -> None:
+        if self._closed:
+            raise RuntimeError("AxiCmdMockBackend is closed")

--- a/contracts/dummy_e2e_contract.py
+++ b/contracts/dummy_e2e_contract.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Offline dummy end-to-end launcher run.
+
+This contract wires the stage-1 dummy Gemma weight manifest into the offline
+AXI command mock backend and emits fake token chunks as a ResultStream. It does
+not touch a board, open SSH, read Hugging Face assets, read configuration, or
+start a real runtime.
+"""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+
+from contracts.axi_cmd_channel import AxiCmdMockBackend, NpuCmd, NpuStat
+from contracts.gemma_weight_prep_contract import GemmaWeightPrep, Manifest
+
+
+SCHEMA_VERSION = "pccx.dummyE2EResultStream.v0"
+TOKEN_COUNT = 6
+
+
+@dataclass(frozen=True)
+class CommandTrace:
+    """One scripted command issued to the offline AXI mock backend."""
+
+    name: str
+    command: NpuCmd
+    status: NpuStat
+    mmio_cmd: int
+    mmio_stat: int
+
+
+@dataclass(frozen=True)
+class FakeToken:
+    """One deterministic fake token emitted by the dummy ResultStream."""
+
+    index: int
+    text: str
+
+
+@dataclass(frozen=True)
+class ResultStream:
+    """Deterministic, offline-only fake token stream for launcher tests."""
+
+    schema_version: str
+    stream_id: str
+    seed: int
+    manifest_id: str
+    model_id: str
+    command_trace: tuple[CommandTrace, ...]
+    tokens: tuple[FakeToken, ...]
+    completed: bool
+    limitations: tuple[str, ...]
+    safety_flags: tuple[tuple[str, bool], ...]
+
+    @property
+    def token_count(self) -> int:
+        return len(self.tokens)
+
+    @property
+    def text(self) -> str:
+        return " ".join(token.text for token in self.tokens)
+
+
+def dummy_e2e(seed: int) -> ResultStream:
+    """Run the offline dummy manifest -> AXI mock -> ResultStream path."""
+
+    manifest = GemmaWeightPrep().prepare_dummy(seed)
+    commands = _scripted_commands(seed, manifest)
+
+    traces: list[CommandTrace] = []
+    with AxiCmdMockBackend(_scripted_replies(commands)) as backend:
+        for name, command, _status in commands:
+            backend.issue(command)
+            status = backend.poll_stat()
+            registers = backend.snapshot_registers()
+            traces.append(
+                CommandTrace(
+                    name=name,
+                    command=command,
+                    status=status,
+                    mmio_cmd=registers["MMIO_CMD"],
+                    mmio_stat=registers["MMIO_STAT"],
+                ),
+            )
+        backend.assert_script_consumed()
+
+    return ResultStream(
+        schema_version=SCHEMA_VERSION,
+        stream_id=f"dummy_e2e_seed_{seed}",
+        seed=seed,
+        manifest_id=manifest.manifest_id,
+        model_id=manifest.model_id,
+        command_trace=tuple(traces),
+        tokens=_fake_tokens(seed, manifest),
+        completed=True,
+        limitations=(
+            "dummy_manifest_only",
+            "fake_tokens_only",
+            "no_board_access",
+            "no_ssh",
+            "no_hf_download_or_weight_load",
+        ),
+        safety_flags=(
+            ("offlineOnly", True),
+            ("deterministic", True),
+            ("dummyManifestOnly", True),
+            ("fakeTokensOnly", True),
+            ("boardAccess", False),
+            ("sshExecution", False),
+            ("hfTouched", False),
+            ("networkCalls", False),
+            ("environmentRead", False),
+            ("modelExecution", False),
+        ),
+    )
+
+
+def format_dummy_e2e_summary(stream: ResultStream) -> str:
+    """Render concise CLI output for the dummy-e2e subcommand."""
+
+    return "\n".join(
+        (
+            "dummy_e2e: ok",
+            f"seed: {stream.seed}",
+            f"manifest: {stream.manifest_id}",
+            f"commands: {len(stream.command_trace)}",
+            f"stream: {stream.stream_id}",
+            f"tokens: {stream.token_count}",
+            f"text: {stream.text}",
+            "offline: board=false ssh=false hf=false network=false",
+        ),
+    ) + "\n"
+
+
+def _scripted_commands(
+    seed: int,
+    manifest: Manifest,
+) -> tuple[tuple[str, NpuCmd, NpuStat], ...]:
+    packed_head = int.from_bytes(manifest.tiles[0].packed_nibbles[:4], "little")
+    seed_byte = seed & 0xFF
+    tile_count = len(manifest.tiles)
+    token_count = TOKEN_COUNT
+    return (
+        (
+            "load_dummy_manifest",
+            NpuCmd(opcode=1, arg0=seed_byte, arg1=tile_count, arg2=packed_head, flags=1),
+            NpuStat(completion_count=1, last_opcode=1, status_code=0),
+        ),
+        (
+            "prime_fake_stream",
+            NpuCmd(opcode=2, arg0=token_count, arg1=seed_byte, arg2=packed_head, flags=2),
+            NpuStat(completion_count=2, last_opcode=2, status_code=0),
+        ),
+        (
+            "finish_fake_stream",
+            NpuCmd(opcode=3, arg0=token_count, arg1=tile_count, arg2=packed_head, flags=4),
+            NpuStat(completion_count=3, last_opcode=3, status_code=0),
+        ),
+    )
+
+
+def _scripted_replies(
+    commands: tuple[tuple[str, NpuCmd, NpuStat], ...],
+) -> tuple[tuple[NpuCmd, NpuStat], ...]:
+    return tuple((command, status) for _name, command, status in commands)
+
+
+def _fake_tokens(seed: int, manifest: Manifest) -> tuple[FakeToken, ...]:
+    vocabulary = (
+        "dummy",
+        "gemma",
+        "axi",
+        "stream",
+        "offline",
+        "tile",
+        "mock",
+        "result",
+    )
+    packed_seed = int.from_bytes(manifest.tiles[0].packed_nibbles[-4:], "little")
+    rng = random.Random((seed << 32) ^ packed_seed)
+    return tuple(
+        FakeToken(index=index, text=f"{rng.choice(vocabulary)}_{rng.randrange(16):x}")
+        for index in range(TOKEN_COUNT)
+    )

--- a/contracts/dummy_e2e_contract.py
+++ b/contracts/dummy_e2e_contract.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 
 from contracts.axi_cmd_channel import AxiCmdMockBackend, NpuCmd, NpuStat
 from contracts.gemma_weight_prep_contract import GemmaWeightPrep, Manifest
+from contracts.trace_capture_client import TraceCaptureFrame
 
 
 SCHEMA_VERSION = "pccx.dummyE2EResultStream.v0"
@@ -134,6 +135,21 @@ def format_dummy_e2e_summary(stream: ResultStream) -> str:
             "offline: board=false ssh=false hf=false network=false",
         ),
     ) + "\n"
+
+
+def dummy_e2e_trace_frames(stream: ResultStream) -> tuple[TraceCaptureFrame, ...]:
+    """Map the offline command trace into lab v2 serial trace frames."""
+
+    return tuple(
+        TraceCaptureFrame(
+            frame_idx=index,
+            axi_stat=trace.mmio_stat,
+            engine_completion=trace.status.completion_count & 0xFF,
+            cycles=(index + 1) * 128,
+            err=None,
+        )
+        for index, trace in enumerate(stream.command_trace)
+    )
 
 
 def _scripted_commands(

--- a/contracts/gemma_weight_prep_contract.py
+++ b/contracts/gemma_weight_prep_contract.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Stage-1 Gemma weight-prep contract and deterministic dummy manifest.
+
+This module is a data-only contract for the future Gemma weight-preparation
+pipeline. Stage 1 intentionally avoids Hugging Face downloads, filesystem
+weight loads, and real W4 quantization. The dummy path exists only to exercise
+manifest shape, invariants, and deterministic test coverage.
+"""
+
+from __future__ import annotations
+
+import math
+import random
+from dataclasses import dataclass
+
+
+SCHEMA_VERSION = "pccx.gemmaWeightPrepManifest.v1"
+DUMMY_MODEL_ID = "gemma3n-e4b-dummy"
+DUMMY_TILE_ID = "gemma3n_e4b_layer0_attn_q_proj_tile0_dummy"
+DUMMY_SCALE_ID = "gemma3n_e4b_layer0_attn_q_proj_tile0_scale_dummy"
+DUMMY_SOURCE_SHAPE = (4, 8)
+DUMMY_TILE_SHAPE = (4, 8)
+
+
+def _product(shape: tuple[int, ...]) -> int:
+    total = 1
+    for dim in shape:
+        total *= dim
+    return total
+
+
+@dataclass(frozen=True)
+class Scale:
+    """Per-tile scale metadata for a placeholder W4 tile.
+
+    Invariants:
+    - `scale_id` is non-empty and unique within its manifest.
+    - `tile_id` points to exactly one `WeightTile` in the same manifest.
+    - `dtype` and `quantization_label` carry `_dummy` to prevent real-W4 claims.
+    - `shape` contains positive dimensions and matches the value count.
+    - `values` are finite positive placeholders, not calibrated scales.
+    """
+
+    scale_id: str
+    tile_id: str
+    dtype: str
+    shape: tuple[int, ...]
+    values: tuple[float, ...]
+    quantization_label: str
+
+    def __post_init__(self) -> None:
+        if not self.scale_id:
+            raise ValueError("scale_id must be non-empty")
+        if not self.tile_id:
+            raise ValueError("tile_id must be non-empty")
+        if not self.dtype.endswith("_dummy"):
+            raise ValueError("dtype must be labelled _dummy")
+        if not self.quantization_label.endswith("_dummy"):
+            raise ValueError("quantization_label must be labelled _dummy")
+        if not self.shape or any(dim <= 0 for dim in self.shape):
+            raise ValueError("shape must contain positive dimensions")
+        if len(self.values) != _product(self.shape):
+            raise ValueError("values must match shape element count")
+        if any((not math.isfinite(value)) or value <= 0.0 for value in self.values):
+            raise ValueError("scale values must be finite and positive")
+
+
+@dataclass(frozen=True)
+class WeightTile:
+    """Packed placeholder W4 tile derived from BF16-shaped dummy data.
+
+    Invariants:
+    - `tile_id` is non-empty and unique within its manifest.
+    - `source_dtype` and `packed_dtype` carry `_dummy` labels.
+    - `source_shape` and `tile_shape` have the same rank and positive dimensions.
+    - `packed_nibbles` has two placeholder W4 nibbles per byte, rounded up.
+    - `scale_id` points to exactly one `Scale` in the same manifest.
+    - The bytes are deterministic dummy payload, not a real W4 algorithm output.
+    """
+
+    tile_id: str
+    source_dtype: str
+    source_shape: tuple[int, ...]
+    tile_shape: tuple[int, ...]
+    packed_dtype: str
+    quantization_label: str
+    packed_nibbles: bytes
+    scale_id: str
+
+    def __post_init__(self) -> None:
+        if not self.tile_id:
+            raise ValueError("tile_id must be non-empty")
+        if not self.source_dtype.endswith("_dummy"):
+            raise ValueError("source_dtype must be labelled _dummy")
+        if not self.packed_dtype.endswith("_dummy"):
+            raise ValueError("packed_dtype must be labelled _dummy")
+        if not self.quantization_label.endswith("_dummy"):
+            raise ValueError("quantization_label must be labelled _dummy")
+        if not self.source_shape or any(dim <= 0 for dim in self.source_shape):
+            raise ValueError("source_shape must contain positive dimensions")
+        if len(self.tile_shape) != len(self.source_shape):
+            raise ValueError("tile_shape must have the same rank as source_shape")
+        if any(dim <= 0 for dim in self.tile_shape):
+            raise ValueError("tile_shape must contain positive dimensions")
+        if any(
+            tile_dim > source_dim
+            for tile_dim, source_dim in zip(self.tile_shape, self.source_shape)
+        ):
+            raise ValueError("tile_shape cannot exceed source_shape")
+        if not self.scale_id:
+            raise ValueError("scale_id must be non-empty")
+
+        expected_bytes = (_product(self.tile_shape) + 1) // 2
+        if len(self.packed_nibbles) != expected_bytes:
+            raise ValueError("packed_nibbles must match placeholder W4 byte count")
+
+
+@dataclass(frozen=True)
+class Manifest:
+    """Data-only Gemma weight-prep manifest.
+
+    Invariants:
+    - `schema_version` is `SCHEMA_VERSION`.
+    - `seed` records the deterministic dummy RNG seed.
+    - `weight_format`, `source_dtype`, `pipeline_label`, and artifact ids carry
+      `_dummy` labels.
+    - Tile and scale identifiers are unique, non-empty, and cross-referenced.
+    - `real_algo_stage` is `stage2`; stage 1 must not claim real W4 support.
+    - `hf_touched` is always false; this contract never reads HF cache/assets.
+    """
+
+    schema_version: str
+    manifest_id: str
+    model_id: str
+    seed: int
+    source_dtype: str
+    weight_format: str
+    pipeline_label: str
+    tiles: tuple[WeightTile, ...]
+    scales: tuple[Scale, ...]
+    artifact_ids: tuple[str, ...]
+    evidence_refs: tuple[str, ...]
+    limitations: tuple[str, ...]
+    real_algo_stage: str
+    hf_touched: bool
+
+    def __post_init__(self) -> None:
+        if self.schema_version != SCHEMA_VERSION:
+            raise ValueError("schema_version mismatch")
+        if not self.manifest_id:
+            raise ValueError("manifest_id must be non-empty")
+        if not self.model_id:
+            raise ValueError("model_id must be non-empty")
+        if not isinstance(self.seed, int):
+            raise ValueError("seed must be an int")
+        if not self.source_dtype.endswith("_dummy"):
+            raise ValueError("source_dtype must be labelled _dummy")
+        if not self.weight_format.endswith("_dummy"):
+            raise ValueError("weight_format must be labelled _dummy")
+        if not self.pipeline_label.endswith("_dummy"):
+            raise ValueError("pipeline_label must be labelled _dummy")
+        if not self.tiles:
+            raise ValueError("manifest must contain at least one tile")
+        if not self.scales:
+            raise ValueError("manifest must contain at least one scale")
+        if any(not artifact_id.endswith("_dummy") for artifact_id in self.artifact_ids):
+            raise ValueError("artifact ids must be labelled _dummy")
+        if self.real_algo_stage != "stage2":
+            raise ValueError("real_algo_stage must be stage2")
+        if self.hf_touched is not False:
+            raise ValueError("hf_touched must be false")
+
+        tile_ids = tuple(tile.tile_id for tile in self.tiles)
+        scale_ids = tuple(scale.scale_id for scale in self.scales)
+        if len(set(tile_ids)) != len(tile_ids):
+            raise ValueError("tile ids must be unique")
+        if len(set(scale_ids)) != len(scale_ids):
+            raise ValueError("scale ids must be unique")
+
+        scales_by_tile = {scale.tile_id for scale in self.scales}
+        for tile in self.tiles:
+            if tile.scale_id not in scale_ids:
+                raise ValueError("tile scale_id must reference a manifest scale")
+            if tile.tile_id not in scales_by_tile:
+                raise ValueError("each tile must have a matching scale")
+
+
+class GemmaWeightPrep:
+    """Stage-1 Gemma weight-prep boundary.
+
+    `prepare_dummy()` is the only implemented pipeline. The real W4 algorithm
+    belongs in stage 2 and remains explicitly unimplemented here.
+    """
+
+    def prepare_dummy(self, seed: int) -> Manifest:
+        """Create a deterministic dummy manifest without loading real weights."""
+
+        rng = random.Random(seed)
+        bf16_words = tuple(rng.getrandbits(16) for _ in range(_product(DUMMY_SOURCE_SHAPE)))
+        packed = self._placeholder_w4_quantize_dummy(bf16_words)
+        scale = Scale(
+            scale_id=DUMMY_SCALE_ID,
+            tile_id=DUMMY_TILE_ID,
+            dtype="float32_dummy",
+            shape=(1,),
+            values=(1.0,),
+            quantization_label="w4_placeholder_scale_dummy",
+        )
+        tile = WeightTile(
+            tile_id=DUMMY_TILE_ID,
+            source_dtype="bf16_dummy",
+            source_shape=DUMMY_SOURCE_SHAPE,
+            tile_shape=DUMMY_TILE_SHAPE,
+            packed_dtype="uint4_packed_dummy",
+            quantization_label="w4_placeholder_quantize_dummy",
+            packed_nibbles=packed,
+            scale_id=scale.scale_id,
+        )
+        return Manifest(
+            schema_version=SCHEMA_VERSION,
+            manifest_id=f"gemma_weight_prep_seed_{seed}_dummy",
+            model_id=DUMMY_MODEL_ID,
+            seed=seed,
+            source_dtype="bf16_dummy",
+            weight_format="w4_placeholder_dummy",
+            pipeline_label="prepare_dummy",
+            tiles=(tile,),
+            scales=(scale,),
+            artifact_ids=("gemma_weight_tile_0_memory_only_dummy",),
+            evidence_refs=("stage1_dummy_manifest_test",),
+            limitations=(
+                "dummy_data_only",
+                "real_w4_algo_in_stage2",
+                "no_hf_download_or_weight_load",
+            ),
+            real_algo_stage="stage2",
+            hf_touched=False,
+        )
+
+    def prepare_real_w4(self) -> Manifest:
+        raise NotImplementedError("real algo in stage 2")
+
+    @staticmethod
+    def _placeholder_w4_quantize_dummy(bf16_words: tuple[int, ...]) -> bytes:
+        """Pack deterministic dummy nibbles; this is not real W4 quantization."""
+
+        nibbles = tuple((word >> 8) & 0x0F for word in bf16_words)
+        packed = bytearray()
+        for index in range(0, len(nibbles), 2):
+            lo = nibbles[index]
+            hi = nibbles[index + 1] if index + 1 < len(nibbles) else 0
+            packed.append(lo | (hi << 4))
+        return bytes(packed)

--- a/contracts/kv260_connection_mock.py
+++ b/contracts/kv260_connection_mock.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Board-less KV260 connection mock for launcher-side integration tests.
+
+The mock implements the same method contract as ``KV260SerialConnection`` but
+keeps all board state in memory. Scenario fixtures are local test data only;
+loading them never opens a tty, starts a process, or probes host devices.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from contracts.kv260_serial_connection import KV260ConnectionProtocol
+
+
+SCENARIO_DIR = (
+    Path(__file__).resolve().parents[1] / "tests" / "fixtures" / "scenarios"
+)
+SCENARIO_EXTENSIONS = (".yaml", ".json")
+
+
+class KV260ConnectionMockScenarioError(ValueError):
+    """Raised when a mock scenario fixture is missing or invalid."""
+
+
+@dataclass(frozen=True)
+class KV260MockBoardState:
+    """In-memory KV260 board state returned by the mock connection."""
+
+    kernel_uname: str
+    xrt_present: bool
+    xrt_version: str
+    xmutil_listapps: tuple[str, ...]
+
+    @classmethod
+    def from_mapping(cls, payload: Mapping[str, Any]) -> "KV260MockBoardState":
+        kernel_uname = _require_string(payload, "kernel_uname")
+        xrt_version = _optional_string(payload, "xrt_version")
+        xrt_present = _optional_bool(payload, "xrt_present")
+        if xrt_present is None:
+            xrt_present = bool(xrt_version)
+
+        return cls(
+            kernel_uname=kernel_uname,
+            xrt_present=xrt_present,
+            xrt_version=xrt_version,
+            xmutil_listapps=_require_string_tuple(payload, "xmutil_listapps"),
+        )
+
+
+@dataclass(frozen=True)
+class KV260ConnectionMock(KV260ConnectionProtocol):
+    """Board-less implementation of the KV260 connection method contract."""
+
+    state: KV260MockBoardState
+
+    @classmethod
+    def from_scenario(
+        cls,
+        name: str,
+        scenario_dir: Path | None = None,
+    ) -> "KV260ConnectionMock":
+        """Load a named scenario from tests/fixtures/scenarios."""
+
+        if not name or Path(name).name != name:
+            raise KV260ConnectionMockScenarioError("scenario name must be a file stem")
+
+        directory = SCENARIO_DIR if scenario_dir is None else scenario_dir
+        path = _scenario_path(directory, name)
+        payload = _load_fixture(path)
+        return cls(KV260MockBoardState.from_mapping(payload))
+
+    @classmethod
+    def from_state(
+        cls,
+        *,
+        kernel_uname: str,
+        xrt_present: bool | None = None,
+        xrt_version: str = "",
+        xmutil_listapps: Sequence[str] = (),
+    ) -> "KV260ConnectionMock":
+        """Build a mock directly from in-memory state."""
+
+        state = KV260MockBoardState.from_mapping(
+            {
+                "kernel_uname": kernel_uname,
+                "xrt_present": xrt_present,
+                "xrt_version": xrt_version,
+                "xmutil_listapps": list(xmutil_listapps),
+            },
+        )
+        return cls(state)
+
+    def is_reachable(self) -> bool:
+        """Return true for board-less tests without touching hardware."""
+
+        return True
+
+    def kernel_uname(self) -> str:
+        """Return the configured mock ``uname -a`` string."""
+
+        return self.state.kernel_uname
+
+    def xrt_present(self) -> bool:
+        """Return the configured mock XRT availability."""
+
+        return self.state.xrt_present
+
+    def xrt_version(self) -> str:
+        """Return the configured mock XRT version string."""
+
+        return self.state.xrt_version
+
+    def xmutil_listapps(self) -> Sequence[str]:
+        """Return the configured mock ``xmutil listapps`` output lines."""
+
+        return self.state.xmutil_listapps
+
+
+def _scenario_path(directory: Path, name: str) -> Path:
+    for extension in SCENARIO_EXTENSIONS:
+        candidate = directory / f"{name}{extension}"
+        if candidate.is_file():
+            return candidate
+    expected = ", ".join(f"{name}{extension}" for extension in SCENARIO_EXTENSIONS)
+    raise KV260ConnectionMockScenarioError(f"scenario fixture not found: {expected}")
+
+
+def _load_fixture(path: Path) -> Mapping[str, Any]:
+    if path.suffix == ".json":
+        with path.open(encoding="utf-8") as fh:
+            payload = json.load(fh)
+    elif path.suffix == ".yaml":
+        payload = _load_simple_yaml(path)
+    else:
+        raise KV260ConnectionMockScenarioError(
+            f"unsupported scenario extension: {path.suffix}",
+        )
+
+    if not isinstance(payload, Mapping):
+        raise KV260ConnectionMockScenarioError("scenario fixture must be an object")
+    return payload
+
+
+def _load_simple_yaml(path: Path) -> Mapping[str, Any]:
+    parsed: dict[str, Any] = {}
+    pending_key: str | None = None
+    pending_list: list[Any] = []
+
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        if not raw_line.strip() or raw_line.lstrip().startswith("#"):
+            continue
+
+        line = raw_line.rstrip()
+        stripped = line.strip()
+        if stripped.startswith("- "):
+            if pending_key is None:
+                raise KV260ConnectionMockScenarioError("list item without key")
+            pending_list.append(_parse_scalar(stripped[2:]))
+            continue
+
+        if pending_key is not None:
+            parsed[pending_key] = tuple(pending_list)
+            pending_key = None
+            pending_list = []
+
+        if ":" not in stripped:
+            raise KV260ConnectionMockScenarioError(f"invalid yaml line: {raw_line}")
+        key, value = stripped.split(":", 1)
+        key = key.strip()
+        value = value.strip()
+        if not key:
+            raise KV260ConnectionMockScenarioError("empty yaml key")
+        if value:
+            parsed[key] = _parse_scalar(value)
+        else:
+            pending_key = key
+            pending_list = []
+
+    if pending_key is not None:
+        parsed[pending_key] = tuple(pending_list)
+
+    return parsed
+
+
+def _parse_scalar(value: str) -> Any:
+    lowered = value.lower()
+    if lowered == "true":
+        return True
+    if lowered == "false":
+        return False
+    if lowered in {"null", "none", "~"}:
+        return None
+    if value == "[]":
+        return ()
+    if value.startswith(('"', "'")) and value.endswith(value[0]):
+        if value[0] == '"':
+            return json.loads(value)
+        return value[1:-1]
+    return value
+
+
+def _require_string(payload: Mapping[str, Any], key: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value:
+        raise KV260ConnectionMockScenarioError(f"{key} must be a non-empty string")
+    return value
+
+
+def _optional_string(payload: Mapping[str, Any], key: str) -> str:
+    value = payload.get(key, "")
+    if value is None:
+        return ""
+    if not isinstance(value, str):
+        raise KV260ConnectionMockScenarioError(f"{key} must be a string")
+    return value
+
+
+def _optional_bool(payload: Mapping[str, Any], key: str) -> bool | None:
+    value = payload.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, bool):
+        raise KV260ConnectionMockScenarioError(f"{key} must be a bool")
+    return value
+
+
+def _require_string_tuple(payload: Mapping[str, Any], key: str) -> tuple[str, ...]:
+    value = payload.get(key)
+    if value is None:
+        raise KV260ConnectionMockScenarioError(f"{key} must be present")
+    if isinstance(value, str) or not isinstance(value, Sequence):
+        raise KV260ConnectionMockScenarioError(f"{key} must be a list of strings")
+    values = tuple(value)
+    if not all(isinstance(item, str) and item for item in values):
+        raise KV260ConnectionMockScenarioError(f"{key} must be a list of strings")
+    return values

--- a/contracts/kv260_serial_connection.py
+++ b/contracts/kv260_serial_connection.py
@@ -1,0 +1,347 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""TTY serial backend for KV260 launcher-side status checks.
+
+The backend uses USB serial console access only. Credentials come from
+`KVFPGA_USER` and `KVFPGA_PASSWORD`; `KVFPGA_HOST` is intentionally ignored.
+Raw environment values are not exposed through repr or public status fields.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Mapping, Protocol, Sequence, runtime_checkable
+
+
+DEFAULT_BAUDRATE = 115200
+DEFAULT_PROMPT_TIMEOUT = 4.0
+DEFAULT_COMMAND_TIMEOUT = 12.0
+DEFAULT_WRITE_TIMEOUT = 1.0
+READ_CHUNK_SIZE = 1024
+END_MARKER = "__PCCX_KV260_SERIAL_DONE__"
+
+LOGIN_PROMPT = re.compile(rb"(?im)(?:^|\r?\n)[^\r\n]*login:\s*$")
+PASSWORD_PROMPT = re.compile(rb"(?im)(?:^|\r?\n)[^\r\n]*password:\s*$")
+SHELL_PROMPT = re.compile(rb"(?m)(?:^|\r?\n)[^\r\n]*[$#]\s*$")
+COMMAND_DONE = re.compile((END_MARKER + r":(\d+)").encode("ascii"))
+
+
+class KV260SerialError(RuntimeError):
+    """Base error for serial backend failures."""
+
+
+class KV260SerialUnavailable(KV260SerialError):
+    """Raised when a tty port or pyserial backend is unavailable."""
+
+
+@runtime_checkable
+class KV260ConnectionProtocol(Protocol):
+    """Method contract shared by KV260 connection backends."""
+
+    def is_reachable(self) -> bool:
+        """Return whether a serial console prompt can be reached."""
+
+    def kernel_uname(self) -> str:
+        """Return `uname -a` from the KV260 serial session."""
+
+    def xrt_present(self) -> bool:
+        """Return whether XRT tooling or libraries are visible on the target."""
+
+    def xmutil_listapps(self) -> Sequence[str]:
+        """Return `xmutil listapps` output lines from the target."""
+
+
+@dataclass(frozen=True)
+class SerialCommandResult:
+    """Target command output with shell exit status."""
+
+    exit_status: int
+    output: str
+
+
+SerialFactory = Callable[..., Any]
+
+
+def kv260_tty_candidates(env: Mapping[str, str] | None = None) -> tuple[str, ...]:
+    """Return candidate KV260 serial tty paths, with env override first."""
+
+    source = os.environ if env is None else env
+    override = source.get("KVFPGA_TTY")
+    if override:
+        return (override,)
+
+    candidates: list[str] = []
+    by_id = Path("/dev/serial/by-id")
+    if by_id.is_dir():
+        for path in sorted(by_id.iterdir()):
+            if "kv260" in path.name.lower():
+                candidates.append(str(path))
+
+    candidates.extend(str(path) for path in sorted(Path("/dev").glob("ttyUSB*")))
+    return tuple(dict.fromkeys(candidates))
+
+
+def detect_kv260_tty(env: Mapping[str, str] | None = None) -> str | None:
+    """Return the first configured or auto-detected KV260 serial tty path."""
+
+    candidates = kv260_tty_candidates(env)
+    return candidates[0] if candidates else None
+
+
+@dataclass
+class KV260SerialConnection:
+    """USB tty serial implementation of the KV260 connection method contract."""
+
+    tty_configured: bool
+    user_configured: bool
+    password_configured: bool
+    baudrate: int = DEFAULT_BAUDRATE
+    prompt_timeout: float = DEFAULT_PROMPT_TIMEOUT
+    command_timeout: float = DEFAULT_COMMAND_TIMEOUT
+    write_timeout: float = DEFAULT_WRITE_TIMEOUT
+    _tty: str | None = field(default=None, repr=False, compare=False)
+    _user: str | None = field(default=None, repr=False, compare=False)
+    _password: str | None = field(default=None, repr=False, compare=False)
+    _serial_factory: SerialFactory | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+    _active_serial: Any | None = field(default=None, repr=False, compare=False)
+
+    @classmethod
+    def from_env(
+        cls,
+        env: Mapping[str, str] | None = None,
+        serial_factory: SerialFactory | None = None,
+    ) -> "KV260SerialConnection":
+        source = os.environ if env is None else env
+        tty = source.get("KVFPGA_TTY")
+        user = source.get("KVFPGA_USER")
+        password = source.get("KVFPGA_PASSWORD")
+        return cls(
+            tty_configured=bool(tty),
+            user_configured=bool(user),
+            password_configured=bool(password),
+            _tty=tty,
+            _user=user,
+            _password=password,
+            _serial_factory=serial_factory,
+        )
+
+    def is_configured(self) -> bool:
+        """Return whether required serial credentials are present."""
+
+        return self.user_configured and self.password_configured
+
+    def is_reachable(self) -> bool:
+        """Open the tty, send a newline, and check for login or shell prompt."""
+
+        serial_session = None
+        try:
+            serial_session = self._open_serial()
+            self._write(serial_session, b"\r\n")
+            prompt, _buffer = self._read_until_prompt(
+                serial_session,
+                timeout=self.prompt_timeout,
+            )
+            return prompt is not None
+        except (OSError, KV260SerialError):
+            return False
+        finally:
+            self._close_serial(serial_session)
+
+    def kernel_uname(self) -> str:
+        with self as connection:
+            result = connection._run_command("uname -a")
+        if result.exit_status != 0:
+            raise KV260SerialError("uname command failed")
+        return result.output.strip()
+
+    def xrt_present(self) -> bool:
+        command = (
+            "command -v xrt-smi >/dev/null 2>&1 || "
+            "command -v xbutil >/dev/null 2>&1 || "
+            "test -e /usr/lib/libxrt_core.so || "
+            "test -e /usr/lib/aarch64-linux-gnu/libxrt_core.so"
+        )
+        with self as connection:
+            result = connection._run_command(command)
+        return result.exit_status == 0
+
+    def xmutil_listapps(self) -> Sequence[str]:
+        with self as connection:
+            result = connection._run_command("xmutil listapps")
+        if result.exit_status != 0:
+            return ()
+        return tuple(line for line in result.output.splitlines() if line.strip())
+
+    def __enter__(self) -> "KV260SerialConnection":
+        serial_session = self._open_serial()
+        try:
+            self._login(serial_session)
+        except Exception:
+            self._close_serial(serial_session)
+            raise
+        self._active_serial = serial_session
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        self.logout()
+
+    def logout(self) -> None:
+        serial_session = self._active_serial
+        self._active_serial = None
+        if serial_session is None:
+            return
+        try:
+            self._write(serial_session, b"exit\r\n")
+        finally:
+            self._close_serial(serial_session)
+
+    def _open_serial(self) -> Any:
+        tty = self._tty or detect_kv260_tty()
+        if not tty:
+            raise KV260SerialUnavailable("no KV260 serial tty detected")
+
+        factory = self._serial_factory
+        if factory is None:
+            try:
+                import serial  # type: ignore[import-not-found]
+            except ImportError as exc:
+                raise KV260SerialUnavailable("pyserial is not installed") from exc
+            factory = serial.Serial
+
+        return factory(
+            port=tty,
+            baudrate=self.baudrate,
+            timeout=0.1,
+            write_timeout=self.write_timeout,
+        )
+
+    def _login(self, serial_session: Any) -> None:
+        if not self._user or not self._password:
+            raise KV260SerialUnavailable("KVFPGA serial credentials are incomplete")
+
+        self._write(serial_session, b"\r\n")
+        prompt, _buffer = self._read_until_prompt(
+            serial_session,
+            timeout=self.prompt_timeout,
+        )
+        if prompt == "login":
+            self._write_line(serial_session, self._user)
+            prompt, _buffer = self._read_until_prompt(
+                serial_session,
+                timeout=self.prompt_timeout,
+            )
+        if prompt == "password":
+            self._write_line(serial_session, self._password)
+            prompt, _buffer = self._read_until_prompt(
+                serial_session,
+                timeout=self.prompt_timeout,
+            )
+        if prompt != "shell":
+            raise KV260SerialError("serial shell prompt was not reached")
+
+    def _run_command(self, command: str) -> SerialCommandResult:
+        serial_session = self._active_serial
+        if serial_session is None:
+            raise KV260SerialError("serial session is not open")
+
+        wrapped = f"{command}; printf '\\n{END_MARKER}:%s\\n' \"$?\""
+        self._write_line(serial_session, wrapped)
+        raw = self._read_until_pattern(
+            serial_session,
+            COMMAND_DONE,
+            timeout=self.command_timeout,
+        )
+        match = COMMAND_DONE.search(raw)
+        if match is None:
+            raise KV260SerialError("command completion marker was not observed")
+
+        exit_status = int(match.group(1).decode("ascii"))
+        output = self._clean_command_output(command, raw[: match.start()])
+        return SerialCommandResult(exit_status=exit_status, output=output)
+
+    def _read_until_prompt(
+        self,
+        serial_session: Any,
+        timeout: float,
+    ) -> tuple[str | None, bytes]:
+        deadline = time.monotonic() + timeout
+        buffer = bytearray()
+        while time.monotonic() < deadline:
+            chunk = serial_session.read(READ_CHUNK_SIZE)
+            if chunk:
+                buffer.extend(chunk)
+                data = bytes(buffer)
+                if LOGIN_PROMPT.search(data):
+                    return "login", data
+                if PASSWORD_PROMPT.search(data):
+                    return "password", data
+                if SHELL_PROMPT.search(data):
+                    return "shell", data
+            else:
+                time.sleep(0.02)
+        return None, bytes(buffer)
+
+    def _read_until_pattern(
+        self,
+        serial_session: Any,
+        pattern: re.Pattern[bytes],
+        timeout: float,
+    ) -> bytes:
+        deadline = time.monotonic() + timeout
+        buffer = bytearray()
+        while time.monotonic() < deadline:
+            chunk = serial_session.read(READ_CHUNK_SIZE)
+            if chunk:
+                buffer.extend(chunk)
+                data = bytes(buffer)
+                if pattern.search(data):
+                    return data
+            else:
+                time.sleep(0.02)
+        raise KV260SerialError("serial read timed out")
+
+    def _write_line(self, serial_session: Any, line: str) -> None:
+        self._write(serial_session, line.encode("utf-8") + b"\r\n")
+
+    def _write(self, serial_session: Any, payload: bytes) -> None:
+        serial_session.write(payload)
+        flush = getattr(serial_session, "flush", None)
+        if flush is not None:
+            flush()
+
+    def _clean_command_output(self, command: str, raw: bytes) -> str:
+        text = raw.decode("utf-8", errors="replace").replace("\r", "")
+        lines = text.split("\n")
+        cleaned: list[str] = []
+        for line in lines:
+            stripped = line.strip()
+            if not stripped:
+                continue
+            if stripped == command or stripped.startswith(f"{command}; "):
+                continue
+            if (
+                command in stripped
+                and "printf" in stripped
+                and END_MARKER in stripped
+            ):
+                continue
+            if stripped.endswith("$") or stripped.endswith("#"):
+                continue
+            cleaned.append(line.rstrip())
+        return "\n".join(cleaned)
+
+    def _close_serial(self, serial_session: Any | None) -> None:
+        if serial_session is None:
+            return
+        close = getattr(serial_session, "close", None)
+        if close is not None:
+            close()

--- a/contracts/trace_capture_client.py
+++ b/contracts/trace_capture_client.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Launcher-side trace capture client for lab-compatible v2 framing.
+
+The client emits line-delimited serial trace framing compatible with
+``pccxai/pccx-lab#163``. It writes only caller-provided frame data and does not
+open a board connection, inspect the environment, or execute a runtime.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import zlib
+from dataclasses import dataclass
+from os import PathLike
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+
+PCCX_TRACE_BEGIN_MARKER = "===PCCX_TRACE_BEGIN seq=0==="
+PCCX_TRACE_END_PREFIX = "===PCCX_TRACE_END seq="
+PCCX_TRACE_MARKER_SUFFIX = "==="
+
+
+@runtime_checkable
+class TextTraceSink(Protocol):
+    def write(self, text: str) -> object:
+        ...
+
+    def flush(self) -> object:
+        ...
+
+
+@runtime_checkable
+class BinaryTraceSink(Protocol):
+    def write(self, data: bytes) -> object:
+        ...
+
+    def flush(self) -> object:
+        ...
+
+
+TraceSink = TextTraceSink | BinaryTraceSink
+
+
+class Closeable(Protocol):
+    def close(self) -> object:
+        ...
+
+
+@dataclass(frozen=True)
+class TraceCaptureFrame:
+    """One v2 serial trace frame before CRC decoration."""
+
+    frame_idx: int
+    axi_stat: int
+    engine_completion: int
+    cycles: int
+    err: str | None = None
+
+
+class TraceCaptureClient:
+    """Write v2-framed trace JSON lines to stdout, a file, or a serial sink."""
+
+    def __init__(
+        self,
+        serial_port: TraceSink | str | PathLike[str] | None = None,
+        file_path: str | PathLike[str] | None = None,
+    ) -> None:
+        if serial_port is not None and file_path is not None:
+            raise ValueError("configure either serial_port or file_path, not both")
+
+        self._owned_sink: Closeable | None = None
+        self._begun = False
+        self._next_seq = 0
+        self._ended = False
+
+        if file_path is not None:
+            path = Path(file_path)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            self._sink: TraceSink = path.open("w", encoding="utf-8", newline="\n")
+            self._owned_sink = self._sink
+        elif isinstance(serial_port, (str, PathLike)):
+            self._sink = Path(serial_port).open("wb")
+            self._owned_sink = self._sink
+        elif serial_port is not None:
+            self._sink = serial_port
+        else:
+            self._sink = sys.stdout
+
+    def __enter__(self) -> "TraceCaptureClient":
+        self.begin()
+        return self
+
+    def __exit__(self, _exc_type: object, _exc: object, _tb: object) -> None:
+        self.close()
+
+    def begin(self) -> None:
+        """Emit the v2 begin marker."""
+
+        if self._begun:
+            raise RuntimeError("trace capture has already begun")
+        self._write_line(PCCX_TRACE_BEGIN_MARKER)
+        self._begun = True
+
+    def write_frame(self, frame: TraceCaptureFrame) -> None:
+        """Emit one v2 JSON frame with an IEEE CRC32."""
+
+        if self._ended:
+            raise RuntimeError("cannot write frames after trace capture ended")
+        if not self._begun:
+            self.begin()
+        payload = _crc_payload(
+            seq=self._next_seq,
+            frame_idx=frame.frame_idx,
+            axi_stat=frame.axi_stat,
+            engine_completion=frame.engine_completion,
+            cycles=frame.cycles,
+            err=frame.err,
+        )
+        crc32 = serial_frame_crc32(
+            seq=self._next_seq,
+            frame_idx=frame.frame_idx,
+            axi_stat=frame.axi_stat,
+            engine_completion=frame.engine_completion,
+            cycles=frame.cycles,
+            err=frame.err,
+        )
+        line = _compact_json({**payload, "crc32": crc32})
+        self._write_line(line)
+        self._next_seq += 1
+
+    def end(self) -> None:
+        """Emit the v2 end marker using the next expected sequence number."""
+
+        if not self._ended:
+            if not self._begun:
+                self.begin()
+            self._write_line(
+                f"{PCCX_TRACE_END_PREFIX}{self._next_seq}{PCCX_TRACE_MARKER_SUFFIX}",
+            )
+            self._ended = True
+
+    def capture(self, frames: tuple[TraceCaptureFrame, ...]) -> None:
+        """Emit begin marker, all frames, and end marker."""
+
+        self.begin()
+        for frame in frames:
+            self.write_frame(frame)
+        self.end()
+
+    def close(self) -> None:
+        """Finish the trace and close an owned file target."""
+
+        self.end()
+        self._flush()
+        if self._owned_sink is not None:
+            self._owned_sink.close()
+
+    @property
+    def next_seq(self) -> int:
+        return self._next_seq
+
+    def _write_line(self, line: str) -> None:
+        text = f"{line}\n"
+        try:
+            self._sink.write(text)  # type: ignore[arg-type]
+        except TypeError:
+            self._sink.write(text.encode("utf-8"))  # type: ignore[arg-type]
+        self._flush()
+
+    def _flush(self) -> None:
+        self._sink.flush()
+
+
+def serial_frame_crc32(
+    seq: int,
+    frame_idx: int,
+    axi_stat: int,
+    engine_completion: int,
+    cycles: int,
+    err: str | None,
+) -> int:
+    """Return lab-compatible IEEE CRC32 over the canonical v2 payload."""
+
+    payload = _compact_json(
+        _crc_payload(
+            seq=seq,
+            frame_idx=frame_idx,
+            axi_stat=axi_stat,
+            engine_completion=engine_completion,
+            cycles=cycles,
+            err=err,
+        ),
+    ).encode("utf-8")
+    return zlib.crc32(payload) & 0xFFFF_FFFF
+
+
+def _crc_payload(
+    seq: int,
+    frame_idx: int,
+    axi_stat: int,
+    engine_completion: int,
+    cycles: int,
+    err: str | None,
+) -> dict[str, int | str | None]:
+    return {
+        "seq": _u64("seq", seq),
+        "frame_idx": _u32("frame_idx", frame_idx),
+        "axi_stat": _u32("axi_stat", axi_stat),
+        "engine_completion": _u8("engine_completion", engine_completion),
+        "cycles": _u64("cycles", cycles),
+        "err": err,
+    }
+
+
+def _compact_json(payload: dict[str, int | str | None]) -> str:
+    return json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+
+
+def _u8(name: str, value: int) -> int:
+    if not 0 <= value <= 0xFF:
+        raise ValueError(f"{name} must fit u8")
+    return value
+
+
+def _u32(name: str, value: int) -> int:
+    if not 0 <= value <= 0xFFFF_FFFF:
+        raise ValueError(f"{name} must fit u32")
+    return value
+
+
+def _u64(name: str, value: int) -> int:
+    if not 0 <= value <= 0xFFFF_FFFF_FFFF_FFFF:
+        raise ValueError(f"{name} must fit u64")
+    return value

--- a/scripts/pccx-launcher
+++ b/scripts/pccx-launcher
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Small launcher CLI dispatcher for local contract utilities."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from contracts.dummy_e2e_contract import dummy_e2e, format_dummy_e2e_summary
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(prog="pccx-launcher")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    dummy = subparsers.add_parser(
+        "dummy-e2e",
+        help="run the offline dummy manifest -> AXI mock -> ResultStream path",
+    )
+    dummy.add_argument("--seed", required=True, type=int, help="deterministic seed")
+
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    if args.command == "dummy-e2e":
+        sys.stdout.write(format_dummy_e2e_summary(dummy_e2e(args.seed)))
+        return 0
+    raise AssertionError(f"unhandled command: {args.command}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/pccx-launcher
+++ b/scripts/pccx-launcher
@@ -44,9 +44,11 @@ def main(argv: list[str] | None = None) -> int:
     if args.command == "dummy-e2e":
         stream = dummy_e2e(args.seed)
         if args.capture is not None:
-            with TraceCaptureClient(file_path=args.capture) as client:
-                for frame in dummy_e2e_trace_frames(stream):
-                    client.write_frame(frame)
+            client = TraceCaptureClient(file_path=args.capture)
+            try:
+                client.capture(dummy_e2e_trace_frames(stream))
+            finally:
+                client.close()
         sys.stdout.write(format_dummy_e2e_summary(stream))
         return 0
     raise AssertionError(f"unhandled command: {args.command}")

--- a/scripts/pccx-launcher
+++ b/scripts/pccx-launcher
@@ -14,7 +14,12 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from contracts.dummy_e2e_contract import dummy_e2e, format_dummy_e2e_summary
+from contracts.dummy_e2e_contract import (
+    dummy_e2e,
+    dummy_e2e_trace_frames,
+    format_dummy_e2e_summary,
+)
+from contracts.trace_capture_client import TraceCaptureClient
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
@@ -26,6 +31,10 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         help="run the offline dummy manifest -> AXI mock -> ResultStream path",
     )
     dummy.add_argument("--seed", required=True, type=int, help="deterministic seed")
+    dummy.add_argument(
+        "--capture",
+        help="write lab-compatible v2 framed trace lines to this file",
+    )
 
     return parser.parse_args(argv)
 
@@ -33,7 +42,12 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(sys.argv[1:] if argv is None else argv)
     if args.command == "dummy-e2e":
-        sys.stdout.write(format_dummy_e2e_summary(dummy_e2e(args.seed)))
+        stream = dummy_e2e(args.seed)
+        if args.capture is not None:
+            with TraceCaptureClient(file_path=args.capture) as client:
+                for frame in dummy_e2e_trace_frames(stream):
+                    client.write_frame(frame)
+        sys.stdout.write(format_dummy_e2e_summary(stream))
         return 0
     raise AssertionError(f"unhandled command: {args.command}")
 

--- a/scripts/tests/axi_cmd_mock_backend_test.py
+++ b/scripts/tests/axi_cmd_mock_backend_test.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Unit tests for the offline AXI command-channel mock backend."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "contracts" / "axi_cmd_channel.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location(
+        "axi_cmd_channel",
+        MODULE_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def assert_raises(error_type, callback) -> None:
+    try:
+        callback()
+    except error_type:
+        return
+    raise AssertionError(f"expected {error_type.__name__}")
+
+
+def test_basic_issue_poll_cycle_updates_register_model() -> None:
+    module = load_module()
+    cmd = module.NpuCmd(opcode=3, arg0=4, arg1=5, arg2=6, flags=7)
+
+    backend = module.AxiCmdMockBackend()
+    assert backend.snapshot_registers() == {
+        module.MMIO_CMD: 0,
+        module.MMIO_STAT: module.NpuStat().register_value(),
+    }
+
+    with backend as channel:
+        channel.issue(cmd)
+        first = channel.poll_stat()
+        second = channel.poll_stat()
+        registers = channel.snapshot_registers()
+
+    assert first == second
+    assert first == module.NpuStat(completion_count=1, last_opcode=3)
+    assert backend.completion_count == 1
+    assert backend.last_cmd == cmd
+    assert registers[module.MMIO_CMD] == cmd.register_value()
+    assert registers[module.MMIO_STAT] == first.register_value()
+    assert_raises(RuntimeError, lambda: backend.poll_stat())
+
+
+def test_multiple_issue_cycles_increment_fake_completion_counter() -> None:
+    module = load_module()
+
+    with module.AxiCmdMockBackend() as channel:
+        channel.issue(module.NpuCmd(opcode=1))
+        assert channel.poll_stat() == module.NpuStat(
+            completion_count=1,
+            last_opcode=1,
+        )
+
+        channel.issue(module.NpuCmd(opcode=2, arg0=10))
+        assert channel.poll_stat() == module.NpuStat(
+            completion_count=2,
+            last_opcode=2,
+        )
+
+
+def test_scripted_reply_mode_verifies_commands_and_returns_expected_status() -> None:
+    module = load_module()
+    first_cmd = module.NpuCmd(opcode=9, arg0=1)
+    second_cmd = module.NpuCmd(opcode=10, arg0=2)
+    first_stat = module.NpuStat(
+        completion_count=1,
+        last_opcode=9,
+        status_code=7,
+    )
+    second_stat = module.NpuStat(
+        completion_count=2,
+        last_opcode=10,
+        error=True,
+        status_code=12,
+    )
+
+    with module.AxiCmdMockBackend(
+        scripted_replies=[
+            (first_cmd, first_stat),
+            (second_cmd, second_stat),
+        ],
+    ) as channel:
+        channel.issue(first_cmd)
+        assert channel.poll_stat() == first_stat
+        assert channel.remaining_scripted_replies == 1
+
+        channel.issue(second_cmd)
+        assert channel.poll_stat() == second_stat
+        assert channel.completion_count == 2
+        assert channel.remaining_scripted_replies == 0
+        channel.assert_script_consumed()
+
+
+def test_scripted_reply_mode_rejects_unexpected_command_without_side_effect() -> None:
+    module = load_module()
+    expected_cmd = module.NpuCmd(opcode=1)
+    unexpected_cmd = module.NpuCmd(opcode=2)
+    expected_stat = module.NpuStat(completion_count=1, last_opcode=1)
+
+    with module.AxiCmdMockBackend(
+        scripted_replies=[(expected_cmd, expected_stat)],
+    ) as channel:
+        assert_raises(
+            module.ScriptedReplyMismatch,
+            lambda: channel.issue(unexpected_cmd),
+        )
+        assert channel.completion_count == 0
+        assert channel.remaining_scripted_replies == 1
+        assert channel.snapshot_registers() == {
+            module.MMIO_CMD: 0,
+            module.MMIO_STAT: module.NpuStat().register_value(),
+        }
+
+
+def test_issue_and_poll_are_safe_under_concurrent_test_use() -> None:
+    module = load_module()
+
+    with module.AxiCmdMockBackend() as channel:
+
+        def issue_and_poll(index: int):
+            channel.issue(module.NpuCmd(opcode=index + 1))
+            return channel.poll_stat()
+
+        with ThreadPoolExecutor(max_workers=4) as executor:
+            stats = list(executor.map(issue_and_poll, range(8)))
+
+        assert channel.completion_count == 8
+        assert len(stats) == 8
+        assert all(isinstance(stat, module.NpuStat) for stat in stats)
+        assert channel.poll_stat().completion_count == 8
+
+
+test_basic_issue_poll_cycle_updates_register_model()
+test_multiple_issue_cycles_increment_fake_completion_counter()
+test_scripted_reply_mode_verifies_commands_and_returns_expected_status()
+test_scripted_reply_mode_rejects_unexpected_command_without_side_effect()
+test_issue_and_poll_are_safe_under_concurrent_test_use()
+
+print("AXI command mock backend tests ok")

--- a/scripts/tests/dummy_e2e_contract_test.py
+++ b/scripts/tests/dummy_e2e_contract_test.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Tests for the offline dummy end-to-end launcher run."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from contracts.dummy_e2e_contract import (
+    SCHEMA_VERSION,
+    TOKEN_COUNT,
+    ResultStream,
+    dummy_e2e,
+    format_dummy_e2e_summary,
+)
+
+
+MODULE_PATH = ROOT / "contracts" / "dummy_e2e_contract.py"
+CLI_PATH = ROOT / "scripts" / "pccx-launcher"
+TEST_PATH = Path(__file__).resolve()
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_dummy_e2e_is_deterministic_for_same_seed() -> None:
+    first = dummy_e2e(42)
+    second = dummy_e2e(42)
+    different = dummy_e2e(43)
+
+    assert first == second
+    assert format_dummy_e2e_summary(first) == format_dummy_e2e_summary(second)
+    assert first != different
+    assert first.tokens != different.tokens
+
+
+def test_dummy_e2e_wires_manifest_axi_mock_and_result_stream() -> None:
+    stream = dummy_e2e(7)
+
+    assert isinstance(stream, ResultStream)
+    assert stream.schema_version == SCHEMA_VERSION
+    assert stream.seed == 7
+    assert stream.manifest_id == "gemma_weight_prep_seed_7_dummy"
+    assert stream.completed is True
+    assert stream.token_count == TOKEN_COUNT
+    assert len(stream.command_trace) == 3
+    assert tuple(trace.name for trace in stream.command_trace) == (
+        "load_dummy_manifest",
+        "prime_fake_stream",
+        "finish_fake_stream",
+    )
+    assert tuple(trace.status.completion_count for trace in stream.command_trace) == (
+        1,
+        2,
+        3,
+    )
+    assert all(trace.mmio_cmd == trace.command.register_value() for trace in stream.command_trace)
+    assert all(trace.mmio_stat == trace.status.register_value() for trace in stream.command_trace)
+    assert tuple(token.index for token in stream.tokens) == tuple(range(TOKEN_COUNT))
+    assert stream.text == " ".join(token.text for token in stream.tokens)
+
+    flags = dict(stream.safety_flags)
+    assert flags["offlineOnly"] is True
+    assert flags["deterministic"] is True
+    assert flags["dummyManifestOnly"] is True
+    assert flags["fakeTokensOnly"] is True
+    assert flags["boardAccess"] is False
+    assert flags["sshExecution"] is False
+    assert flags["hfTouched"] is False
+    assert flags["networkCalls"] is False
+    assert flags["environmentRead"] is False
+    assert flags["modelExecution"] is False
+
+
+def test_cli_dummy_e2e_summary_is_concise_and_deterministic() -> None:
+    command = [str(CLI_PATH), "dummy-e2e", "--seed", "42"]
+    first = subprocess.run(command, check=True, capture_output=True, text=True)
+    second = subprocess.run(command, check=True, capture_output=True, text=True)
+
+    assert first.stderr == ""
+    assert first.stdout == second.stdout
+    assert first.stdout == format_dummy_e2e_summary(dummy_e2e(42))
+    assert first.stdout.endswith("\n")
+    assert "dummy_e2e: ok\n" in first.stdout
+    assert "seed: 42\n" in first.stdout
+    assert "tokens: 6\n" in first.stdout
+    assert "offline: board=false ssh=false hf=false network=false\n" in first.stdout
+
+
+def test_source_has_offline_claim_guard() -> None:
+    source = read_text(MODULE_PATH)
+    cli = read_text(CLI_PATH)
+    combined = source + "\n" + cli
+
+    forbidden_runtime_terms = [
+        "huggingface_hub",
+        "hf_hub_download",
+        ".safetensors",
+        ".gguf",
+        ".pt",
+        ".pth",
+        "requests",
+        "urllib",
+        "socket",
+        "subprocess",
+        "paramiko",
+        "fabric",
+        "os.environ",
+        "getenv",
+    ]
+    lowered = combined.lower()
+    for term in forbidden_runtime_terms:
+        assert term not in lowered, term
+
+    forbidden_private_patterns = [
+        r"/home/[^\s\"']+",
+        r"/Users/[^\s\"']+",
+        r"[A-Za-z]:\\Users\\",
+        r"\b(?:api[_-]?key|authorization|bearer|password|secret|token)\b\s*[:=]",
+    ]
+    summary = format_dummy_e2e_summary(dummy_e2e(42))
+    for pattern in forbidden_private_patterns:
+        assert not re.search(pattern, summary, re.IGNORECASE), pattern
+
+
+def test_source_headers_for_touched_code_files() -> None:
+    expected_headers = {
+        MODULE_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        CLI_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        TEST_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+    }
+    for path, header in expected_headers.items():
+        assert read_text(path).splitlines()[: len(header)] == header, path
+
+
+test_dummy_e2e_is_deterministic_for_same_seed()
+test_dummy_e2e_wires_manifest_axi_mock_and_result_stream()
+test_cli_dummy_e2e_summary_is_concise_and_deterministic()
+test_source_has_offline_claim_guard()
+test_source_headers_for_touched_code_files()
+
+print("dummy e2e contract tests ok")

--- a/scripts/tests/full_mock_integration_test.py
+++ b/scripts/tests/full_mock_integration_test.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Full-mock integration test for the offline launcher harness."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from contracts.axi_cmd_channel import AxiCmdMockBackend, NpuStat
+from contracts.dummy_e2e_contract import dummy_e2e, dummy_e2e_trace_frames
+from contracts.kv260_connection_mock import KV260ConnectionMock
+from contracts.trace_capture_client import (
+    PCCX_TRACE_BEGIN_MARKER,
+    TraceCaptureClient,
+    serial_frame_crc32,
+)
+
+
+TEST_PATH = Path(__file__).resolve()
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def parse_trace(path: Path) -> list[dict[str, object]]:
+    lines = read_text(path).splitlines()
+    assert lines[0] == PCCX_TRACE_BEGIN_MARKER
+    assert lines[-1] == f"===PCCX_TRACE_END seq={len(lines[1:-1])}==="
+
+    frames: list[dict[str, object]] = []
+    for seq, line in enumerate(lines[1:-1]):
+        frame = json.loads(line)
+        assert frame["seq"] == seq
+        assert frame["crc32"] == serial_frame_crc32(
+            seq=int(frame["seq"]),
+            frame_idx=int(frame["frame_idx"]),
+            axi_stat=int(frame["axi_stat"]),
+            engine_completion=int(frame["engine_completion"]),
+            cycles=int(frame["cycles"]),
+            err=frame["err"] if isinstance(frame["err"], str) else None,
+        )
+        frames.append(frame)
+    return frames
+
+
+def test_happy_path_full_mock_dummy_e2e_trace_capture() -> None:
+    connection = KV260ConnectionMock.from_scenario("happy_path")
+
+    assert connection.is_reachable() is True
+    assert connection.xrt_present() is True
+    assert connection.xrt_version() == "XRT mock 2.16.0"
+    assert "app: pccx-npu" in connection.xmutil_listapps()
+
+    stream = dummy_e2e(42)
+    expected_statuses = tuple(trace.status for trace in stream.command_trace)
+    expected_axi_stats = tuple(status.register_value() for status in expected_statuses)
+
+    with AxiCmdMockBackend() as axi:
+        for trace, expected_status in zip(stream.command_trace, expected_statuses):
+            axi.issue(trace.command)
+            observed_status = axi.poll_stat()
+            registers = axi.snapshot_registers()
+
+            assert observed_status == expected_status
+            assert observed_status.error is False
+            assert registers["MMIO_CMD"] == trace.command.register_value()
+            assert registers["MMIO_STAT"] == expected_status.register_value()
+        assert axi.completion_count == len(stream.command_trace)
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        trace_path = Path(temp_dir) / "full-mock-dummy-e2e.trace.jsonl"
+        client = TraceCaptureClient(file_path=trace_path)
+        try:
+            client.capture(dummy_e2e_trace_frames(stream))
+        finally:
+            client.close()
+        frames = parse_trace(trace_path)
+
+    assert len(frames) == len(stream.command_trace)
+    assert len(frames) == 3
+    assert [frame["frame_idx"] for frame in frames] == [0, 1, 2]
+    assert [frame["axi_stat"] for frame in frames] == list(expected_axi_stats)
+    assert [frame["engine_completion"] for frame in frames] == [
+        status.completion_count for status in expected_statuses
+    ]
+    assert [frame["cycles"] for frame in frames] == [128, 256, 384]
+    assert all(frame["err"] is None for frame in frames)
+    assert all(
+        status == NpuStat(index, index, False, False, 0)
+        for index, status in enumerate(expected_statuses, 1)
+    )
+    assert stream.completed is True
+    assert dict(stream.safety_flags)["boardAccess"] is False
+    assert dict(stream.safety_flags)["networkCalls"] is False
+    assert dict(stream.safety_flags)["environmentRead"] is False
+
+
+def test_source_has_full_mock_claim_guard() -> None:
+    source = read_text(TEST_PATH)
+    lowered = source.lower()
+
+    forbidden_runtime_terms = [
+        "huggingface" + "_hub",
+        "hf_hub" + "_download",
+        "request" + "s",
+        "url" + "lib",
+        "sock" + "et",
+        "param" + "iko",
+        "fab" + "ric",
+        "os." + "environ",
+        "get" + "env",
+        "/dev/" + "mem",
+        "serial." + "serial",
+    ]
+    for term in forbidden_runtime_terms:
+        assert term not in lowered, term
+
+    forbidden_private_patterns = [
+        "/" + r"home/[^\s\"']+",
+        "/" + r"Users/[^\s\"']+",
+        r"[A-Za-z]:\\" + r"Users\\",
+        r"\b(?:api[_-]?key|authorization|bearer|password|secret|tok"
+        r"en)\b\s*[:=]",
+    ]
+    for pattern in forbidden_private_patterns:
+        assert not re.search(pattern, source, re.IGNORECASE), pattern
+
+
+def test_source_headers_for_touched_test_file() -> None:
+    assert read_text(TEST_PATH).splitlines()[:3] == [
+        "#!/usr/bin/env python3",
+        "# SPDX-License-Identifier: Apache-2.0",
+        "# Copyright 2026 pccxai",
+    ]
+
+
+test_happy_path_full_mock_dummy_e2e_trace_capture()
+test_source_has_full_mock_claim_guard()
+test_source_headers_for_touched_test_file()
+
+print("full mock integration tests ok")

--- a/scripts/tests/gemma_weight_prep_contract_test.py
+++ b/scripts/tests/gemma_weight_prep_contract_test.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Tests for the stage-1 Gemma weight-prep contract."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "contracts" / "gemma_weight_prep_contract.py"
+TEST_PATH = Path(__file__).resolve()
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location(
+        "gemma_weight_prep_contract",
+        MODULE_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_prepare_dummy_seed_42_manifest_invariants() -> None:
+    module = load_module()
+    manifest = module.GemmaWeightPrep().prepare_dummy(42)
+
+    assert isinstance(manifest, module.Manifest)
+    assert manifest.schema_version == module.SCHEMA_VERSION
+    assert manifest.manifest_id == "gemma_weight_prep_seed_42_dummy"
+    assert manifest.model_id == module.DUMMY_MODEL_ID
+    assert manifest.seed == 42
+    assert manifest.source_dtype == "bf16_dummy"
+    assert manifest.weight_format == "w4_placeholder_dummy"
+    assert manifest.pipeline_label == "prepare_dummy"
+    assert manifest.real_algo_stage == "stage2"
+    assert manifest.hf_touched is False
+    assert "real_w4_algo_in_stage2" in manifest.limitations
+    assert "no_hf_download_or_weight_load" in manifest.limitations
+
+    assert len(manifest.tiles) == 1
+    assert len(manifest.scales) == 1
+    tile = manifest.tiles[0]
+    scale = manifest.scales[0]
+    assert isinstance(tile, module.WeightTile)
+    assert isinstance(scale, module.Scale)
+    assert tile.tile_id.endswith("_dummy")
+    assert scale.scale_id.endswith("_dummy")
+    assert tile.source_dtype == "bf16_dummy"
+    assert tile.source_shape == module.DUMMY_SOURCE_SHAPE
+    assert tile.tile_shape == module.DUMMY_TILE_SHAPE
+    assert tile.packed_dtype == "uint4_packed_dummy"
+    assert tile.quantization_label == "w4_placeholder_quantize_dummy"
+    assert scale.quantization_label == "w4_placeholder_scale_dummy"
+    assert tile.scale_id == scale.scale_id
+    assert scale.tile_id == tile.tile_id
+
+    expected_byte_count = (4 * 8 + 1) // 2
+    assert len(tile.packed_nibbles) == expected_byte_count
+    assert tile.packed_nibbles.hex() == "c3d6e639acddb4768c77b7a1f67236bb"
+    assert manifest.artifact_ids == ("gemma_weight_tile_0_memory_only_dummy",)
+    assert all(artifact.endswith("_dummy") for artifact in manifest.artifact_ids)
+
+
+def test_prepare_dummy_is_deterministic_and_seeded() -> None:
+    module = load_module()
+    prep = module.GemmaWeightPrep()
+    manifest_a = prep.prepare_dummy(42)
+    manifest_b = prep.prepare_dummy(42)
+    manifest_c = prep.prepare_dummy(43)
+
+    assert manifest_a == manifest_b
+    assert manifest_a.tiles[0].packed_nibbles != manifest_c.tiles[0].packed_nibbles
+
+
+def test_real_w4_algo_is_stage_2_only() -> None:
+    module = load_module()
+    try:
+        module.GemmaWeightPrep().prepare_real_w4()
+    except NotImplementedError as exc:
+        assert "real algo in stage 2" in str(exc)
+    else:
+        raise AssertionError("expected real W4 path to remain unimplemented")
+
+
+def test_source_has_claim_and_hf_guards() -> None:
+    source = read_text(MODULE_PATH)
+    lowered_source = source.lower()
+
+    forbidden_runtime_terms = [
+        "transformers",
+        "huggingface_hub",
+        "hf_hub_download",
+        ".safetensors",
+        ".gguf",
+        ".pt",
+        ".pth",
+        "open(",
+        "read_bytes",
+        "read_text",
+        "requests",
+        "urllib",
+        "subprocess",
+        "socket",
+    ]
+    for term in forbidden_runtime_terms:
+        assert term not in lowered_source, term
+
+    forbidden_claims = [
+        "production-ready",
+        "marketplace-ready",
+        "stable API",
+        "stable ABI",
+        "KV260 inference works",
+        "Gemma 3N E4B runs on KV260",
+        "20 tok/s achieved",
+        "timing closed",
+        "bitstream ready",
+    ]
+    scan_text = source.lower()
+    for claim in forbidden_claims:
+        assert claim.lower() not in scan_text, claim
+
+
+def test_source_headers_for_touched_code_files() -> None:
+    expected_headers = {
+        MODULE_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        TEST_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+    }
+    for path, header in expected_headers.items():
+        assert read_text(path).splitlines()[: len(header)] == header, path
+
+
+test_prepare_dummy_seed_42_manifest_invariants()
+test_prepare_dummy_is_deterministic_and_seeded()
+test_real_w4_algo_is_stage_2_only()
+test_source_has_claim_and_hf_guards()
+test_source_headers_for_touched_code_files()
+
+print("gemma weight prep contract tests ok")

--- a/scripts/tests/kv260_connection_mock_test.py
+++ b/scripts/tests/kv260_connection_mock_test.py
@@ -96,6 +96,60 @@ def test_partial_apps_scenario_returns_configured_listapps_subset() -> None:
     assert connection.xmutil_listapps() == ("app: pccx-npu",)
 
 
+def test_boot_in_progress_scenario_returns_incomplete_boot_without_xrt() -> None:
+    module, _serial_module = load_module()
+
+    connection = module.KV260ConnectionMock.from_scenario("boot_in_progress")
+
+    assert connection.is_reachable() is True
+    assert connection.kernel_uname() == "boot incomplete"
+    assert connection.xrt_present() is False
+    assert connection.xrt_version() == ""
+    assert connection.xmutil_listapps() == ()
+
+
+def test_xrt_present_no_apps_scenario_returns_empty_listapps() -> None:
+    module, _serial_module = load_module()
+
+    connection = module.KV260ConnectionMock.from_scenario("xrt_present_no_apps")
+
+    assert connection.is_reachable() is True
+    assert connection.kernel_uname() == (
+        "Linux kv260-xrt-no-apps 6.6.0-pccx-mock #1 SMP PREEMPT aarch64 GNU/Linux"
+    )
+    assert connection.xrt_present() is True
+    assert connection.xrt_version() == "XRT mock 2.16.0-no-apps"
+    assert connection.xmutil_listapps() == ()
+
+
+def test_single_app_loaded_scenario_returns_one_listapps_entry() -> None:
+    module, _serial_module = load_module()
+
+    connection = module.KV260ConnectionMock.from_scenario("single_app_loaded")
+
+    assert connection.is_reachable() is True
+    assert connection.kernel_uname() == (
+        "Linux kv260-single-app 6.6.0-pccx-mock #1 SMP PREEMPT aarch64 GNU/Linux"
+    )
+    assert connection.xrt_present() is True
+    assert connection.xrt_version() == "XRT mock 2.16.0-single-app"
+    assert connection.xmutil_listapps() == ("app: pccx-npu",)
+
+
+def test_panic_state_scenario_returns_last_panic_line() -> None:
+    module, _serial_module = load_module()
+
+    connection = module.KV260ConnectionMock.from_scenario("panic_state")
+
+    assert connection.is_reachable() is True
+    assert connection.kernel_uname() == (
+        "Kernel panic - not syncing: VFS: Unable to mount root fs on unknown-block(0,0)"
+    )
+    assert connection.xrt_present() is False
+    assert connection.xrt_version() == ""
+    assert connection.xmutil_listapps() == ()
+
+
 def test_direct_state_builder_defaults_xrt_presence_from_version() -> None:
     module, _serial_module = load_module()
 
@@ -133,9 +187,13 @@ def test_expected_scenario_fixture_count() -> None:
     )
 
     assert [path.stem for path in scenario_files] == [
+        "boot_in_progress",
         "happy_path",
+        "panic_state",
         "partial_apps",
+        "single_app_loaded",
         "xrt_missing",
+        "xrt_present_no_apps",
     ]
 
 
@@ -207,6 +265,10 @@ def test_source_headers_for_touched_python_files() -> None:
 test_happy_path_scenario_implements_serial_connection_protocol()
 test_xrt_missing_scenario_keeps_board_reachable_without_xrt()
 test_partial_apps_scenario_returns_configured_listapps_subset()
+test_boot_in_progress_scenario_returns_incomplete_boot_without_xrt()
+test_xrt_present_no_apps_scenario_returns_empty_listapps()
+test_single_app_loaded_scenario_returns_one_listapps_entry()
+test_panic_state_scenario_returns_last_panic_line()
 test_direct_state_builder_defaults_xrt_presence_from_version()
 test_scenario_loader_rejects_missing_or_path_like_names()
 test_expected_scenario_fixture_count()

--- a/scripts/tests/kv260_connection_mock_test.py
+++ b/scripts/tests/kv260_connection_mock_test.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Unit tests for the board-less KV260 connection mock."""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "contracts" / "kv260_connection_mock.py"
+SERIAL_MODULE_PATH = ROOT / "contracts" / "kv260_serial_connection.py"
+TEST_PATH = Path(__file__).resolve()
+SCENARIO_DIR = ROOT / "tests" / "fixtures" / "scenarios"
+
+
+def load_module():
+    sys.path.insert(0, str(ROOT))
+    serial_spec = importlib.util.spec_from_file_location(
+        "contracts.kv260_serial_connection",
+        SERIAL_MODULE_PATH,
+    )
+    serial_module = importlib.util.module_from_spec(serial_spec)
+    assert serial_spec.loader is not None
+    sys.modules[serial_spec.name] = serial_module
+    serial_spec.loader.exec_module(serial_module)
+
+    spec = importlib.util.spec_from_file_location(
+        "contracts.kv260_connection_mock",
+        MODULE_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module, serial_module
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def assert_raises(error_type, callback) -> None:
+    try:
+        callback()
+    except error_type:
+        return
+    raise AssertionError(f"expected {error_type.__name__}")
+
+
+def test_happy_path_scenario_implements_serial_connection_protocol() -> None:
+    module, serial_module = load_module()
+
+    connection = module.KV260ConnectionMock.from_scenario("happy_path")
+
+    assert isinstance(connection, serial_module.KV260ConnectionProtocol)
+    assert connection.is_reachable() is True
+    assert connection.kernel_uname() == (
+        "Linux kv260-happy 6.6.0-pccx-mock #1 SMP PREEMPT aarch64 GNU/Linux"
+    )
+    assert connection.xrt_present() is True
+    assert connection.xrt_version() == "XRT mock 2.16.0"
+    assert connection.xmutil_listapps() == (
+        "app: pccx-npu",
+        "app: diagnostics",
+        "app: shell",
+    )
+
+
+def test_xrt_missing_scenario_keeps_board_reachable_without_xrt() -> None:
+    module, _serial_module = load_module()
+
+    connection = module.KV260ConnectionMock.from_scenario("xrt_missing")
+
+    assert connection.is_reachable() is True
+    assert connection.kernel_uname() == (
+        "Linux kv260-no-xrt 6.6.0-pccx-mock #1 SMP PREEMPT aarch64 GNU/Linux"
+    )
+    assert connection.xrt_present() is False
+    assert connection.xrt_version() == ""
+    assert connection.xmutil_listapps() == ()
+
+
+def test_partial_apps_scenario_returns_configured_listapps_subset() -> None:
+    module, _serial_module = load_module()
+
+    connection = module.KV260ConnectionMock.from_scenario("partial_apps")
+
+    assert connection.is_reachable() is True
+    assert connection.xrt_present() is True
+    assert connection.xrt_version() == "XRT mock 2.16.0-partial"
+    assert connection.xmutil_listapps() == ("app: pccx-npu",)
+
+
+def test_direct_state_builder_defaults_xrt_presence_from_version() -> None:
+    module, _serial_module = load_module()
+
+    connection = module.KV260ConnectionMock.from_state(
+        kernel_uname="Linux kv260-direct 6.6.0-pccx-mock aarch64",
+        xrt_version="XRT mock direct",
+        xmutil_listapps=["app: direct"],
+    )
+
+    assert connection.is_reachable() is True
+    assert connection.kernel_uname() == "Linux kv260-direct 6.6.0-pccx-mock aarch64"
+    assert connection.xrt_present() is True
+    assert connection.xrt_version() == "XRT mock direct"
+    assert connection.xmutil_listapps() == ("app: direct",)
+
+
+def test_scenario_loader_rejects_missing_or_path_like_names() -> None:
+    module, _serial_module = load_module()
+
+    assert_raises(
+        module.KV260ConnectionMockScenarioError,
+        lambda: module.KV260ConnectionMock.from_scenario("../happy_path"),
+    )
+    assert_raises(
+        module.KV260ConnectionMockScenarioError,
+        lambda: module.KV260ConnectionMock.from_scenario("missing"),
+    )
+
+
+def test_expected_scenario_fixture_count() -> None:
+    scenario_files = sorted(
+        path
+        for path in SCENARIO_DIR.iterdir()
+        if path.suffix in {".yaml", ".json"}
+    )
+
+    assert [path.stem for path in scenario_files] == [
+        "happy_path",
+        "partial_apps",
+        "xrt_missing",
+    ]
+
+
+def test_source_has_no_board_calls_or_credential_leaks() -> None:
+    source = read_text(MODULE_PATH)
+    test_source = read_text(TEST_PATH)
+    fixture_source = "\n".join(read_text(path) for path in SCENARIO_DIR.iterdir())
+    scan_text = "\n".join([source, fixture_source])
+
+    forbidden_terms = [
+        "param" + "iko",
+        "s" + "cp ",
+        "subprocess",
+        "os.system",
+        "popen",
+        "socket",
+        "requests",
+        "urllib",
+        "serial.Serial",
+        "/dev/",
+        "/dev/mem",
+        "KVFPGA_PASSWORD",
+        "KVFPGA_USER",
+        "KVFPGA_HOST",
+    ]
+    lowered_source = source.lower()
+    for term in forbidden_terms:
+        assert term.lower() not in lowered_source, term
+
+    assert "print(" not in source
+    assert "logging." not in source
+    assert ("raw " + "credential") not in test_source.lower()
+
+    forbidden_claims = [
+        "production-" + "ready",
+        "marketplace-" + "ready",
+        "stable " + "API",
+        "stable " + "ABI",
+        "KV260 inference " + "works",
+        "Gemma 3N E4B " + "runs on KV260",
+        "20 tok/s " + "achieved",
+        "timing " + "closed",
+        "bitstream " + "ready",
+    ]
+    lowered = scan_text.lower()
+    for claim in forbidden_claims:
+        assert claim.lower() not in lowered, claim
+
+    assert not re.search(r"\bssh\s+[^\"']+", source, re.IGNORECASE)
+
+
+def test_source_headers_for_touched_python_files() -> None:
+    expected_headers = {
+        MODULE_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        TEST_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+    }
+    for path, header in expected_headers.items():
+        assert read_text(path).splitlines()[: len(header)] == header, path
+
+
+test_happy_path_scenario_implements_serial_connection_protocol()
+test_xrt_missing_scenario_keeps_board_reachable_without_xrt()
+test_partial_apps_scenario_returns_configured_listapps_subset()
+test_direct_state_builder_defaults_xrt_presence_from_version()
+test_scenario_loader_rejects_missing_or_path_like_names()
+test_expected_scenario_fixture_count()
+test_source_has_no_board_calls_or_credential_leaks()
+test_source_headers_for_touched_python_files()
+
+print("kv260 connection mock tests ok")

--- a/scripts/tests/kv260_serial_connection_test.py
+++ b/scripts/tests/kv260_serial_connection_test.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Tests for the KV260 USB tty serial connection backend."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "contracts" / "kv260_serial_connection.py"
+TEST_PATH = Path(__file__).resolve()
+TEST_PASSWORD_VALUE = "kv260-" + "serial-" + "secret-for-test"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location(
+        "kv260_serial_connection",
+        MODULE_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+class FakeSerial:
+    instances: list["FakeSerial"] = []
+
+    def __init__(self, *args, **kwargs) -> None:
+        self.args = args
+        self.kwargs = kwargs
+        self.writes: list[bytes] = []
+        self.closed = False
+        self.reads = list(type(self).reads)
+        type(self).instances.append(self)
+
+    reads: list[bytes] = []
+
+    def read(self, _size: int) -> bytes:
+        if self.reads:
+            return self.reads.pop(0)
+        return b""
+
+    def write(self, payload: bytes) -> int:
+        self.writes.append(payload)
+        return len(payload)
+
+    def flush(self) -> None:
+        return None
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def reset_fake(reads: list[bytes]) -> None:
+    FakeSerial.instances = []
+    FakeSerial.reads = reads
+
+
+def test_type_contract_and_env_presence_only() -> None:
+    module = load_module()
+    fake_env = {
+        "KVFPGA_HOST": "ignored-host.example.invalid",
+        "KVFPGA_TTY": "/dev/ttyUSB-kv260-test",
+        "KVFPGA_USER": "kv260-user-for-test",
+        "KVFPGA_PASSWORD": TEST_PASSWORD_VALUE,
+    }
+    connection = module.KV260SerialConnection.from_env(
+        fake_env,
+        serial_factory=FakeSerial,
+    )
+    rendered = repr(connection)
+
+    assert isinstance(connection, module.KV260ConnectionProtocol)
+    assert connection.is_configured() is True
+    assert connection.tty_configured is True
+    assert connection.user_configured is True
+    assert connection.password_configured is True
+    assert "ignored-host" not in rendered
+    assert fake_env["KVFPGA_TTY"] not in rendered
+    assert fake_env["KVFPGA_USER"] not in rendered
+    assert fake_env["KVFPGA_PASSWORD"] not in rendered
+
+
+def test_tty_override_and_auto_detect_helpers() -> None:
+    module = load_module()
+
+    assert module.kv260_tty_candidates({"KVFPGA_TTY": "/tmp/tty-kv260"}) == (
+        "/tmp/tty-kv260",
+    )
+    assert module.detect_kv260_tty({"KVFPGA_TTY": "/tmp/tty-kv260"}) == (
+        "/tmp/tty-kv260"
+    )
+    assert isinstance(module.kv260_tty_candidates({}), tuple)
+
+
+def test_reachable_accepts_login_or_shell_prompt() -> None:
+    module = load_module()
+    fake_env = {"KVFPGA_TTY": "/tmp/tty-kv260"}
+
+    reset_fake([b"kv260 login: "])
+    login_connection = module.KV260SerialConnection.from_env(
+        fake_env,
+        serial_factory=FakeSerial,
+    )
+    assert login_connection.is_reachable() is True
+    assert FakeSerial.instances[-1].closed is True
+
+    reset_fake([b"root@kv260:~$ "])
+    shell_connection = module.KV260SerialConnection.from_env(
+        fake_env,
+        serial_factory=FakeSerial,
+    )
+    assert shell_connection.is_reachable() is True
+    assert FakeSerial.instances[-1].closed is True
+
+
+def test_login_uname_and_logout_over_serial() -> None:
+    module = load_module()
+    fake_env = {
+        "KVFPGA_TTY": "/tmp/tty-kv260",
+        "KVFPGA_USER": "kv260-user-for-test",
+        "KVFPGA_PASSWORD": TEST_PASSWORD_VALUE,
+    }
+    reset_fake(
+        [
+            b"kv260 login: ",
+            b"Password: ",
+            b"root@kv260:~$ ",
+            (
+                b"root@kv260:~$ uname -a; printf "
+                b"'\\n__PCCX_KV260_SERIAL_DONE__:%s\\n' \"$?\"\r\n"
+                b"Linux kv260 6.6.0-test #1 SMP PREEMPT aarch64 GNU/Linux\r\n"
+                b"__PCCX_KV260_SERIAL_DONE__:0\r\n"
+                b"root@kv260:~$ "
+            ),
+        ],
+    )
+    connection = module.KV260SerialConnection.from_env(
+        fake_env,
+        serial_factory=FakeSerial,
+    )
+
+    assert connection.kernel_uname() == (
+        "Linux kv260 6.6.0-test #1 SMP PREEMPT aarch64 GNU/Linux"
+    )
+    writes = b"".join(FakeSerial.instances[-1].writes)
+    assert b"uname -a" in writes
+    assert writes.endswith(b"exit\r\n")
+    assert FakeSerial.instances[-1].closed is True
+
+
+def test_xrt_present_and_xmutil_listapps_use_serial_commands() -> None:
+    module = load_module()
+    fake_env = {
+        "KVFPGA_TTY": "/tmp/tty-kv260",
+        "KVFPGA_USER": "kv260-user-for-test",
+        "KVFPGA_PASSWORD": TEST_PASSWORD_VALUE,
+    }
+
+    reset_fake([b"$ ", b"__PCCX_KV260_SERIAL_DONE__:0\r\n$ "])
+    connection = module.KV260SerialConnection.from_env(
+        fake_env,
+        serial_factory=FakeSerial,
+    )
+    assert connection.xrt_present() is True
+
+    reset_fake(
+        [
+            b"$ ",
+            (
+                b"$ xmutil listapps; printf "
+                b"'\\n__PCCX_KV260_SERIAL_DONE__:%s\\n' \"$?\"\r\n"
+                b"accelerated_app\r\n"
+                b"diagnostic_app\r\n"
+                b"__PCCX_KV260_SERIAL_DONE__:0\r\n$ "
+            ),
+        ],
+    )
+    listapps_connection = module.KV260SerialConnection.from_env(
+        fake_env,
+        serial_factory=FakeSerial,
+    )
+    assert listapps_connection.xmutil_listapps() == (
+        "accelerated_app",
+        "diagnostic_app",
+    )
+
+
+def test_live_serial_probe_skips_gracefully_without_tty() -> None:
+    module = load_module()
+    tty = module.detect_kv260_tty()
+    if tty is None:
+        print("skip: no KV260 tty device detected")
+        return
+    try:
+        import serial  # type: ignore[import-not-found]  # noqa: F401
+    except ImportError:
+        print("skip: pyserial is not installed")
+        return
+    if not os.environ.get("KVFPGA_USER") or not os.environ.get("KVFPGA_PASSWORD"):
+        print("skip: KVFPGA serial credentials are incomplete")
+        return
+
+    connection = module.KV260SerialConnection.from_env()
+    assert isinstance(connection.is_reachable(), bool)
+
+
+def test_source_has_no_credential_leaks_or_unsupported_paths() -> None:
+    source = read_text(MODULE_PATH)
+    test_source = read_text(TEST_PATH)
+    scan_text = source
+
+    forbidden_terms = [
+        "param" + "iko",
+        "s" + "cp ",
+        "subprocess",
+        "os.system",
+        "popen",
+        "socket",
+        "requests",
+        "urllib",
+        "transformers",
+        "huggingface_hub",
+        "/dev/mem",
+    ]
+    lowered_source = source.lower()
+    for term in forbidden_terms:
+        assert term not in lowered_source, term
+
+    assert "print(" not in source
+    assert "logging." not in source
+    assert TEST_PASSWORD_VALUE not in source
+    assert ("serial-" + "secret-for-test") not in test_source
+
+    forbidden_claims = [
+        "production-" + "ready",
+        "marketplace-" + "ready",
+        "stable " + "API",
+        "stable " + "ABI",
+        "KV260 inference " + "works",
+        "Gemma 3N E4B " + "runs on KV260",
+        "20 tok/s " + "achieved",
+        "timing " + "closed",
+        "bitstream " + "ready",
+    ]
+    lowered = scan_text.lower()
+    for claim in forbidden_claims:
+        assert claim.lower() not in lowered, claim
+
+    assert not re.search(r"\bssh\s+[^\"']+", source, re.IGNORECASE)
+
+
+def test_source_headers_for_touched_python_files() -> None:
+    expected_headers = {
+        MODULE_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        TEST_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+    }
+    for path, header in expected_headers.items():
+        assert read_text(path).splitlines()[: len(header)] == header, path
+
+
+test_type_contract_and_env_presence_only()
+test_tty_override_and_auto_detect_helpers()
+test_reachable_accepts_login_or_shell_prompt()
+test_login_uname_and_logout_over_serial()
+test_xrt_present_and_xmutil_listapps_use_serial_commands()
+test_live_serial_probe_skips_gracefully_without_tty()
+test_source_has_no_credential_leaks_or_unsupported_paths()
+test_source_headers_for_touched_python_files()
+
+print("kv260 serial connection tests ok")

--- a/scripts/tests/trace_capture_client_test.py
+++ b/scripts/tests/trace_capture_client_test.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Type-focused tests for launcher trace capture framing."""
+
+from __future__ import annotations
+
+import io
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from contracts.dummy_e2e_contract import dummy_e2e, dummy_e2e_trace_frames
+from contracts.trace_capture_client import (
+    PCCX_TRACE_BEGIN_MARKER,
+    TraceCaptureClient,
+    TraceCaptureFrame,
+    serial_frame_crc32,
+)
+
+
+CLI_PATH = ROOT / "scripts" / "pccx-launcher"
+MODULE_PATH = ROOT / "contracts" / "trace_capture_client.py"
+TEST_PATH = Path(__file__).resolve()
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def split_capture(text: str) -> list[str]:
+    return text.splitlines()
+
+
+def assert_valid_v2_frame(line: str, seq: int) -> dict[str, object]:
+    frame = json.loads(line)
+
+    assert frame["seq"] == seq
+    assert set(frame) == {
+        "seq",
+        "frame_idx",
+        "axi_stat",
+        "engine_completion",
+        "cycles",
+        "err",
+        "crc32",
+    }
+    assert frame["crc32"] == serial_frame_crc32(
+        seq=int(frame["seq"]),
+        frame_idx=int(frame["frame_idx"]),
+        axi_stat=int(frame["axi_stat"]),
+        engine_completion=int(frame["engine_completion"]),
+        cycles=int(frame["cycles"]),
+        err=frame["err"] if isinstance(frame["err"], str) else None,
+    )
+    return frame
+
+
+def test_crc32_matches_lab_v2_contract_fixture() -> None:
+    assert serial_frame_crc32(0, 0, 1, 3, 128, None) == 230_227_294
+
+
+def test_trace_capture_client_writes_stdout_style_text_sink() -> None:
+    sink = io.StringIO()
+    client = TraceCaptureClient(serial_port=sink)
+    client.capture(
+        (
+            TraceCaptureFrame(
+                frame_idx=0,
+                axi_stat=1,
+                engine_completion=3,
+                cycles=128,
+            ),
+        ),
+    )
+
+    lines = split_capture(sink.getvalue())
+    assert lines[0] == PCCX_TRACE_BEGIN_MARKER
+    assert_valid_v2_frame(lines[1], seq=0)
+    assert lines[2] == "===PCCX_TRACE_END seq=1==="
+
+
+def test_trace_capture_client_writes_bytes_serial_sink_without_real_serial() -> None:
+    sink = io.BytesIO()
+    client = TraceCaptureClient(serial_port=sink)
+    client.capture(
+        (
+            TraceCaptureFrame(
+                frame_idx=7,
+                axi_stat=9,
+                engine_completion=1,
+                cycles=512,
+                err="fixture warning",
+            ),
+        ),
+    )
+
+    lines = split_capture(sink.getvalue().decode("utf-8"))
+    frame = assert_valid_v2_frame(lines[1], seq=0)
+    assert frame["frame_idx"] == 7
+    assert frame["err"] == "fixture warning"
+
+
+def test_dummy_e2e_trace_frames_are_v2_capture_ready() -> None:
+    stream = dummy_e2e(42)
+    frames = dummy_e2e_trace_frames(stream)
+
+    assert len(frames) == len(stream.command_trace)
+    assert tuple(frame.frame_idx for frame in frames) == (0, 1, 2)
+    assert tuple(frame.axi_stat for frame in frames) == tuple(
+        trace.mmio_stat for trace in stream.command_trace
+    )
+    assert tuple(frame.engine_completion for frame in frames) == (1, 2, 3)
+    assert tuple(frame.cycles for frame in frames) == (128, 256, 384)
+
+
+def test_cli_dummy_e2e_capture_writes_v2_framed_fixture_file() -> None:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        capture_path = Path(temp_dir) / "dummy-e2e.trace.jsonl"
+        out = subprocess.run(
+            [
+                str(CLI_PATH),
+                "dummy-e2e",
+                "--seed",
+                "42",
+                "--capture",
+                str(capture_path),
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        assert out.stderr == ""
+        assert "dummy_e2e: ok\n" in out.stdout
+        lines = split_capture(read_text(capture_path))
+
+    assert lines[0] == PCCX_TRACE_BEGIN_MARKER
+    assert lines[-1] == "===PCCX_TRACE_END seq=3==="
+    assert len(lines) == 5
+    frames = [assert_valid_v2_frame(line, seq=index) for index, line in enumerate(lines[1:-1])]
+    assert [frame["frame_idx"] for frame in frames] == [0, 1, 2]
+
+
+def test_trace_capture_source_headers_and_no_runtime_claims() -> None:
+    expected_headers = {
+        MODULE_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        TEST_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+    }
+    for path, header in expected_headers.items():
+        assert read_text(path).splitlines()[: len(header)] == header, path
+
+    lowered = read_text(MODULE_PATH).lower()
+    for term in ("os.environ", "getenv", "requests", "urllib", "socket", "paramiko", "fabric"):
+        assert term not in lowered, term
+
+
+test_crc32_matches_lab_v2_contract_fixture()
+test_trace_capture_client_writes_stdout_style_text_sink()
+test_trace_capture_client_writes_bytes_serial_sink_without_real_serial()
+test_dummy_e2e_trace_frames_are_v2_capture_ready()
+test_cli_dummy_e2e_capture_writes_v2_framed_fixture_file()
+test_trace_capture_source_headers_and_no_runtime_claims()
+
+print("trace capture client tests ok")

--- a/scripts/tests/trace_capture_client_test.py
+++ b/scripts/tests/trace_capture_client_test.py
@@ -149,6 +149,38 @@ def test_cli_dummy_e2e_capture_writes_v2_framed_fixture_file() -> None:
     assert [frame["frame_idx"] for frame in frames] == [0, 1, 2]
 
 
+def test_cli_dummy_e2e_capture_smoke_tmp_x_jsonl() -> None:
+    capture_path = Path("/tmp/x.jsonl")
+    capture_path.unlink(missing_ok=True)
+    try:
+        out = subprocess.run(
+            [
+                str(CLI_PATH),
+                "dummy-e2e",
+                "--seed",
+                "42",
+                "--capture",
+                str(capture_path),
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        assert out.stderr == ""
+        assert capture_path.exists()
+        lines = split_capture(read_text(capture_path))
+
+        assert lines[0] == PCCX_TRACE_BEGIN_MARKER
+        expected_frames = dummy_e2e_trace_frames(dummy_e2e(42))
+        assert len(lines[1:-1]) == len(expected_frames)
+        assert lines[-1] == f"===PCCX_TRACE_END seq={len(lines[1:-1])}==="
+        for index, line in enumerate(lines[1:-1]):
+            assert_valid_v2_frame(line, seq=index)
+    finally:
+        capture_path.unlink(missing_ok=True)
+
+
 def test_trace_capture_source_headers_and_no_runtime_claims() -> None:
     expected_headers = {
         MODULE_PATH: [
@@ -175,6 +207,7 @@ test_trace_capture_client_writes_stdout_style_text_sink()
 test_trace_capture_client_writes_bytes_serial_sink_without_real_serial()
 test_dummy_e2e_trace_frames_are_v2_capture_ready()
 test_cli_dummy_e2e_capture_writes_v2_framed_fixture_file()
+test_cli_dummy_e2e_capture_smoke_tmp_x_jsonl()
 test_trace_capture_source_headers_and_no_runtime_claims()
 
 print("trace capture client tests ok")

--- a/tests/fixtures/scenarios/boot_in_progress.yaml
+++ b/tests/fixtures/scenarios/boot_in_progress.yaml
@@ -1,0 +1,4 @@
+kernel_uname: "boot incomplete"
+xrt_present: false
+xrt_version: ""
+xmutil_listapps: []

--- a/tests/fixtures/scenarios/happy_path.yaml
+++ b/tests/fixtures/scenarios/happy_path.yaml
@@ -1,0 +1,7 @@
+kernel_uname: "Linux kv260-happy 6.6.0-pccx-mock #1 SMP PREEMPT aarch64 GNU/Linux"
+xrt_present: true
+xrt_version: "XRT mock 2.16.0"
+xmutil_listapps:
+  - "app: pccx-npu"
+  - "app: diagnostics"
+  - "app: shell"

--- a/tests/fixtures/scenarios/panic_state.yaml
+++ b/tests/fixtures/scenarios/panic_state.yaml
@@ -1,0 +1,4 @@
+kernel_uname: "Kernel panic - not syncing: VFS: Unable to mount root fs on unknown-block(0,0)"
+xrt_present: false
+xrt_version: ""
+xmutil_listapps: []

--- a/tests/fixtures/scenarios/partial_apps.yaml
+++ b/tests/fixtures/scenarios/partial_apps.yaml
@@ -1,0 +1,5 @@
+kernel_uname: "Linux kv260-partial 6.6.0-pccx-mock #1 SMP PREEMPT aarch64 GNU/Linux"
+xrt_present: true
+xrt_version: "XRT mock 2.16.0-partial"
+xmutil_listapps:
+  - "app: pccx-npu"

--- a/tests/fixtures/scenarios/single_app_loaded.yaml
+++ b/tests/fixtures/scenarios/single_app_loaded.yaml
@@ -1,0 +1,5 @@
+kernel_uname: "Linux kv260-single-app 6.6.0-pccx-mock #1 SMP PREEMPT aarch64 GNU/Linux"
+xrt_present: true
+xrt_version: "XRT mock 2.16.0-single-app"
+xmutil_listapps:
+  - "app: pccx-npu"

--- a/tests/fixtures/scenarios/xrt_missing.json
+++ b/tests/fixtures/scenarios/xrt_missing.json
@@ -1,0 +1,6 @@
+{
+  "kernel_uname": "Linux kv260-no-xrt 6.6.0-pccx-mock #1 SMP PREEMPT aarch64 GNU/Linux",
+  "xrt_present": false,
+  "xrt_version": "",
+  "xmutil_listapps": []
+}

--- a/tests/fixtures/scenarios/xrt_present_no_apps.yaml
+++ b/tests/fixtures/scenarios/xrt_present_no_apps.yaml
@@ -1,0 +1,4 @@
+kernel_uname: "Linux kv260-xrt-no-apps 6.6.0-pccx-mock #1 SMP PREEMPT aarch64 GNU/Linux"
+xrt_present: true
+xrt_version: "XRT mock 2.16.0-no-apps"
+xmutil_listapps: []


### PR DESCRIPTION
## Summary
- Merge the offline mock component branches used by refs #74, #75, #77, #78, #79, and #80.
- Add a full-mock integration test that loads the KV260 happy_path scenario, exercises AxiCmdMockBackend with dummy_e2e(seed=42), captures v2 trace frames to a tempfile, parses them, and asserts expected NPU status/register values with zero frame errors.
- Add the integration test to CI.

## Validation
- python3 scripts/tests/full_mock_integration_test.py
- python3 scripts/tests/axi_cmd_mock_backend_test.py
- python3 scripts/tests/dummy_e2e_contract_test.py
- python3 scripts/tests/trace_capture_client_test.py
- python3 scripts/tests/kv260_connection_mock_test.py
- python3 scripts/tests/kv260_serial_connection_test.py
- python3 scripts/tests/gemma_weight_prep_contract_test.py
- python3 -m compileall -q contracts scripts/tests
- git diff --check
- claim-scan clean

Refs #74 #75 #77 #78 #79 #80