### PR TITLE
feat(io): token stream over serial

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -329,6 +329,8 @@ jobs:
         run: python3 scripts/tests/kv260_serial_connection_test.py
       - name: run AXI command mock backend tests
         run: python3 scripts/tests/axi_cmd_mock_backend_test.py
+      - name: run token stream over serial tests
+        run: python3 scripts/tests/token_stream_over_serial_test.py
       - name: run chat/session contract tests
         run: python3 scripts/tests/chat_session_contract_test.py
       - name: run chat model status contract tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,6 +325,8 @@ jobs:
         run: python3 scripts/tests/device_session_status_contract_test.py
       - name: run runtime readiness contract tests
         run: python3 scripts/tests/runtime_readiness_contract_test.py
+      - name: run KV260 serial connection tests
+        run: python3 scripts/tests/kv260_serial_connection_test.py
       - name: run chat/session contract tests
         run: python3 scripts/tests/chat_session_contract_test.py
       - name: run chat model status contract tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,6 +325,8 @@ jobs:
         run: python3 scripts/tests/device_session_status_contract_test.py
       - name: run runtime readiness contract tests
         run: python3 scripts/tests/runtime_readiness_contract_test.py
+      - name: run AXI command mock backend tests
+        run: python3 scripts/tests/axi_cmd_mock_backend_test.py
       - name: run chat/session contract tests
         run: python3 scripts/tests/chat_session_contract_test.py
       - name: run chat model status contract tests

--- a/contracts/axi_cmd_channel.py
+++ b/contracts/axi_cmd_channel.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Offline AXI command-channel contract and mock backend.
+
+This module is intentionally local-only. It models the command and status
+registers in memory so tests can exercise launcher-side command flow without a
+board, device file, driver, or runtime transport.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from threading import RLock
+from typing import Deque, Iterable, Protocol
+
+
+MMIO_CMD = "MMIO_CMD"
+MMIO_STAT = "MMIO_STAT"
+UINT32_MASK = 0xFFFF_FFFF
+
+
+@dataclass(frozen=True)
+class NpuCmd:
+    """Command payload written to the modeled MMIO_CMD register."""
+
+    opcode: int
+    arg0: int = 0
+    arg1: int = 0
+    arg2: int = 0
+    flags: int = 0
+
+    def __post_init__(self) -> None:
+        for field_name in ("opcode", "arg0", "arg1", "arg2", "flags"):
+            value = getattr(self, field_name)
+            if not isinstance(value, int):
+                raise TypeError(f"{field_name} must be an int")
+            if value < 0:
+                raise ValueError(f"{field_name} must be non-negative")
+
+    def register_value(self) -> int:
+        """Return a deterministic 32-bit representation for MMIO_CMD."""
+
+        packed = (
+            (self.opcode & 0xFF)
+            | ((self.flags & 0xFF) << 8)
+            | ((self.arg0 & 0xFF) << 16)
+            | ((self.arg1 & 0xFF) << 24)
+        )
+        return (packed ^ (self.arg2 & UINT32_MASK)) & UINT32_MASK
+
+
+@dataclass(frozen=True)
+class NpuStat:
+    """Status payload read from the modeled MMIO_STAT register."""
+
+    completion_count: int = 0
+    last_opcode: int = 0
+    busy: bool = False
+    error: bool = False
+    status_code: int = 0
+
+    def __post_init__(self) -> None:
+        for field_name in ("completion_count", "last_opcode", "status_code"):
+            value = getattr(self, field_name)
+            if not isinstance(value, int):
+                raise TypeError(f"{field_name} must be an int")
+            if value < 0:
+                raise ValueError(f"{field_name} must be non-negative")
+        for field_name in ("busy", "error"):
+            if not isinstance(getattr(self, field_name), bool):
+                raise TypeError(f"{field_name} must be a bool")
+
+    def register_value(self) -> int:
+        """Return a deterministic 32-bit representation for MMIO_STAT."""
+
+        value = (
+            (self.completion_count & 0xFFFF) << 16
+            | ((self.status_code & 0x3F) << 8)
+            | ((self.last_opcode & 0x3F) << 2)
+            | (0x2 if self.error else 0)
+            | (0x1 if self.busy else 0)
+        )
+        return value & UINT32_MASK
+
+
+class AxiCmdChannel(Protocol):
+    """Minimal command-channel interface used by launcher-side tests."""
+
+    def issue(self, cmd: NpuCmd) -> None:
+        """Issue a command to the channel."""
+
+    def poll_stat(self) -> NpuStat:
+        """Read the current command-channel status."""
+
+
+class ScriptedReplyMismatch(AssertionError):
+    """Raised when a scripted mock backend observes an unexpected command."""
+
+
+class AxiCmdMockBackend:
+    """Thread-safe in-memory AXI command backend for offline tests."""
+
+    def __init__(
+        self,
+        scripted_replies: Iterable[tuple[NpuCmd, NpuStat]] | None = None,
+    ) -> None:
+        self._lock = RLock()
+        self._registers = {MMIO_CMD: 0, MMIO_STAT: 0}
+        self._scripted_replies: Deque[tuple[NpuCmd, NpuStat]] = deque(
+            scripted_replies or (),
+        )
+        self._last_cmd: NpuCmd | None = None
+        self._last_stat = NpuStat()
+        self._completion_count = 0
+        self._closed = False
+
+    def __enter__(self) -> "AxiCmdMockBackend":
+        with self._lock:
+            self._closed = False
+            return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        self.close()
+
+    @property
+    def completion_count(self) -> int:
+        with self._lock:
+            return self._completion_count
+
+    @property
+    def last_cmd(self) -> NpuCmd | None:
+        with self._lock:
+            return self._last_cmd
+
+    @property
+    def remaining_scripted_replies(self) -> int:
+        with self._lock:
+            return len(self._scripted_replies)
+
+    def close(self) -> None:
+        with self._lock:
+            self._closed = True
+
+    def issue(self, cmd: NpuCmd) -> None:
+        if not isinstance(cmd, NpuCmd):
+            raise TypeError("cmd must be an NpuCmd")
+
+        with self._lock:
+            self._ensure_open()
+            scripted_stat = self._consume_scripted_reply(cmd)
+            self._completion_count += 1
+            self._last_cmd = cmd
+            self._last_stat = scripted_stat or self._default_stat_for(cmd)
+            self._registers[MMIO_CMD] = cmd.register_value()
+            self._registers[MMIO_STAT] = self._last_stat.register_value()
+
+    def poll_stat(self) -> NpuStat:
+        with self._lock:
+            self._ensure_open()
+            self._registers[MMIO_STAT] = self._last_stat.register_value()
+            return self._last_stat
+
+    def snapshot_registers(self) -> dict[str, int]:
+        with self._lock:
+            return dict(self._registers)
+
+    def assert_script_consumed(self) -> None:
+        with self._lock:
+            remaining = len(self._scripted_replies)
+            if remaining:
+                raise ScriptedReplyMismatch(
+                    f"{remaining} scripted AXI command replies were not used",
+                )
+
+    def _consume_scripted_reply(self, cmd: NpuCmd) -> NpuStat | None:
+        if not self._scripted_replies:
+            return None
+
+        expected_cmd, expected_stat = self._scripted_replies[0]
+        if cmd != expected_cmd:
+            raise ScriptedReplyMismatch(
+                f"expected command {expected_cmd!r}, got {cmd!r}",
+            )
+        self._scripted_replies.popleft()
+        return expected_stat
+
+    def _default_stat_for(self, cmd: NpuCmd) -> NpuStat:
+        return NpuStat(
+            completion_count=self._completion_count,
+            last_opcode=cmd.opcode,
+            busy=False,
+            error=False,
+            status_code=0,
+        )
+
+    def _ensure_open(self) -> None:
+        if self._closed:
+            raise RuntimeError("AxiCmdMockBackend is closed")

--- a/contracts/kv260_serial_connection.py
+++ b/contracts/kv260_serial_connection.py
@@ -1,0 +1,347 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""TTY serial backend for KV260 launcher-side status checks.
+
+The backend uses USB serial console access only. Credentials come from
+`KVFPGA_USER` and `KVFPGA_PASSWORD`; `KVFPGA_HOST` is intentionally ignored.
+Raw environment values are not exposed through repr or public status fields.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Mapping, Protocol, Sequence, runtime_checkable
+
+
+DEFAULT_BAUDRATE = 115200
+DEFAULT_PROMPT_TIMEOUT = 4.0
+DEFAULT_COMMAND_TIMEOUT = 12.0
+DEFAULT_WRITE_TIMEOUT = 1.0
+READ_CHUNK_SIZE = 1024
+END_MARKER = "__PCCX_KV260_SERIAL_DONE__"
+
+LOGIN_PROMPT = re.compile(rb"(?im)(?:^|\r?\n)[^\r\n]*login:\s*$")
+PASSWORD_PROMPT = re.compile(rb"(?im)(?:^|\r?\n)[^\r\n]*password:\s*$")
+SHELL_PROMPT = re.compile(rb"(?m)(?:^|\r?\n)[^\r\n]*[$#]\s*$")
+COMMAND_DONE = re.compile((END_MARKER + r":(\d+)").encode("ascii"))
+
+
+class KV260SerialError(RuntimeError):
+    """Base error for serial backend failures."""
+
+
+class KV260SerialUnavailable(KV260SerialError):
+    """Raised when a tty port or pyserial backend is unavailable."""
+
+
+@runtime_checkable
+class KV260ConnectionProtocol(Protocol):
+    """Method contract shared by KV260 connection backends."""
+
+    def is_reachable(self) -> bool:
+        """Return whether a serial console prompt can be reached."""
+
+    def kernel_uname(self) -> str:
+        """Return `uname -a` from the KV260 serial session."""
+
+    def xrt_present(self) -> bool:
+        """Return whether XRT tooling or libraries are visible on the target."""
+
+    def xmutil_listapps(self) -> Sequence[str]:
+        """Return `xmutil listapps` output lines from the target."""
+
+
+@dataclass(frozen=True)
+class SerialCommandResult:
+    """Target command output with shell exit status."""
+
+    exit_status: int
+    output: str
+
+
+SerialFactory = Callable[..., Any]
+
+
+def kv260_tty_candidates(env: Mapping[str, str] | None = None) -> tuple[str, ...]:
+    """Return candidate KV260 serial tty paths, with env override first."""
+
+    source = os.environ if env is None else env
+    override = source.get("KVFPGA_TTY")
+    if override:
+        return (override,)
+
+    candidates: list[str] = []
+    by_id = Path("/dev/serial/by-id")
+    if by_id.is_dir():
+        for path in sorted(by_id.iterdir()):
+            if "kv260" in path.name.lower():
+                candidates.append(str(path))
+
+    candidates.extend(str(path) for path in sorted(Path("/dev").glob("ttyUSB*")))
+    return tuple(dict.fromkeys(candidates))
+
+
+def detect_kv260_tty(env: Mapping[str, str] | None = None) -> str | None:
+    """Return the first configured or auto-detected KV260 serial tty path."""
+
+    candidates = kv260_tty_candidates(env)
+    return candidates[0] if candidates else None
+
+
+@dataclass
+class KV260SerialConnection:
+    """USB tty serial implementation of the KV260 connection method contract."""
+
+    tty_configured: bool
+    user_configured: bool
+    password_configured: bool
+    baudrate: int = DEFAULT_BAUDRATE
+    prompt_timeout: float = DEFAULT_PROMPT_TIMEOUT
+    command_timeout: float = DEFAULT_COMMAND_TIMEOUT
+    write_timeout: float = DEFAULT_WRITE_TIMEOUT
+    _tty: str | None = field(default=None, repr=False, compare=False)
+    _user: str | None = field(default=None, repr=False, compare=False)
+    _password: str | None = field(default=None, repr=False, compare=False)
+    _serial_factory: SerialFactory | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+    _active_serial: Any | None = field(default=None, repr=False, compare=False)
+
+    @classmethod
+    def from_env(
+        cls,
+        env: Mapping[str, str] | None = None,
+        serial_factory: SerialFactory | None = None,
+    ) -> "KV260SerialConnection":
+        source = os.environ if env is None else env
+        tty = source.get("KVFPGA_TTY")
+        user = source.get("KVFPGA_USER")
+        password = source.get("KVFPGA_PASSWORD")
+        return cls(
+            tty_configured=bool(tty),
+            user_configured=bool(user),
+            password_configured=bool(password),
+            _tty=tty,
+            _user=user,
+            _password=password,
+            _serial_factory=serial_factory,
+        )
+
+    def is_configured(self) -> bool:
+        """Return whether required serial credentials are present."""
+
+        return self.user_configured and self.password_configured
+
+    def is_reachable(self) -> bool:
+        """Open the tty, send a newline, and check for login or shell prompt."""
+
+        serial_session = None
+        try:
+            serial_session = self._open_serial()
+            self._write(serial_session, b"\r\n")
+            prompt, _buffer = self._read_until_prompt(
+                serial_session,
+                timeout=self.prompt_timeout,
+            )
+            return prompt is not None
+        except (OSError, KV260SerialError):
+            return False
+        finally:
+            self._close_serial(serial_session)
+
+    def kernel_uname(self) -> str:
+        with self as connection:
+            result = connection._run_command("uname -a")
+        if result.exit_status != 0:
+            raise KV260SerialError("uname command failed")
+        return result.output.strip()
+
+    def xrt_present(self) -> bool:
+        command = (
+            "command -v xrt-smi >/dev/null 2>&1 || "
+            "command -v xbutil >/dev/null 2>&1 || "
+            "test -e /usr/lib/libxrt_core.so || "
+            "test -e /usr/lib/aarch64-linux-gnu/libxrt_core.so"
+        )
+        with self as connection:
+            result = connection._run_command(command)
+        return result.exit_status == 0
+
+    def xmutil_listapps(self) -> Sequence[str]:
+        with self as connection:
+            result = connection._run_command("xmutil listapps")
+        if result.exit_status != 0:
+            return ()
+        return tuple(line for line in result.output.splitlines() if line.strip())
+
+    def __enter__(self) -> "KV260SerialConnection":
+        serial_session = self._open_serial()
+        try:
+            self._login(serial_session)
+        except Exception:
+            self._close_serial(serial_session)
+            raise
+        self._active_serial = serial_session
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        self.logout()
+
+    def logout(self) -> None:
+        serial_session = self._active_serial
+        self._active_serial = None
+        if serial_session is None:
+            return
+        try:
+            self._write(serial_session, b"exit\r\n")
+        finally:
+            self._close_serial(serial_session)
+
+    def _open_serial(self) -> Any:
+        tty = self._tty or detect_kv260_tty()
+        if not tty:
+            raise KV260SerialUnavailable("no KV260 serial tty detected")
+
+        factory = self._serial_factory
+        if factory is None:
+            try:
+                import serial  # type: ignore[import-not-found]
+            except ImportError as exc:
+                raise KV260SerialUnavailable("pyserial is not installed") from exc
+            factory = serial.Serial
+
+        return factory(
+            port=tty,
+            baudrate=self.baudrate,
+            timeout=0.1,
+            write_timeout=self.write_timeout,
+        )
+
+    def _login(self, serial_session: Any) -> None:
+        if not self._user or not self._password:
+            raise KV260SerialUnavailable("KVFPGA serial credentials are incomplete")
+
+        self._write(serial_session, b"\r\n")
+        prompt, _buffer = self._read_until_prompt(
+            serial_session,
+            timeout=self.prompt_timeout,
+        )
+        if prompt == "login":
+            self._write_line(serial_session, self._user)
+            prompt, _buffer = self._read_until_prompt(
+                serial_session,
+                timeout=self.prompt_timeout,
+            )
+        if prompt == "password":
+            self._write_line(serial_session, self._password)
+            prompt, _buffer = self._read_until_prompt(
+                serial_session,
+                timeout=self.prompt_timeout,
+            )
+        if prompt != "shell":
+            raise KV260SerialError("serial shell prompt was not reached")
+
+    def _run_command(self, command: str) -> SerialCommandResult:
+        serial_session = self._active_serial
+        if serial_session is None:
+            raise KV260SerialError("serial session is not open")
+
+        wrapped = f"{command}; printf '\\n{END_MARKER}:%s\\n' \"$?\""
+        self._write_line(serial_session, wrapped)
+        raw = self._read_until_pattern(
+            serial_session,
+            COMMAND_DONE,
+            timeout=self.command_timeout,
+        )
+        match = COMMAND_DONE.search(raw)
+        if match is None:
+            raise KV260SerialError("command completion marker was not observed")
+
+        exit_status = int(match.group(1).decode("ascii"))
+        output = self._clean_command_output(command, raw[: match.start()])
+        return SerialCommandResult(exit_status=exit_status, output=output)
+
+    def _read_until_prompt(
+        self,
+        serial_session: Any,
+        timeout: float,
+    ) -> tuple[str | None, bytes]:
+        deadline = time.monotonic() + timeout
+        buffer = bytearray()
+        while time.monotonic() < deadline:
+            chunk = serial_session.read(READ_CHUNK_SIZE)
+            if chunk:
+                buffer.extend(chunk)
+                data = bytes(buffer)
+                if LOGIN_PROMPT.search(data):
+                    return "login", data
+                if PASSWORD_PROMPT.search(data):
+                    return "password", data
+                if SHELL_PROMPT.search(data):
+                    return "shell", data
+            else:
+                time.sleep(0.02)
+        return None, bytes(buffer)
+
+    def _read_until_pattern(
+        self,
+        serial_session: Any,
+        pattern: re.Pattern[bytes],
+        timeout: float,
+    ) -> bytes:
+        deadline = time.monotonic() + timeout
+        buffer = bytearray()
+        while time.monotonic() < deadline:
+            chunk = serial_session.read(READ_CHUNK_SIZE)
+            if chunk:
+                buffer.extend(chunk)
+                data = bytes(buffer)
+                if pattern.search(data):
+                    return data
+            else:
+                time.sleep(0.02)
+        raise KV260SerialError("serial read timed out")
+
+    def _write_line(self, serial_session: Any, line: str) -> None:
+        self._write(serial_session, line.encode("utf-8") + b"\r\n")
+
+    def _write(self, serial_session: Any, payload: bytes) -> None:
+        serial_session.write(payload)
+        flush = getattr(serial_session, "flush", None)
+        if flush is not None:
+            flush()
+
+    def _clean_command_output(self, command: str, raw: bytes) -> str:
+        text = raw.decode("utf-8", errors="replace").replace("\r", "")
+        lines = text.split("\n")
+        cleaned: list[str] = []
+        for line in lines:
+            stripped = line.strip()
+            if not stripped:
+                continue
+            if stripped == command or stripped.startswith(f"{command}; "):
+                continue
+            if (
+                command in stripped
+                and "printf" in stripped
+                and END_MARKER in stripped
+            ):
+                continue
+            if stripped.endswith("$") or stripped.endswith("#"):
+                continue
+            cleaned.append(line.rstrip())
+        return "\n".join(cleaned)
+
+    def _close_serial(self, serial_session: Any | None) -> None:
+        if serial_session is None:
+            return
+        close = getattr(serial_session, "close", None)
+        if close is not None:
+            close()

--- a/contracts/token_stream_over_serial.py
+++ b/contracts/token_stream_over_serial.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Token stream transport over the KV260 serial tty.
+
+This is first-pass framing; refine after first board run. The control-plane
+wire format uses ASCII begin/end markers around length-prefixed binary chunks,
+matching the lab trace framing shape while keeping token payloads binary.
+"""
+
+from __future__ import annotations
+
+import struct
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import Any, Iterator, List, Protocol, Sequence, runtime_checkable
+
+from contracts.axi_cmd_channel import AxiCmdChannel, NpuCmd
+from contracts.kv260_serial_connection import (
+    KV260SerialConnection,
+    detect_kv260_tty,
+)
+
+
+INPUT_BEGIN_MARKER = b"PCCX_TOKEN_INPUT_BEGIN_V1\n"
+INPUT_END_MARKER = b"PCCX_TOKEN_INPUT_END_V1\n"
+OUTPUT_BEGIN_MARKER = b"PCCX_TOKEN_OUTPUT_BEGIN_V1\n"
+OUTPUT_END_MARKER = b"PCCX_TOKEN_OUTPUT_END_V1\n"
+INPUT_CHUNK_TAG = b"ITOK"
+OUTPUT_CHUNK_TAG = b"OTOK"
+UINT32_MAX = 0xFFFF_FFFF
+DEFAULT_EOS_TOKEN_ID = 1
+DEFAULT_CHUNK_TOKEN_COUNT = 256
+DEFAULT_OUTPUT_TIMEOUT_S = 5.0
+READ_CHUNK_SIZE = 1024
+
+OP_BEGIN_INPUT = 0x31
+OP_END_INPUT = 0x32
+OP_READ_OUTPUT = 0x33
+
+
+class TokenStreamError(RuntimeError):
+    """Base error for token-stream transport failures."""
+
+
+class TokenStreamFramingError(TokenStreamError):
+    """Raised when received token framing is malformed."""
+
+
+@runtime_checkable
+class TokenStreamProtocol(Protocol):
+    """Method contract for launcher-side token streaming."""
+
+    def send_input_tokens(self, token_ids: List[int]) -> None:
+        """Send prompt token IDs to the KV260 control-plane tty."""
+
+    def recv_output_tokens(self, timeout_s: float) -> List[int]:
+        """Receive generated token IDs until EOS, end marker, or timeout."""
+
+    def infer(self, prompt_token_ids: List[int]) -> List[int]:
+        """Send prompt token IDs and return generated output token IDs."""
+
+
+@dataclass
+class TokenStreamOverSerial:
+    """Length-prefixed token transport using a KV260 serial connection."""
+
+    connection: KV260SerialConnection
+    axi_channel: AxiCmdChannel | None = None
+    eos_token_id: int = DEFAULT_EOS_TOKEN_ID
+    chunk_token_count: int = DEFAULT_CHUNK_TOKEN_COUNT
+    output_timeout_s: float = DEFAULT_OUTPUT_TIMEOUT_S
+    _active_serial: Any | None = field(default=None, init=False, repr=False)
+
+    @classmethod
+    def from_env(
+        cls,
+        serial_factory: Any | None = None,
+        axi_channel: AxiCmdChannel | None = None,
+    ) -> "TokenStreamOverSerial":
+        """Build a token stream from KV260 serial environment settings."""
+
+        return cls(
+            connection=KV260SerialConnection.from_env(
+                serial_factory=serial_factory,
+            ),
+            axi_channel=axi_channel,
+        )
+
+    def __post_init__(self) -> None:
+        if self.eos_token_id < 0 or self.eos_token_id > UINT32_MAX:
+            raise ValueError("eos_token_id must fit uint32")
+        if self.chunk_token_count <= 0:
+            raise ValueError("chunk_token_count must be positive")
+        if self.output_timeout_s < 0:
+            raise ValueError("output_timeout_s must be non-negative")
+
+    def __enter__(self) -> "TokenStreamOverSerial":
+        if self._active_serial is None:
+            self._active_serial = self.connection._open_serial()
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        self.close()
+
+    def close(self) -> None:
+        """Close the active serial session when this wrapper opened one."""
+
+        serial_session = self._active_serial
+        self._active_serial = None
+        self.connection._close_serial(serial_session)
+
+    def send_input_tokens(self, token_ids: List[int]) -> None:
+        """Encode prompt tokens and write them to the KV260 serial tty."""
+
+        tokens = _validate_tokens(token_ids)
+        self._issue_axi(OP_BEGIN_INPUT, len(tokens))
+        payload = encode_input_stream(tokens, self.chunk_token_count)
+        with self._serial_for_call() as serial_session:
+            self.connection._write(serial_session, payload)
+        self._issue_axi(OP_END_INPUT, len(tokens))
+
+    def recv_output_tokens(self, timeout_s: float) -> List[int]:
+        """Read output token framing until EOS, output end, or timeout."""
+
+        if timeout_s < 0:
+            raise ValueError("timeout_s must be non-negative")
+
+        self._issue_axi(OP_READ_OUTPUT, 0)
+        deadline = time.monotonic() + timeout_s
+        buffer = bytearray()
+        tokens: list[int] = []
+        parser_offset = 0
+        saw_begin = False
+
+        with self._serial_for_call() as serial_session:
+            while time.monotonic() <= deadline:
+                chunk = serial_session.read(READ_CHUNK_SIZE)
+                if chunk:
+                    buffer.extend(chunk)
+                    state = _parse_output_buffer(
+                        bytes(buffer),
+                        parser_offset,
+                        tokens,
+                        self.eos_token_id,
+                        saw_begin,
+                    )
+                    parser_offset = state.offset
+                    saw_begin = state.saw_begin
+                    if state.done:
+                        return list(tokens)
+                    continue
+                time.sleep(0.02)
+
+        return list(tokens)
+
+    def infer(self, prompt_token_ids: List[int]) -> List[int]:
+        """Send prompt tokens and return output tokens over one tty session."""
+
+        if self._active_serial is not None:
+            self.send_input_tokens(prompt_token_ids)
+            return self.recv_output_tokens(self.output_timeout_s)
+
+        with self:
+            self.send_input_tokens(prompt_token_ids)
+            return self.recv_output_tokens(self.output_timeout_s)
+
+    @contextmanager
+    def _serial_for_call(self) -> Iterator[Any]:
+        if self._active_serial is not None:
+            yield self._active_serial
+            return
+
+        serial_session = self.connection._open_serial()
+        try:
+            yield serial_session
+        finally:
+            self.connection._close_serial(serial_session)
+
+    def _issue_axi(self, opcode: int, arg0: int) -> None:
+        if self.axi_channel is None:
+            return
+        self.axi_channel.issue(NpuCmd(opcode=opcode, arg0=arg0))
+        stat = self.axi_channel.poll_stat()
+        if stat.error:
+            raise TokenStreamError(
+                f"AXI command {opcode} failed with status {stat.status_code}",
+            )
+
+
+@dataclass(frozen=True)
+class _ParseState:
+    offset: int
+    saw_begin: bool
+    done: bool = False
+
+
+def encode_input_stream(
+    token_ids: Sequence[int],
+    chunk_token_count: int = DEFAULT_CHUNK_TOKEN_COUNT,
+) -> bytes:
+    """Return first-pass control-plane input framing for token IDs."""
+
+    tokens = _validate_tokens(token_ids)
+    if chunk_token_count <= 0:
+        raise ValueError("chunk_token_count must be positive")
+
+    chunks = [INPUT_BEGIN_MARKER]
+    for start in range(0, len(tokens), chunk_token_count):
+        chunk_tokens = tokens[start : start + chunk_token_count]
+        payload = _pack_tokens(chunk_tokens)
+        chunks.append(INPUT_CHUNK_TAG + struct.pack(">I", len(payload)) + payload)
+    chunks.append(INPUT_END_MARKER)
+    return b"".join(chunks)
+
+
+def encode_output_stream(token_ids: Sequence[int]) -> bytes:
+    """Return output framing for mock tests and future fixture capture."""
+
+    tokens = _validate_tokens(token_ids)
+    payload = _pack_tokens(tokens)
+    return (
+        OUTPUT_BEGIN_MARKER
+        + OUTPUT_CHUNK_TAG
+        + struct.pack(">I", len(payload))
+        + payload
+        + OUTPUT_END_MARKER
+    )
+
+
+def _parse_output_buffer(
+    buffer: bytes,
+    offset: int,
+    tokens: list[int],
+    eos_token_id: int,
+    saw_begin: bool,
+) -> _ParseState:
+    if not saw_begin:
+        marker_at = buffer.find(OUTPUT_BEGIN_MARKER, offset)
+        if marker_at < 0:
+            keep_from = max(0, len(buffer) - len(OUTPUT_BEGIN_MARKER))
+            return _ParseState(offset=keep_from, saw_begin=False)
+        offset = marker_at + len(OUTPUT_BEGIN_MARKER)
+        saw_begin = True
+
+    while offset < len(buffer):
+        if buffer.startswith(OUTPUT_END_MARKER, offset):
+            return _ParseState(
+                offset=offset + len(OUTPUT_END_MARKER),
+                saw_begin=saw_begin,
+                done=True,
+            )
+        if OUTPUT_END_MARKER.startswith(buffer[offset:]):
+            return _ParseState(offset=offset, saw_begin=saw_begin)
+        header_size = len(OUTPUT_CHUNK_TAG) + 4
+        if len(buffer) - offset < header_size:
+            return _ParseState(offset=offset, saw_begin=saw_begin)
+        tag = buffer[offset : offset + len(OUTPUT_CHUNK_TAG)]
+        if tag != OUTPUT_CHUNK_TAG:
+            raise TokenStreamFramingError("unexpected output token chunk tag")
+        size_offset = offset + len(OUTPUT_CHUNK_TAG)
+        payload_len = struct.unpack(">I", buffer[size_offset : size_offset + 4])[0]
+        if payload_len % 4:
+            raise TokenStreamFramingError("token payload length must be uint32 aligned")
+        payload_offset = size_offset + 4
+        payload_end = payload_offset + payload_len
+        if len(buffer) < payload_end:
+            return _ParseState(offset=offset, saw_begin=saw_begin)
+        chunk_tokens = _unpack_tokens(buffer[payload_offset:payload_end])
+        tokens.extend(chunk_tokens)
+        if eos_token_id in chunk_tokens:
+            return _ParseState(offset=payload_end, saw_begin=saw_begin, done=True)
+        offset = payload_end
+
+    return _ParseState(offset=offset, saw_begin=saw_begin)
+
+
+def _validate_tokens(token_ids: Sequence[int]) -> list[int]:
+    tokens = list(token_ids)
+    for token_id in tokens:
+        if not isinstance(token_id, int):
+            raise TypeError("token IDs must be integers")
+        if token_id < 0 or token_id > UINT32_MAX:
+            raise ValueError("token IDs must fit uint32")
+    return tokens
+
+
+def _pack_tokens(token_ids: Sequence[int]) -> bytes:
+    if not token_ids:
+        return b""
+    return struct.pack(f">{len(token_ids)}I", *token_ids)
+
+
+def _unpack_tokens(payload: bytes) -> list[int]:
+    if not payload:
+        return []
+    return list(struct.unpack(f">{len(payload) // 4}I", payload))

--- a/scripts/tests/axi_cmd_mock_backend_test.py
+++ b/scripts/tests/axi_cmd_mock_backend_test.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Unit tests for the offline AXI command-channel mock backend."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "contracts" / "axi_cmd_channel.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location(
+        "axi_cmd_channel",
+        MODULE_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def assert_raises(error_type, callback) -> None:
+    try:
+        callback()
+    except error_type:
+        return
+    raise AssertionError(f"expected {error_type.__name__}")
+
+
+def test_basic_issue_poll_cycle_updates_register_model() -> None:
+    module = load_module()
+    cmd = module.NpuCmd(opcode=3, arg0=4, arg1=5, arg2=6, flags=7)
+
+    backend = module.AxiCmdMockBackend()
+    assert backend.snapshot_registers() == {
+        module.MMIO_CMD: 0,
+        module.MMIO_STAT: module.NpuStat().register_value(),
+    }
+
+    with backend as channel:
+        channel.issue(cmd)
+        first = channel.poll_stat()
+        second = channel.poll_stat()
+        registers = channel.snapshot_registers()
+
+    assert first == second
+    assert first == module.NpuStat(completion_count=1, last_opcode=3)
+    assert backend.completion_count == 1
+    assert backend.last_cmd == cmd
+    assert registers[module.MMIO_CMD] == cmd.register_value()
+    assert registers[module.MMIO_STAT] == first.register_value()
+    assert_raises(RuntimeError, lambda: backend.poll_stat())
+
+
+def test_multiple_issue_cycles_increment_fake_completion_counter() -> None:
+    module = load_module()
+
+    with module.AxiCmdMockBackend() as channel:
+        channel.issue(module.NpuCmd(opcode=1))
+        assert channel.poll_stat() == module.NpuStat(
+            completion_count=1,
+            last_opcode=1,
+        )
+
+        channel.issue(module.NpuCmd(opcode=2, arg0=10))
+        assert channel.poll_stat() == module.NpuStat(
+            completion_count=2,
+            last_opcode=2,
+        )
+
+
+def test_scripted_reply_mode_verifies_commands_and_returns_expected_status() -> None:
+    module = load_module()
+    first_cmd = module.NpuCmd(opcode=9, arg0=1)
+    second_cmd = module.NpuCmd(opcode=10, arg0=2)
+    first_stat = module.NpuStat(
+        completion_count=1,
+        last_opcode=9,
+        status_code=7,
+    )
+    second_stat = module.NpuStat(
+        completion_count=2,
+        last_opcode=10,
+        error=True,
+        status_code=12,
+    )
+
+    with module.AxiCmdMockBackend(
+        scripted_replies=[
+            (first_cmd, first_stat),
+            (second_cmd, second_stat),
+        ],
+    ) as channel:
+        channel.issue(first_cmd)
+        assert channel.poll_stat() == first_stat
+        assert channel.remaining_scripted_replies == 1
+
+        channel.issue(second_cmd)
+        assert channel.poll_stat() == second_stat
+        assert channel.completion_count == 2
+        assert channel.remaining_scripted_replies == 0
+        channel.assert_script_consumed()
+
+
+def test_scripted_reply_mode_rejects_unexpected_command_without_side_effect() -> None:
+    module = load_module()
+    expected_cmd = module.NpuCmd(opcode=1)
+    unexpected_cmd = module.NpuCmd(opcode=2)
+    expected_stat = module.NpuStat(completion_count=1, last_opcode=1)
+
+    with module.AxiCmdMockBackend(
+        scripted_replies=[(expected_cmd, expected_stat)],
+    ) as channel:
+        assert_raises(
+            module.ScriptedReplyMismatch,
+            lambda: channel.issue(unexpected_cmd),
+        )
+        assert channel.completion_count == 0
+        assert channel.remaining_scripted_replies == 1
+        assert channel.snapshot_registers() == {
+            module.MMIO_CMD: 0,
+            module.MMIO_STAT: module.NpuStat().register_value(),
+        }
+
+
+def test_issue_and_poll_are_safe_under_concurrent_test_use() -> None:
+    module = load_module()
+
+    with module.AxiCmdMockBackend() as channel:
+
+        def issue_and_poll(index: int):
+            channel.issue(module.NpuCmd(opcode=index + 1))
+            return channel.poll_stat()
+
+        with ThreadPoolExecutor(max_workers=4) as executor:
+            stats = list(executor.map(issue_and_poll, range(8)))
+
+        assert channel.completion_count == 8
+        assert len(stats) == 8
+        assert all(isinstance(stat, module.NpuStat) for stat in stats)
+        assert channel.poll_stat().completion_count == 8
+
+
+test_basic_issue_poll_cycle_updates_register_model()
+test_multiple_issue_cycles_increment_fake_completion_counter()
+test_scripted_reply_mode_verifies_commands_and_returns_expected_status()
+test_scripted_reply_mode_rejects_unexpected_command_without_side_effect()
+test_issue_and_poll_are_safe_under_concurrent_test_use()
+
+print("AXI command mock backend tests ok")

--- a/scripts/tests/kv260_serial_connection_test.py
+++ b/scripts/tests/kv260_serial_connection_test.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Tests for the KV260 USB tty serial connection backend."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "contracts" / "kv260_serial_connection.py"
+TEST_PATH = Path(__file__).resolve()
+TEST_PASSWORD_VALUE = "kv260-" + "serial-" + "secret-for-test"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location(
+        "kv260_serial_connection",
+        MODULE_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+class FakeSerial:
+    instances: list["FakeSerial"] = []
+
+    def __init__(self, *args, **kwargs) -> None:
+        self.args = args
+        self.kwargs = kwargs
+        self.writes: list[bytes] = []
+        self.closed = False
+        self.reads = list(type(self).reads)
+        type(self).instances.append(self)
+
+    reads: list[bytes] = []
+
+    def read(self, _size: int) -> bytes:
+        if self.reads:
+            return self.reads.pop(0)
+        return b""
+
+    def write(self, payload: bytes) -> int:
+        self.writes.append(payload)
+        return len(payload)
+
+    def flush(self) -> None:
+        return None
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def reset_fake(reads: list[bytes]) -> None:
+    FakeSerial.instances = []
+    FakeSerial.reads = reads
+
+
+def test_type_contract_and_env_presence_only() -> None:
+    module = load_module()
+    fake_env = {
+        "KVFPGA_HOST": "ignored-host.example.invalid",
+        "KVFPGA_TTY": "/dev/ttyUSB-kv260-test",
+        "KVFPGA_USER": "kv260-user-for-test",
+        "KVFPGA_PASSWORD": TEST_PASSWORD_VALUE,
+    }
+    connection = module.KV260SerialConnection.from_env(
+        fake_env,
+        serial_factory=FakeSerial,
+    )
+    rendered = repr(connection)
+
+    assert isinstance(connection, module.KV260ConnectionProtocol)
+    assert connection.is_configured() is True
+    assert connection.tty_configured is True
+    assert connection.user_configured is True
+    assert connection.password_configured is True
+    assert "ignored-host" not in rendered
+    assert fake_env["KVFPGA_TTY"] not in rendered
+    assert fake_env["KVFPGA_USER"] not in rendered
+    assert fake_env["KVFPGA_PASSWORD"] not in rendered
+
+
+def test_tty_override_and_auto_detect_helpers() -> None:
+    module = load_module()
+
+    assert module.kv260_tty_candidates({"KVFPGA_TTY": "/tmp/tty-kv260"}) == (
+        "/tmp/tty-kv260",
+    )
+    assert module.detect_kv260_tty({"KVFPGA_TTY": "/tmp/tty-kv260"}) == (
+        "/tmp/tty-kv260"
+    )
+    assert isinstance(module.kv260_tty_candidates({}), tuple)
+
+
+def test_reachable_accepts_login_or_shell_prompt() -> None:
+    module = load_module()
+    fake_env = {"KVFPGA_TTY": "/tmp/tty-kv260"}
+
+    reset_fake([b"kv260 login: "])
+    login_connection = module.KV260SerialConnection.from_env(
+        fake_env,
+        serial_factory=FakeSerial,
+    )
+    assert login_connection.is_reachable() is True
+    assert FakeSerial.instances[-1].closed is True
+
+    reset_fake([b"root@kv260:~$ "])
+    shell_connection = module.KV260SerialConnection.from_env(
+        fake_env,
+        serial_factory=FakeSerial,
+    )
+    assert shell_connection.is_reachable() is True
+    assert FakeSerial.instances[-1].closed is True
+
+
+def test_login_uname_and_logout_over_serial() -> None:
+    module = load_module()
+    fake_env = {
+        "KVFPGA_TTY": "/tmp/tty-kv260",
+        "KVFPGA_USER": "kv260-user-for-test",
+        "KVFPGA_PASSWORD": TEST_PASSWORD_VALUE,
+    }
+    reset_fake(
+        [
+            b"kv260 login: ",
+            b"Password: ",
+            b"root@kv260:~$ ",
+            (
+                b"root@kv260:~$ uname -a; printf "
+                b"'\\n__PCCX_KV260_SERIAL_DONE__:%s\\n' \"$?\"\r\n"
+                b"Linux kv260 6.6.0-test #1 SMP PREEMPT aarch64 GNU/Linux\r\n"
+                b"__PCCX_KV260_SERIAL_DONE__:0\r\n"
+                b"root@kv260:~$ "
+            ),
+        ],
+    )
+    connection = module.KV260SerialConnection.from_env(
+        fake_env,
+        serial_factory=FakeSerial,
+    )
+
+    assert connection.kernel_uname() == (
+        "Linux kv260 6.6.0-test #1 SMP PREEMPT aarch64 GNU/Linux"
+    )
+    writes = b"".join(FakeSerial.instances[-1].writes)
+    assert b"uname -a" in writes
+    assert writes.endswith(b"exit\r\n")
+    assert FakeSerial.instances[-1].closed is True
+
+
+def test_xrt_present_and_xmutil_listapps_use_serial_commands() -> None:
+    module = load_module()
+    fake_env = {
+        "KVFPGA_TTY": "/tmp/tty-kv260",
+        "KVFPGA_USER": "kv260-user-for-test",
+        "KVFPGA_PASSWORD": TEST_PASSWORD_VALUE,
+    }
+
+    reset_fake([b"$ ", b"__PCCX_KV260_SERIAL_DONE__:0\r\n$ "])
+    connection = module.KV260SerialConnection.from_env(
+        fake_env,
+        serial_factory=FakeSerial,
+    )
+    assert connection.xrt_present() is True
+
+    reset_fake(
+        [
+            b"$ ",
+            (
+                b"$ xmutil listapps; printf "
+                b"'\\n__PCCX_KV260_SERIAL_DONE__:%s\\n' \"$?\"\r\n"
+                b"accelerated_app\r\n"
+                b"diagnostic_app\r\n"
+                b"__PCCX_KV260_SERIAL_DONE__:0\r\n$ "
+            ),
+        ],
+    )
+    listapps_connection = module.KV260SerialConnection.from_env(
+        fake_env,
+        serial_factory=FakeSerial,
+    )
+    assert listapps_connection.xmutil_listapps() == (
+        "accelerated_app",
+        "diagnostic_app",
+    )
+
+
+def test_live_serial_probe_skips_gracefully_without_tty() -> None:
+    module = load_module()
+    tty = module.detect_kv260_tty()
+    if tty is None:
+        print("skip: no KV260 tty device detected")
+        return
+    try:
+        import serial  # type: ignore[import-not-found]  # noqa: F401
+    except ImportError:
+        print("skip: pyserial is not installed")
+        return
+    if not os.environ.get("KVFPGA_USER") or not os.environ.get("KVFPGA_PASSWORD"):
+        print("skip: KVFPGA serial credentials are incomplete")
+        return
+
+    connection = module.KV260SerialConnection.from_env()
+    assert isinstance(connection.is_reachable(), bool)
+
+
+def test_source_has_no_credential_leaks_or_unsupported_paths() -> None:
+    source = read_text(MODULE_PATH)
+    test_source = read_text(TEST_PATH)
+    scan_text = source
+
+    forbidden_terms = [
+        "param" + "iko",
+        "s" + "cp ",
+        "subprocess",
+        "os.system",
+        "popen",
+        "socket",
+        "requests",
+        "urllib",
+        "transformers",
+        "huggingface_hub",
+        "/dev/mem",
+    ]
+    lowered_source = source.lower()
+    for term in forbidden_terms:
+        assert term not in lowered_source, term
+
+    assert "print(" not in source
+    assert "logging." not in source
+    assert TEST_PASSWORD_VALUE not in source
+    assert ("serial-" + "secret-for-test") not in test_source
+
+    forbidden_claims = [
+        "production-" + "ready",
+        "marketplace-" + "ready",
+        "stable " + "API",
+        "stable " + "ABI",
+        "KV260 inference " + "works",
+        "Gemma 3N E4B " + "runs on KV260",
+        "20 tok/s " + "achieved",
+        "timing " + "closed",
+        "bitstream " + "ready",
+    ]
+    lowered = scan_text.lower()
+    for claim in forbidden_claims:
+        assert claim.lower() not in lowered, claim
+
+    assert not re.search(r"\bssh\s+[^\"']+", source, re.IGNORECASE)
+
+
+def test_source_headers_for_touched_python_files() -> None:
+    expected_headers = {
+        MODULE_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        TEST_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+    }
+    for path, header in expected_headers.items():
+        assert read_text(path).splitlines()[: len(header)] == header, path
+
+
+test_type_contract_and_env_presence_only()
+test_tty_override_and_auto_detect_helpers()
+test_reachable_accepts_login_or_shell_prompt()
+test_login_uname_and_logout_over_serial()
+test_xrt_present_and_xmutil_listapps_use_serial_commands()
+test_live_serial_probe_skips_gracefully_without_tty()
+test_source_has_no_credential_leaks_or_unsupported_paths()
+test_source_headers_for_touched_python_files()
+
+print("kv260 serial connection tests ok")

--- a/scripts/tests/token_stream_over_serial_test.py
+++ b/scripts/tests/token_stream_over_serial_test.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Tests for first-pass token streaming over the KV260 serial tty."""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+MODULE_PATH = ROOT / "contracts" / "token_stream_over_serial.py"
+TEST_PATH = Path(__file__).resolve()
+
+from contracts.axi_cmd_channel import AxiCmdMockBackend, NpuCmd, NpuStat
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location(
+        "token_stream_over_serial",
+        MODULE_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+class FakeSerial:
+    instances: list["FakeSerial"] = []
+    reads: list[bytes] = []
+
+    def __init__(self, *args, **kwargs) -> None:
+        self.args = args
+        self.kwargs = kwargs
+        self.writes: list[bytes] = []
+        self.closed = False
+        self.reads = list(type(self).reads)
+        type(self).instances.append(self)
+
+    def read(self, _size: int) -> bytes:
+        if self.reads:
+            return self.reads.pop(0)
+        return b""
+
+    def write(self, payload: bytes) -> int:
+        self.writes.append(payload)
+        return len(payload)
+
+    def flush(self) -> None:
+        return None
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def reset_fake(reads: list[bytes] | None = None) -> None:
+    FakeSerial.instances = []
+    FakeSerial.reads = list(reads or [])
+
+
+def make_connection(module, fake_env: dict[str, str] | None = None):
+    env = fake_env or {"KVFPGA_TTY": "/tmp/tty-kv260-token-test"}
+    return module.KV260SerialConnection.from_env(
+        env,
+        serial_factory=FakeSerial,
+    )
+
+
+def test_type_contract_runs_without_tty_or_board() -> None:
+    module = load_module()
+    reset_fake()
+    stream = module.TokenStreamOverSerial(connection=make_connection(module))
+
+    assert isinstance(stream, module.TokenStreamProtocol)
+    assert stream.eos_token_id == module.DEFAULT_EOS_TOKEN_ID
+    assert stream.chunk_token_count == module.DEFAULT_CHUNK_TOKEN_COUNT
+
+
+def test_input_tokens_use_marker_wrapped_length_prefixed_binary_chunks() -> None:
+    module = load_module()
+    payload = module.encode_input_stream([2, 65536, 9], chunk_token_count=2)
+
+    assert payload.startswith(module.INPUT_BEGIN_MARKER)
+    assert payload.endswith(module.INPUT_END_MARKER)
+    assert payload.count(module.INPUT_CHUNK_TAG) == 2
+    assert b"\x00\x00\x00\x08\x00\x00\x00\x02\x00\x01\x00\x00" in payload
+    assert b"\x00\x00\x00\x04\x00\x00\x00\x09" in payload
+
+
+def test_mock_axi_backend_simulates_full_round_trip() -> None:
+    module = load_module()
+    reset_fake([module.encode_output_stream([201, 202, module.DEFAULT_EOS_TOKEN_ID])])
+    commands = [
+        (
+            NpuCmd(module.OP_BEGIN_INPUT, arg0=3),
+            NpuStat(completion_count=1, last_opcode=module.OP_BEGIN_INPUT),
+        ),
+        (
+            NpuCmd(module.OP_END_INPUT, arg0=3),
+            NpuStat(completion_count=2, last_opcode=module.OP_END_INPUT),
+        ),
+        (
+            NpuCmd(module.OP_READ_OUTPUT, arg0=0),
+            NpuStat(completion_count=3, last_opcode=module.OP_READ_OUTPUT),
+        ),
+    ]
+
+    with AxiCmdMockBackend(commands) as axi:
+        stream = module.TokenStreamOverSerial(
+            connection=make_connection(module),
+            axi_channel=axi,
+        )
+        output_tokens = stream.infer([101, 102, 103])
+        axi.assert_script_consumed()
+
+    assert output_tokens == [201, 202, module.DEFAULT_EOS_TOKEN_ID]
+    assert len(FakeSerial.instances) == 1
+    written = b"".join(FakeSerial.instances[0].writes)
+    assert written == module.encode_input_stream([101, 102, 103])
+    assert FakeSerial.instances[0].closed is True
+
+
+def test_recv_output_tokens_returns_partial_tokens_on_timeout() -> None:
+    module = load_module()
+    reset_fake([module.OUTPUT_BEGIN_MARKER])
+    stream = module.TokenStreamOverSerial(connection=make_connection(module))
+
+    assert stream.recv_output_tokens(timeout_s=0.01) == []
+    assert FakeSerial.instances[-1].closed is True
+
+
+def test_live_serial_probe_skips_without_tty() -> None:
+    module = load_module()
+    tty = module.detect_kv260_tty()
+    if tty is None:
+        print("skip: no KV260 tty device detected")
+        return
+    try:
+        import serial  # type: ignore[import-not-found]  # noqa: F401
+    except ImportError:
+        print("skip: pyserial is not installed")
+        return
+
+    stream = module.TokenStreamOverSerial.from_env()
+    assert isinstance(stream, module.TokenStreamProtocol)
+
+
+def test_source_has_no_credential_leaks_or_unsupported_paths() -> None:
+    source = read_text(MODULE_PATH)
+    test_source = read_text(TEST_PATH)
+    scan_text = source + "\n" + test_source
+
+    forbidden_terms = [
+        "param" + "iko",
+        "s" + "cp ",
+        "subprocess",
+        "os.system",
+        "popen",
+        "socket",
+        "requests",
+        "urllib",
+        "transformers",
+        "huggingface_hub",
+        "/dev/mem",
+    ]
+    lowered_source = source.lower()
+    for term in forbidden_terms:
+        assert term not in lowered_source, term
+
+    forbidden_claims = [
+        "production-" + "ready",
+        "marketplace-" + "ready",
+        "stable " + "API",
+        "stable " + "ABI",
+        "KV260 inference " + "works",
+        "Gemma 3N E4B " + "runs on KV260",
+        "20 tok/s " + "achieved",
+        "timing " + "closed",
+        "bitstream " + "ready",
+    ]
+    lowered = scan_text.lower()
+    for claim in forbidden_claims:
+        assert claim.lower() not in lowered, claim
+
+    assert not re.search(r"\bssh\s+[^\"']+", source, re.IGNORECASE)
+
+
+def test_source_headers_for_touched_python_files() -> None:
+    expected_headers = {
+        MODULE_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        TEST_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+    }
+    for path, header in expected_headers.items():
+        assert read_text(path).splitlines()[: len(header)] == header, path
+
+
+test_type_contract_runs_without_tty_or_board()
+test_input_tokens_use_marker_wrapped_length_prefixed_binary_chunks()
+test_mock_axi_backend_simulates_full_round_trip()
+test_recv_output_tokens_returns_partial_tokens_on_timeout()
+test_live_serial_probe_skips_without_tty()
+test_source_has_no_credential_leaks_or_unsupported_paths()
+test_source_headers_for_touched_python_files()
+
+print("token stream over serial tests ok")


### PR DESCRIPTION
## Summary
- add TokenStreamOverSerial for first-pass Gemma token streaming over the KV260 tty
- use marker-wrapped, length-prefixed binary token chunks as first-pass framing; refine after first board run
- add type-only, mock AXI, framing, timeout, and no-tty live-skip tests

## References
- Refs #72
- Refs #74

## Validation
- python3 scripts/tests/token_stream_over_serial_test.py
- python3 scripts/tests/kv260_serial_connection_test.py
- python3 scripts/tests/axi_cmd_mock_backend_test.py
- for t in scripts/tests/*.py; do python3 ""; done
- python3 -m compileall -q contracts scripts/tests
- git diff --check
- claim-scan clean

Note: shellcheck is not installed in this environment; no shell files changed.