### PR TITLE
test(integration): full-mock gemma w4 path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -329,6 +329,8 @@ jobs:
         run: python3 scripts/tests/kv260_serial_connection_test.py
       - name: run AXI command mock backend tests
         run: python3 scripts/tests/axi_cmd_mock_backend_test.py
+      - name: run token stream over serial tests
+        run: python3 scripts/tests/token_stream_over_serial_test.py
       - name: run chat/session contract tests
         run: python3 scripts/tests/chat_session_contract_test.py
       - name: run chat model status contract tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,6 +325,8 @@ jobs:
         run: python3 scripts/tests/device_session_status_contract_test.py
       - name: run runtime readiness contract tests
         run: python3 scripts/tests/runtime_readiness_contract_test.py
+      - name: run KV260 serial connection tests
+        run: python3 scripts/tests/kv260_serial_connection_test.py
       - name: run chat/session contract tests
         run: python3 scripts/tests/chat_session_contract_test.py
       - name: run chat model status contract tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -331,6 +331,8 @@ jobs:
         run: python3 scripts/tests/axi_cmd_mock_backend_test.py
       - name: run token stream over serial tests
         run: python3 scripts/tests/token_stream_over_serial_test.py
+      - name: run full-mock Gemma W4 path integration tests
+        run: python3 scripts/tests/full_mock_gemma_path_integration_test.py
       - name: run chat/session contract tests
         run: python3 scripts/tests/chat_session_contract_test.py
       - name: run chat model status contract tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,6 +325,8 @@ jobs:
         run: python3 scripts/tests/device_session_status_contract_test.py
       - name: run runtime readiness contract tests
         run: python3 scripts/tests/runtime_readiness_contract_test.py
+      - name: run AXI command mock backend tests
+        run: python3 scripts/tests/axi_cmd_mock_backend_test.py
       - name: run chat/session contract tests
         run: python3 scripts/tests/chat_session_contract_test.py
       - name: run chat model status contract tests

--- a/contracts/axi_cmd_channel.py
+++ b/contracts/axi_cmd_channel.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Offline AXI command-channel contract and mock backend.
+
+This module is intentionally local-only. It models the command and status
+registers in memory so tests can exercise launcher-side command flow without a
+board, device file, driver, or runtime transport.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from threading import RLock
+from typing import Deque, Iterable, Protocol
+
+
+MMIO_CMD = "MMIO_CMD"
+MMIO_STAT = "MMIO_STAT"
+UINT32_MASK = 0xFFFF_FFFF
+
+
+@dataclass(frozen=True)
+class NpuCmd:
+    """Command payload written to the modeled MMIO_CMD register."""
+
+    opcode: int
+    arg0: int = 0
+    arg1: int = 0
+    arg2: int = 0
+    flags: int = 0
+
+    def __post_init__(self) -> None:
+        for field_name in ("opcode", "arg0", "arg1", "arg2", "flags"):
+            value = getattr(self, field_name)
+            if not isinstance(value, int):
+                raise TypeError(f"{field_name} must be an int")
+            if value < 0:
+                raise ValueError(f"{field_name} must be non-negative")
+
+    def register_value(self) -> int:
+        """Return a deterministic 32-bit representation for MMIO_CMD."""
+
+        packed = (
+            (self.opcode & 0xFF)
+            | ((self.flags & 0xFF) << 8)
+            | ((self.arg0 & 0xFF) << 16)
+            | ((self.arg1 & 0xFF) << 24)
+        )
+        return (packed ^ (self.arg2 & UINT32_MASK)) & UINT32_MASK
+
+
+@dataclass(frozen=True)
+class NpuStat:
+    """Status payload read from the modeled MMIO_STAT register."""
+
+    completion_count: int = 0
+    last_opcode: int = 0
+    busy: bool = False
+    error: bool = False
+    status_code: int = 0
+
+    def __post_init__(self) -> None:
+        for field_name in ("completion_count", "last_opcode", "status_code"):
+            value = getattr(self, field_name)
+            if not isinstance(value, int):
+                raise TypeError(f"{field_name} must be an int")
+            if value < 0:
+                raise ValueError(f"{field_name} must be non-negative")
+        for field_name in ("busy", "error"):
+            if not isinstance(getattr(self, field_name), bool):
+                raise TypeError(f"{field_name} must be a bool")
+
+    def register_value(self) -> int:
+        """Return a deterministic 32-bit representation for MMIO_STAT."""
+
+        value = (
+            (self.completion_count & 0xFFFF) << 16
+            | ((self.status_code & 0x3F) << 8)
+            | ((self.last_opcode & 0x3F) << 2)
+            | (0x2 if self.error else 0)
+            | (0x1 if self.busy else 0)
+        )
+        return value & UINT32_MASK
+
+
+class AxiCmdChannel(Protocol):
+    """Minimal command-channel interface used by launcher-side tests."""
+
+    def issue(self, cmd: NpuCmd) -> None:
+        """Issue a command to the channel."""
+
+    def poll_stat(self) -> NpuStat:
+        """Read the current command-channel status."""
+
+
+class ScriptedReplyMismatch(AssertionError):
+    """Raised when a scripted mock backend observes an unexpected command."""
+
+
+class AxiCmdMockBackend:
+    """Thread-safe in-memory AXI command backend for offline tests."""
+
+    def __init__(
+        self,
+        scripted_replies: Iterable[tuple[NpuCmd, NpuStat]] | None = None,
+    ) -> None:
+        self._lock = RLock()
+        self._registers = {MMIO_CMD: 0, MMIO_STAT: 0}
+        self._scripted_replies: Deque[tuple[NpuCmd, NpuStat]] = deque(
+            scripted_replies or (),
+        )
+        self._last_cmd: NpuCmd | None = None
+        self._last_stat = NpuStat()
+        self._completion_count = 0
+        self._closed = False
+
+    def __enter__(self) -> "AxiCmdMockBackend":
+        with self._lock:
+            self._closed = False
+            return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        self.close()
+
+    @property
+    def completion_count(self) -> int:
+        with self._lock:
+            return self._completion_count
+
+    @property
+    def last_cmd(self) -> NpuCmd | None:
+        with self._lock:
+            return self._last_cmd
+
+    @property
+    def remaining_scripted_replies(self) -> int:
+        with self._lock:
+            return len(self._scripted_replies)
+
+    def close(self) -> None:
+        with self._lock:
+            self._closed = True
+
+    def issue(self, cmd: NpuCmd) -> None:
+        if not isinstance(cmd, NpuCmd):
+            raise TypeError("cmd must be an NpuCmd")
+
+        with self._lock:
+            self._ensure_open()
+            scripted_stat = self._consume_scripted_reply(cmd)
+            self._completion_count += 1
+            self._last_cmd = cmd
+            self._last_stat = scripted_stat or self._default_stat_for(cmd)
+            self._registers[MMIO_CMD] = cmd.register_value()
+            self._registers[MMIO_STAT] = self._last_stat.register_value()
+
+    def poll_stat(self) -> NpuStat:
+        with self._lock:
+            self._ensure_open()
+            self._registers[MMIO_STAT] = self._last_stat.register_value()
+            return self._last_stat
+
+    def snapshot_registers(self) -> dict[str, int]:
+        with self._lock:
+            return dict(self._registers)
+
+    def assert_script_consumed(self) -> None:
+        with self._lock:
+            remaining = len(self._scripted_replies)
+            if remaining:
+                raise ScriptedReplyMismatch(
+                    f"{remaining} scripted AXI command replies were not used",
+                )
+
+    def _consume_scripted_reply(self, cmd: NpuCmd) -> NpuStat | None:
+        if not self._scripted_replies:
+            return None
+
+        expected_cmd, expected_stat = self._scripted_replies[0]
+        if cmd != expected_cmd:
+            raise ScriptedReplyMismatch(
+                f"expected command {expected_cmd!r}, got {cmd!r}",
+            )
+        self._scripted_replies.popleft()
+        return expected_stat
+
+    def _default_stat_for(self, cmd: NpuCmd) -> NpuStat:
+        return NpuStat(
+            completion_count=self._completion_count,
+            last_opcode=cmd.opcode,
+            busy=False,
+            error=False,
+            status_code=0,
+        )
+
+    def _ensure_open(self) -> None:
+        if self._closed:
+            raise RuntimeError("AxiCmdMockBackend is closed")

--- a/contracts/gemma_weight_prep_contract.py
+++ b/contracts/gemma_weight_prep_contract.py
@@ -1,27 +1,44 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 pccxai
-"""Stage-1 Gemma weight-prep contract and deterministic dummy manifest.
+"""Gemma weight-prep contract and deterministic W4 manifests.
 
-This module is a data-only contract for the future Gemma weight-preparation
-pipeline. Stage 1 intentionally avoids Hugging Face downloads, filesystem
-weight loads, and real W4 quantization. The dummy path exists only to exercise
-manifest shape, invariants, and deterministic test coverage.
+This module is a data-only contract for Gemma weight preparation. It never
+downloads Hugging Face assets and never reads weights from disk. Real W4
+preparation accepts caller-supplied BF16-shaped numeric weights as an argument;
+the caller is responsible for sourcing those values.
 """
 
 from __future__ import annotations
 
+import hashlib
 import math
 import random
 from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
 
 
 SCHEMA_VERSION = "pccx.gemmaWeightPrepManifest.v1"
+ACT_SCALE_POLICY = "ACT_SCALE_EMAX_BFP"
+DEFAULT_GROUP_SIZE = 64
+INT4_BITS = 4
+INT4_MIN = -8
+INT4_MAX = 7
 DUMMY_MODEL_ID = "gemma3n-e4b-dummy"
 DUMMY_TILE_ID = "gemma3n_e4b_layer0_attn_q_proj_tile0_dummy"
 DUMMY_SCALE_ID = "gemma3n_e4b_layer0_attn_q_proj_tile0_scale_dummy"
 DUMMY_SOURCE_SHAPE = (4, 8)
 DUMMY_TILE_SHAPE = (4, 8)
+REAL_MODEL_ID = "gemma3n-e4b-caller-supplied"
+REAL_TILE_ID = "gemma3n_e4b_w4_tile0"
+REAL_SCALE_ID = "gemma3n_e4b_w4_tile0_scale"
+REAL_SOURCE_DTYPE = "bf16"
+REAL_SCALE_DTYPE = "float32"
+REAL_PACKED_DTYPE = "int4_packed_uint8"
+REAL_WEIGHT_FORMAT = "w4_int4_emax_bfp_pow2"
+REAL_QUANTIZATION_LABEL = "w4_emax_bfp_pow2"
 
 
 def _product(shape: tuple[int, ...]) -> int:
@@ -31,16 +48,108 @@ def _product(shape: tuple[int, ...]) -> int:
     return total
 
 
+def _validate_group_size(group_size: int) -> int:
+    if isinstance(group_size, bool) or not isinstance(group_size, int):
+        raise ValueError("group_size must be a positive int")
+    if group_size <= 0:
+        raise ValueError("group_size must be a positive int")
+    return group_size
+
+
+def _sha256_bytes(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _is_sha256_hex(value: str) -> bool:
+    return len(value) == 64 and all(char in "0123456789abcdef" for char in value)
+
+
+def _normalise_weights(weights: Any) -> np.ndarray:
+    array = np.asarray(weights, dtype=np.float32)
+    if array.size == 0:
+        raise ValueError("weights must contain at least one value")
+    if any(dim <= 0 for dim in array.shape):
+        raise ValueError("weights must not contain empty dimensions")
+    if not bool(np.all(np.isfinite(array))):
+        raise ValueError("weights must contain only finite values")
+    return np.ascontiguousarray(array, dtype=np.float32)
+
+
+def _channel_rows(array: np.ndarray) -> np.ndarray:
+    if array.ndim == 0:
+        return array.reshape(1, 1)
+    if array.ndim == 1:
+        return array.reshape(1, array.shape[0])
+    trailing_shape = tuple(int(dim) for dim in array.shape[1:])
+    return array.reshape(array.shape[0], _product(trailing_shape))
+
+
+def _emax_bfp_pow2_scale(group: np.ndarray) -> float:
+    max_abs = float(np.max(np.abs(group)))
+    if max_abs == 0.0:
+        return 1.0
+
+    e_max = math.floor(math.log2(max_abs))
+    # INT4 carries one sign bit and three magnitude positions; `e_max - 2`
+    # keeps the BFP exponent shared while matching the signed INT4 lane width.
+    return math.ldexp(1.0, e_max - (INT4_BITS - 2))
+
+
+def _quantize_signed_int4(group: np.ndarray, scale: float) -> np.ndarray:
+    rounded = np.rint(group.astype(np.float64) / scale)
+    return np.clip(rounded, INT4_MIN, INT4_MAX).astype(np.int8)
+
+
+def _pack_signed_int4_low_nibble_first(values: np.ndarray) -> bytes:
+    flat = np.asarray(values, dtype=np.int8).reshape(-1)
+    if bool(np.any(flat < INT4_MIN)) or bool(np.any(flat > INT4_MAX)):
+        raise ValueError("values must be in signed INT4 range")
+
+    packed = bytearray()
+    for index in range(0, len(flat), 2):
+        low = int(flat[index]) & 0x0F
+        high = int(flat[index + 1]) & 0x0F if index + 1 < len(flat) else 0
+        packed.append(low | (high << 4))
+    return bytes(packed)
+
+
+def _real_w4_quantize(
+    weights: Any,
+    group_size: int,
+) -> tuple[tuple[int, ...], tuple[int, int], tuple[float, ...], bytes]:
+    group_size = _validate_group_size(group_size)
+    array = _normalise_weights(weights)
+    source_shape = tuple(int(dim) for dim in array.shape)
+    rows = _channel_rows(array)
+    channel_count, channel_width = rows.shape
+    groups_per_channel = math.ceil(channel_width / group_size)
+
+    scales: list[float] = []
+    quantized = np.zeros(rows.shape, dtype=np.int8)
+    for channel_index in range(channel_count):
+        row = rows[channel_index]
+        for group_index in range(groups_per_channel):
+            start = group_index * group_size
+            stop = min(start + group_size, channel_width)
+            group = row[start:stop]
+            scale = _emax_bfp_pow2_scale(group)
+            scales.append(scale)
+            quantized[channel_index, start:stop] = _quantize_signed_int4(group, scale)
+
+    packed = _pack_signed_int4_low_nibble_first(quantized)
+    return source_shape, (channel_count, groups_per_channel), tuple(scales), packed
+
+
 @dataclass(frozen=True)
 class Scale:
-    """Per-tile scale metadata for a placeholder W4 tile.
+    """Per-tile scale metadata for a W4 tile.
 
     Invariants:
     - `scale_id` is non-empty and unique within its manifest.
     - `tile_id` points to exactly one `WeightTile` in the same manifest.
-    - `dtype` and `quantization_label` carry `_dummy` to prevent real-W4 claims.
+    - Dummy entries carry `_dummy`; real entries use `w4_emax_bfp_pow2`.
     - `shape` contains positive dimensions and matches the value count.
-    - `values` are finite positive placeholders, not calibrated scales.
+    - `values` are finite positive per-group scales.
     """
 
     scale_id: str
@@ -55,10 +164,15 @@ class Scale:
             raise ValueError("scale_id must be non-empty")
         if not self.tile_id:
             raise ValueError("tile_id must be non-empty")
-        if not self.dtype.endswith("_dummy"):
-            raise ValueError("dtype must be labelled _dummy")
-        if not self.quantization_label.endswith("_dummy"):
-            raise ValueError("quantization_label must be labelled _dummy")
+        is_dummy = self.quantization_label.endswith("_dummy")
+        if is_dummy:
+            if not self.dtype.endswith("_dummy"):
+                raise ValueError("dummy dtype must be labelled _dummy")
+        else:
+            if self.dtype != REAL_SCALE_DTYPE:
+                raise ValueError("real scale dtype must be float32")
+            if self.quantization_label != REAL_QUANTIZATION_LABEL:
+                raise ValueError("real scale must use w4 e_max BFP label")
         if not self.shape or any(dim <= 0 for dim in self.shape):
             raise ValueError("shape must contain positive dimensions")
         if len(self.values) != _product(self.shape):
@@ -69,15 +183,16 @@ class Scale:
 
 @dataclass(frozen=True)
 class WeightTile:
-    """Packed placeholder W4 tile derived from BF16-shaped dummy data.
+    """Packed W4 tile derived from BF16-shaped data.
 
     Invariants:
     - `tile_id` is non-empty and unique within its manifest.
-    - `source_dtype` and `packed_dtype` carry `_dummy` labels.
-    - `source_shape` and `tile_shape` have the same rank and positive dimensions.
-    - `packed_nibbles` has two placeholder W4 nibbles per byte, rounded up.
+    - Dummy entries carry `_dummy`; real entries use BF16 source and W4 packing.
+    - `source_shape` and `tile_shape` have the same rank.
+    - Non-scalar dimensions must be positive.
+    - `packed_nibbles` has two signed INT4 nibbles per byte, rounded up.
     - `scale_id` points to exactly one `Scale` in the same manifest.
-    - The bytes are deterministic dummy payload, not a real W4 algorithm output.
+    - Real entries include a SHA256 digest of the packed bytes.
     """
 
     tile_id: str
@@ -88,22 +203,32 @@ class WeightTile:
     quantization_label: str
     packed_nibbles: bytes
     scale_id: str
+    packed_sha256: str = ""
 
     def __post_init__(self) -> None:
         if not self.tile_id:
             raise ValueError("tile_id must be non-empty")
-        if not self.source_dtype.endswith("_dummy"):
-            raise ValueError("source_dtype must be labelled _dummy")
-        if not self.packed_dtype.endswith("_dummy"):
-            raise ValueError("packed_dtype must be labelled _dummy")
-        if not self.quantization_label.endswith("_dummy"):
-            raise ValueError("quantization_label must be labelled _dummy")
-        if not self.source_shape or any(dim <= 0 for dim in self.source_shape):
-            raise ValueError("source_shape must contain positive dimensions")
+        is_dummy = self.quantization_label.endswith("_dummy")
+        if is_dummy:
+            if not self.source_dtype.endswith("_dummy"):
+                raise ValueError("dummy source_dtype must be labelled _dummy")
+            if not self.packed_dtype.endswith("_dummy"):
+                raise ValueError("dummy packed_dtype must be labelled _dummy")
+        else:
+            if self.source_dtype != REAL_SOURCE_DTYPE:
+                raise ValueError("real source_dtype must be bf16")
+            if self.packed_dtype != REAL_PACKED_DTYPE:
+                raise ValueError("real packed_dtype must be int4_packed_uint8")
+            if self.quantization_label != REAL_QUANTIZATION_LABEL:
+                raise ValueError("real tile must use w4 e_max BFP label")
+            if not _is_sha256_hex(self.packed_sha256):
+                raise ValueError("real tile must include packed-byte SHA256")
+        if any(dim <= 0 for dim in self.source_shape):
+            raise ValueError("source_shape dimensions must be positive")
         if len(self.tile_shape) != len(self.source_shape):
             raise ValueError("tile_shape must have the same rank as source_shape")
         if any(dim <= 0 for dim in self.tile_shape):
-            raise ValueError("tile_shape must contain positive dimensions")
+            raise ValueError("tile_shape dimensions must be positive")
         if any(
             tile_dim > source_dim
             for tile_dim, source_dim in zip(self.tile_shape, self.source_shape)
@@ -114,7 +239,11 @@ class WeightTile:
 
         expected_bytes = (_product(self.tile_shape) + 1) // 2
         if len(self.packed_nibbles) != expected_bytes:
-            raise ValueError("packed_nibbles must match placeholder W4 byte count")
+            raise ValueError("packed_nibbles must match W4 byte count")
+        if self.packed_sha256 and (
+            self.packed_sha256 != _sha256_bytes(self.packed_nibbles)
+        ):
+            raise ValueError("packed_sha256 must match packed_nibbles")
 
 
 @dataclass(frozen=True)
@@ -123,18 +252,17 @@ class Manifest:
 
     Invariants:
     - `schema_version` is `SCHEMA_VERSION`.
-    - `seed` records the deterministic dummy RNG seed.
-    - `weight_format`, `source_dtype`, `pipeline_label`, and artifact ids carry
-      `_dummy` labels.
+    - Dummy manifests keep `_dummy` labels for compatibility.
+    - Real manifests use the caller-supplied BF16 W4 e_max BFP path.
     - Tile and scale identifiers are unique, non-empty, and cross-referenced.
-    - `real_algo_stage` is `stage2`; stage 1 must not claim real W4 support.
+    - `real_algo_stage` is `stage2`.
     - `hf_touched` is always false; this contract never reads HF cache/assets.
     """
 
     schema_version: str
     manifest_id: str
     model_id: str
-    seed: int
+    seed: int | None
     source_dtype: str
     weight_format: str
     pipeline_label: str
@@ -145,6 +273,9 @@ class Manifest:
     limitations: tuple[str, ...]
     real_algo_stage: str
     hf_touched: bool
+    group_size: int | None = None
+    act_scale_policy: str = ""
+    packed_sha256: str = ""
 
     def __post_init__(self) -> None:
         if self.schema_version != SCHEMA_VERSION:
@@ -153,20 +284,41 @@ class Manifest:
             raise ValueError("manifest_id must be non-empty")
         if not self.model_id:
             raise ValueError("model_id must be non-empty")
-        if not isinstance(self.seed, int):
+        is_dummy = self.pipeline_label.endswith("_dummy")
+        if self.seed is not None and not isinstance(self.seed, int):
             raise ValueError("seed must be an int")
-        if not self.source_dtype.endswith("_dummy"):
-            raise ValueError("source_dtype must be labelled _dummy")
-        if not self.weight_format.endswith("_dummy"):
-            raise ValueError("weight_format must be labelled _dummy")
-        if not self.pipeline_label.endswith("_dummy"):
-            raise ValueError("pipeline_label must be labelled _dummy")
+        if is_dummy:
+            if self.seed is None:
+                raise ValueError("dummy seed must be an int")
+            if not self.source_dtype.endswith("_dummy"):
+                raise ValueError("dummy source_dtype must be labelled _dummy")
+            if not self.weight_format.endswith("_dummy"):
+                raise ValueError("dummy weight_format must be labelled _dummy")
+            if any(
+                not artifact_id.endswith("_dummy")
+                for artifact_id in self.artifact_ids
+            ):
+                raise ValueError("dummy artifact ids must be labelled _dummy")
+        else:
+            if self.seed is not None:
+                raise ValueError("real manifest seed must be None")
+            if self.source_dtype != REAL_SOURCE_DTYPE:
+                raise ValueError("real source_dtype must be bf16")
+            if self.weight_format != REAL_WEIGHT_FORMAT:
+                raise ValueError("real weight_format must be w4 int4 e_max BFP")
+            if self.pipeline_label != "prepare_real":
+                raise ValueError("real pipeline_label must be prepare_real")
+            _validate_group_size(self.group_size if self.group_size is not None else 0)
+            if self.act_scale_policy != ACT_SCALE_POLICY:
+                raise ValueError("real act_scale_policy must match e_max BFP policy")
+            if not _is_sha256_hex(self.packed_sha256):
+                raise ValueError("real manifest must include packed-byte SHA256")
+            if any(artifact_id.endswith("_dummy") for artifact_id in self.artifact_ids):
+                raise ValueError("real artifact ids must not be labelled _dummy")
         if not self.tiles:
             raise ValueError("manifest must contain at least one tile")
         if not self.scales:
             raise ValueError("manifest must contain at least one scale")
-        if any(not artifact_id.endswith("_dummy") for artifact_id in self.artifact_ids):
-            raise ValueError("artifact ids must be labelled _dummy")
         if self.real_algo_stage != "stage2":
             raise ValueError("real_algo_stage must be stage2")
         if self.hf_touched is not False:
@@ -185,20 +337,26 @@ class Manifest:
                 raise ValueError("tile scale_id must reference a manifest scale")
             if tile.tile_id not in scales_by_tile:
                 raise ValueError("each tile must have a matching scale")
+        if self.packed_sha256:
+            packed = b"".join(tile.packed_nibbles for tile in self.tiles)
+            if self.packed_sha256 != _sha256_bytes(packed):
+                raise ValueError("manifest packed_sha256 must match manifest tiles")
 
 
 class GemmaWeightPrep:
-    """Stage-1 Gemma weight-prep boundary.
+    """Gemma weight-prep boundary.
 
-    `prepare_dummy()` is the only implemented pipeline. The real W4 algorithm
-    belongs in stage 2 and remains explicitly unimplemented here.
+    `prepare_dummy()` remains for stage-1 compatibility. `prepare_real()`
+    performs offline W4 quantization for caller-supplied weights only.
     """
 
     def prepare_dummy(self, seed: int) -> Manifest:
         """Create a deterministic dummy manifest without loading real weights."""
 
         rng = random.Random(seed)
-        bf16_words = tuple(rng.getrandbits(16) for _ in range(_product(DUMMY_SOURCE_SHAPE)))
+        bf16_words = tuple(
+            rng.getrandbits(16) for _ in range(_product(DUMMY_SOURCE_SHAPE))
+        )
         packed = self._placeholder_w4_quantize_dummy(bf16_words)
         scale = Scale(
             scale_id=DUMMY_SCALE_ID,
@@ -239,8 +397,72 @@ class GemmaWeightPrep:
             hf_touched=False,
         )
 
-    def prepare_real_w4(self) -> Manifest:
-        raise NotImplementedError("real algo in stage 2")
+    def prepare_real(
+        self,
+        weights: Any,
+        group_size: int = DEFAULT_GROUP_SIZE,
+    ) -> Manifest:
+        """Quantize caller-supplied BF16-shaped weights to signed packed W4."""
+
+        source_shape, scale_shape, scale_values, packed = _real_w4_quantize(
+            weights,
+            group_size,
+        )
+        packed_sha256 = _sha256_bytes(packed)
+        scale = Scale(
+            scale_id=REAL_SCALE_ID,
+            tile_id=REAL_TILE_ID,
+            dtype=REAL_SCALE_DTYPE,
+            shape=scale_shape,
+            values=scale_values,
+            quantization_label=REAL_QUANTIZATION_LABEL,
+        )
+        tile = WeightTile(
+            tile_id=REAL_TILE_ID,
+            source_dtype=REAL_SOURCE_DTYPE,
+            source_shape=source_shape,
+            tile_shape=source_shape,
+            packed_dtype=REAL_PACKED_DTYPE,
+            quantization_label=REAL_QUANTIZATION_LABEL,
+            packed_nibbles=packed,
+            scale_id=scale.scale_id,
+            packed_sha256=packed_sha256,
+        )
+        return Manifest(
+            schema_version=SCHEMA_VERSION,
+            manifest_id=f"gemma_weight_prep_real_w4_{packed_sha256[:12]}",
+            model_id=REAL_MODEL_ID,
+            seed=None,
+            source_dtype=REAL_SOURCE_DTYPE,
+            weight_format=REAL_WEIGHT_FORMAT,
+            pipeline_label="prepare_real",
+            tiles=(tile,),
+            scales=(scale,),
+            artifact_ids=(f"gemma_weight_tile_0_memory_only_{packed_sha256[:12]}",),
+            evidence_refs=(
+                "pccxai/pccx-llm-launcher#73",
+                "pccxai/pccx-FPGA-NPU-LLM-kv260#80",
+            ),
+            limitations=(
+                "caller_supplied_weights_only",
+                "offline_quantization_only",
+                "no_hf_download_or_weight_load",
+            ),
+            real_algo_stage="stage2",
+            hf_touched=False,
+            group_size=group_size,
+            act_scale_policy=ACT_SCALE_POLICY,
+            packed_sha256=packed_sha256,
+        )
+
+    def prepare_real_w4(
+        self,
+        weights: Any,
+        group_size: int = DEFAULT_GROUP_SIZE,
+    ) -> Manifest:
+        """Compatibility alias for the stage-2 real W4 path."""
+
+        return self.prepare_real(weights, group_size)
 
     @staticmethod
     def _placeholder_w4_quantize_dummy(bf16_words: tuple[int, ...]) -> bytes:
@@ -253,3 +475,9 @@ class GemmaWeightPrep:
             hi = nibbles[index + 1] if index + 1 < len(nibbles) else 0
             packed.append(lo | (hi << 4))
         return bytes(packed)
+
+
+def prepare_real(weights: Any, group_size: int = DEFAULT_GROUP_SIZE) -> Manifest:
+    """Module-level entry point for real offline W4 quantization."""
+
+    return GemmaWeightPrep().prepare_real(weights, group_size)

--- a/contracts/gemma_weight_prep_contract.py
+++ b/contracts/gemma_weight_prep_contract.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Stage-1 Gemma weight-prep contract and deterministic dummy manifest.
+
+This module is a data-only contract for the future Gemma weight-preparation
+pipeline. Stage 1 intentionally avoids Hugging Face downloads, filesystem
+weight loads, and real W4 quantization. The dummy path exists only to exercise
+manifest shape, invariants, and deterministic test coverage.
+"""
+
+from __future__ import annotations
+
+import math
+import random
+from dataclasses import dataclass
+
+
+SCHEMA_VERSION = "pccx.gemmaWeightPrepManifest.v1"
+DUMMY_MODEL_ID = "gemma3n-e4b-dummy"
+DUMMY_TILE_ID = "gemma3n_e4b_layer0_attn_q_proj_tile0_dummy"
+DUMMY_SCALE_ID = "gemma3n_e4b_layer0_attn_q_proj_tile0_scale_dummy"
+DUMMY_SOURCE_SHAPE = (4, 8)
+DUMMY_TILE_SHAPE = (4, 8)
+
+
+def _product(shape: tuple[int, ...]) -> int:
+    total = 1
+    for dim in shape:
+        total *= dim
+    return total
+
+
+@dataclass(frozen=True)
+class Scale:
+    """Per-tile scale metadata for a placeholder W4 tile.
+
+    Invariants:
+    - `scale_id` is non-empty and unique within its manifest.
+    - `tile_id` points to exactly one `WeightTile` in the same manifest.
+    - `dtype` and `quantization_label` carry `_dummy` to prevent real-W4 claims.
+    - `shape` contains positive dimensions and matches the value count.
+    - `values` are finite positive placeholders, not calibrated scales.
+    """
+
+    scale_id: str
+    tile_id: str
+    dtype: str
+    shape: tuple[int, ...]
+    values: tuple[float, ...]
+    quantization_label: str
+
+    def __post_init__(self) -> None:
+        if not self.scale_id:
+            raise ValueError("scale_id must be non-empty")
+        if not self.tile_id:
+            raise ValueError("tile_id must be non-empty")
+        if not self.dtype.endswith("_dummy"):
+            raise ValueError("dtype must be labelled _dummy")
+        if not self.quantization_label.endswith("_dummy"):
+            raise ValueError("quantization_label must be labelled _dummy")
+        if not self.shape or any(dim <= 0 for dim in self.shape):
+            raise ValueError("shape must contain positive dimensions")
+        if len(self.values) != _product(self.shape):
+            raise ValueError("values must match shape element count")
+        if any((not math.isfinite(value)) or value <= 0.0 for value in self.values):
+            raise ValueError("scale values must be finite and positive")
+
+
+@dataclass(frozen=True)
+class WeightTile:
+    """Packed placeholder W4 tile derived from BF16-shaped dummy data.
+
+    Invariants:
+    - `tile_id` is non-empty and unique within its manifest.
+    - `source_dtype` and `packed_dtype` carry `_dummy` labels.
+    - `source_shape` and `tile_shape` have the same rank and positive dimensions.
+    - `packed_nibbles` has two placeholder W4 nibbles per byte, rounded up.
+    - `scale_id` points to exactly one `Scale` in the same manifest.
+    - The bytes are deterministic dummy payload, not a real W4 algorithm output.
+    """
+
+    tile_id: str
+    source_dtype: str
+    source_shape: tuple[int, ...]
+    tile_shape: tuple[int, ...]
+    packed_dtype: str
+    quantization_label: str
+    packed_nibbles: bytes
+    scale_id: str
+
+    def __post_init__(self) -> None:
+        if not self.tile_id:
+            raise ValueError("tile_id must be non-empty")
+        if not self.source_dtype.endswith("_dummy"):
+            raise ValueError("source_dtype must be labelled _dummy")
+        if not self.packed_dtype.endswith("_dummy"):
+            raise ValueError("packed_dtype must be labelled _dummy")
+        if not self.quantization_label.endswith("_dummy"):
+            raise ValueError("quantization_label must be labelled _dummy")
+        if not self.source_shape or any(dim <= 0 for dim in self.source_shape):
+            raise ValueError("source_shape must contain positive dimensions")
+        if len(self.tile_shape) != len(self.source_shape):
+            raise ValueError("tile_shape must have the same rank as source_shape")
+        if any(dim <= 0 for dim in self.tile_shape):
+            raise ValueError("tile_shape must contain positive dimensions")
+        if any(
+            tile_dim > source_dim
+            for tile_dim, source_dim in zip(self.tile_shape, self.source_shape)
+        ):
+            raise ValueError("tile_shape cannot exceed source_shape")
+        if not self.scale_id:
+            raise ValueError("scale_id must be non-empty")
+
+        expected_bytes = (_product(self.tile_shape) + 1) // 2
+        if len(self.packed_nibbles) != expected_bytes:
+            raise ValueError("packed_nibbles must match placeholder W4 byte count")
+
+
+@dataclass(frozen=True)
+class Manifest:
+    """Data-only Gemma weight-prep manifest.
+
+    Invariants:
+    - `schema_version` is `SCHEMA_VERSION`.
+    - `seed` records the deterministic dummy RNG seed.
+    - `weight_format`, `source_dtype`, `pipeline_label`, and artifact ids carry
+      `_dummy` labels.
+    - Tile and scale identifiers are unique, non-empty, and cross-referenced.
+    - `real_algo_stage` is `stage2`; stage 1 must not claim real W4 support.
+    - `hf_touched` is always false; this contract never reads HF cache/assets.
+    """
+
+    schema_version: str
+    manifest_id: str
+    model_id: str
+    seed: int
+    source_dtype: str
+    weight_format: str
+    pipeline_label: str
+    tiles: tuple[WeightTile, ...]
+    scales: tuple[Scale, ...]
+    artifact_ids: tuple[str, ...]
+    evidence_refs: tuple[str, ...]
+    limitations: tuple[str, ...]
+    real_algo_stage: str
+    hf_touched: bool
+
+    def __post_init__(self) -> None:
+        if self.schema_version != SCHEMA_VERSION:
+            raise ValueError("schema_version mismatch")
+        if not self.manifest_id:
+            raise ValueError("manifest_id must be non-empty")
+        if not self.model_id:
+            raise ValueError("model_id must be non-empty")
+        if not isinstance(self.seed, int):
+            raise ValueError("seed must be an int")
+        if not self.source_dtype.endswith("_dummy"):
+            raise ValueError("source_dtype must be labelled _dummy")
+        if not self.weight_format.endswith("_dummy"):
+            raise ValueError("weight_format must be labelled _dummy")
+        if not self.pipeline_label.endswith("_dummy"):
+            raise ValueError("pipeline_label must be labelled _dummy")
+        if not self.tiles:
+            raise ValueError("manifest must contain at least one tile")
+        if not self.scales:
+            raise ValueError("manifest must contain at least one scale")
+        if any(not artifact_id.endswith("_dummy") for artifact_id in self.artifact_ids):
+            raise ValueError("artifact ids must be labelled _dummy")
+        if self.real_algo_stage != "stage2":
+            raise ValueError("real_algo_stage must be stage2")
+        if self.hf_touched is not False:
+            raise ValueError("hf_touched must be false")
+
+        tile_ids = tuple(tile.tile_id for tile in self.tiles)
+        scale_ids = tuple(scale.scale_id for scale in self.scales)
+        if len(set(tile_ids)) != len(tile_ids):
+            raise ValueError("tile ids must be unique")
+        if len(set(scale_ids)) != len(scale_ids):
+            raise ValueError("scale ids must be unique")
+
+        scales_by_tile = {scale.tile_id for scale in self.scales}
+        for tile in self.tiles:
+            if tile.scale_id not in scale_ids:
+                raise ValueError("tile scale_id must reference a manifest scale")
+            if tile.tile_id not in scales_by_tile:
+                raise ValueError("each tile must have a matching scale")
+
+
+class GemmaWeightPrep:
+    """Stage-1 Gemma weight-prep boundary.
+
+    `prepare_dummy()` is the only implemented pipeline. The real W4 algorithm
+    belongs in stage 2 and remains explicitly unimplemented here.
+    """
+
+    def prepare_dummy(self, seed: int) -> Manifest:
+        """Create a deterministic dummy manifest without loading real weights."""
+
+        rng = random.Random(seed)
+        bf16_words = tuple(rng.getrandbits(16) for _ in range(_product(DUMMY_SOURCE_SHAPE)))
+        packed = self._placeholder_w4_quantize_dummy(bf16_words)
+        scale = Scale(
+            scale_id=DUMMY_SCALE_ID,
+            tile_id=DUMMY_TILE_ID,
+            dtype="float32_dummy",
+            shape=(1,),
+            values=(1.0,),
+            quantization_label="w4_placeholder_scale_dummy",
+        )
+        tile = WeightTile(
+            tile_id=DUMMY_TILE_ID,
+            source_dtype="bf16_dummy",
+            source_shape=DUMMY_SOURCE_SHAPE,
+            tile_shape=DUMMY_TILE_SHAPE,
+            packed_dtype="uint4_packed_dummy",
+            quantization_label="w4_placeholder_quantize_dummy",
+            packed_nibbles=packed,
+            scale_id=scale.scale_id,
+        )
+        return Manifest(
+            schema_version=SCHEMA_VERSION,
+            manifest_id=f"gemma_weight_prep_seed_{seed}_dummy",
+            model_id=DUMMY_MODEL_ID,
+            seed=seed,
+            source_dtype="bf16_dummy",
+            weight_format="w4_placeholder_dummy",
+            pipeline_label="prepare_dummy",
+            tiles=(tile,),
+            scales=(scale,),
+            artifact_ids=("gemma_weight_tile_0_memory_only_dummy",),
+            evidence_refs=("stage1_dummy_manifest_test",),
+            limitations=(
+                "dummy_data_only",
+                "real_w4_algo_in_stage2",
+                "no_hf_download_or_weight_load",
+            ),
+            real_algo_stage="stage2",
+            hf_touched=False,
+        )
+
+    def prepare_real_w4(self) -> Manifest:
+        raise NotImplementedError("real algo in stage 2")
+
+    @staticmethod
+    def _placeholder_w4_quantize_dummy(bf16_words: tuple[int, ...]) -> bytes:
+        """Pack deterministic dummy nibbles; this is not real W4 quantization."""
+
+        nibbles = tuple((word >> 8) & 0x0F for word in bf16_words)
+        packed = bytearray()
+        for index in range(0, len(nibbles), 2):
+            lo = nibbles[index]
+            hi = nibbles[index + 1] if index + 1 < len(nibbles) else 0
+            packed.append(lo | (hi << 4))
+        return bytes(packed)

--- a/contracts/kv260_serial_connection.py
+++ b/contracts/kv260_serial_connection.py
@@ -1,0 +1,347 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""TTY serial backend for KV260 launcher-side status checks.
+
+The backend uses USB serial console access only. Credentials come from
+`KVFPGA_USER` and `KVFPGA_PASSWORD`; `KVFPGA_HOST` is intentionally ignored.
+Raw environment values are not exposed through repr or public status fields.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Mapping, Protocol, Sequence, runtime_checkable
+
+
+DEFAULT_BAUDRATE = 115200
+DEFAULT_PROMPT_TIMEOUT = 4.0
+DEFAULT_COMMAND_TIMEOUT = 12.0
+DEFAULT_WRITE_TIMEOUT = 1.0
+READ_CHUNK_SIZE = 1024
+END_MARKER = "__PCCX_KV260_SERIAL_DONE__"
+
+LOGIN_PROMPT = re.compile(rb"(?im)(?:^|\r?\n)[^\r\n]*login:\s*$")
+PASSWORD_PROMPT = re.compile(rb"(?im)(?:^|\r?\n)[^\r\n]*password:\s*$")
+SHELL_PROMPT = re.compile(rb"(?m)(?:^|\r?\n)[^\r\n]*[$#]\s*$")
+COMMAND_DONE = re.compile((END_MARKER + r":(\d+)").encode("ascii"))
+
+
+class KV260SerialError(RuntimeError):
+    """Base error for serial backend failures."""
+
+
+class KV260SerialUnavailable(KV260SerialError):
+    """Raised when a tty port or pyserial backend is unavailable."""
+
+
+@runtime_checkable
+class KV260ConnectionProtocol(Protocol):
+    """Method contract shared by KV260 connection backends."""
+
+    def is_reachable(self) -> bool:
+        """Return whether a serial console prompt can be reached."""
+
+    def kernel_uname(self) -> str:
+        """Return `uname -a` from the KV260 serial session."""
+
+    def xrt_present(self) -> bool:
+        """Return whether XRT tooling or libraries are visible on the target."""
+
+    def xmutil_listapps(self) -> Sequence[str]:
+        """Return `xmutil listapps` output lines from the target."""
+
+
+@dataclass(frozen=True)
+class SerialCommandResult:
+    """Target command output with shell exit status."""
+
+    exit_status: int
+    output: str
+
+
+SerialFactory = Callable[..., Any]
+
+
+def kv260_tty_candidates(env: Mapping[str, str] | None = None) -> tuple[str, ...]:
+    """Return candidate KV260 serial tty paths, with env override first."""
+
+    source = os.environ if env is None else env
+    override = source.get("KVFPGA_TTY")
+    if override:
+        return (override,)
+
+    candidates: list[str] = []
+    by_id = Path("/dev/serial/by-id")
+    if by_id.is_dir():
+        for path in sorted(by_id.iterdir()):
+            if "kv260" in path.name.lower():
+                candidates.append(str(path))
+
+    candidates.extend(str(path) for path in sorted(Path("/dev").glob("ttyUSB*")))
+    return tuple(dict.fromkeys(candidates))
+
+
+def detect_kv260_tty(env: Mapping[str, str] | None = None) -> str | None:
+    """Return the first configured or auto-detected KV260 serial tty path."""
+
+    candidates = kv260_tty_candidates(env)
+    return candidates[0] if candidates else None
+
+
+@dataclass
+class KV260SerialConnection:
+    """USB tty serial implementation of the KV260 connection method contract."""
+
+    tty_configured: bool
+    user_configured: bool
+    password_configured: bool
+    baudrate: int = DEFAULT_BAUDRATE
+    prompt_timeout: float = DEFAULT_PROMPT_TIMEOUT
+    command_timeout: float = DEFAULT_COMMAND_TIMEOUT
+    write_timeout: float = DEFAULT_WRITE_TIMEOUT
+    _tty: str | None = field(default=None, repr=False, compare=False)
+    _user: str | None = field(default=None, repr=False, compare=False)
+    _password: str | None = field(default=None, repr=False, compare=False)
+    _serial_factory: SerialFactory | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+    _active_serial: Any | None = field(default=None, repr=False, compare=False)
+
+    @classmethod
+    def from_env(
+        cls,
+        env: Mapping[str, str] | None = None,
+        serial_factory: SerialFactory | None = None,
+    ) -> "KV260SerialConnection":
+        source = os.environ if env is None else env
+        tty = source.get("KVFPGA_TTY")
+        user = source.get("KVFPGA_USER")
+        password = source.get("KVFPGA_PASSWORD")
+        return cls(
+            tty_configured=bool(tty),
+            user_configured=bool(user),
+            password_configured=bool(password),
+            _tty=tty,
+            _user=user,
+            _password=password,
+            _serial_factory=serial_factory,
+        )
+
+    def is_configured(self) -> bool:
+        """Return whether required serial credentials are present."""
+
+        return self.user_configured and self.password_configured
+
+    def is_reachable(self) -> bool:
+        """Open the tty, send a newline, and check for login or shell prompt."""
+
+        serial_session = None
+        try:
+            serial_session = self._open_serial()
+            self._write(serial_session, b"\r\n")
+            prompt, _buffer = self._read_until_prompt(
+                serial_session,
+                timeout=self.prompt_timeout,
+            )
+            return prompt is not None
+        except (OSError, KV260SerialError):
+            return False
+        finally:
+            self._close_serial(serial_session)
+
+    def kernel_uname(self) -> str:
+        with self as connection:
+            result = connection._run_command("uname -a")
+        if result.exit_status != 0:
+            raise KV260SerialError("uname command failed")
+        return result.output.strip()
+
+    def xrt_present(self) -> bool:
+        command = (
+            "command -v xrt-smi >/dev/null 2>&1 || "
+            "command -v xbutil >/dev/null 2>&1 || "
+            "test -e /usr/lib/libxrt_core.so || "
+            "test -e /usr/lib/aarch64-linux-gnu/libxrt_core.so"
+        )
+        with self as connection:
+            result = connection._run_command(command)
+        return result.exit_status == 0
+
+    def xmutil_listapps(self) -> Sequence[str]:
+        with self as connection:
+            result = connection._run_command("xmutil listapps")
+        if result.exit_status != 0:
+            return ()
+        return tuple(line for line in result.output.splitlines() if line.strip())
+
+    def __enter__(self) -> "KV260SerialConnection":
+        serial_session = self._open_serial()
+        try:
+            self._login(serial_session)
+        except Exception:
+            self._close_serial(serial_session)
+            raise
+        self._active_serial = serial_session
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        self.logout()
+
+    def logout(self) -> None:
+        serial_session = self._active_serial
+        self._active_serial = None
+        if serial_session is None:
+            return
+        try:
+            self._write(serial_session, b"exit\r\n")
+        finally:
+            self._close_serial(serial_session)
+
+    def _open_serial(self) -> Any:
+        tty = self._tty or detect_kv260_tty()
+        if not tty:
+            raise KV260SerialUnavailable("no KV260 serial tty detected")
+
+        factory = self._serial_factory
+        if factory is None:
+            try:
+                import serial  # type: ignore[import-not-found]
+            except ImportError as exc:
+                raise KV260SerialUnavailable("pyserial is not installed") from exc
+            factory = serial.Serial
+
+        return factory(
+            port=tty,
+            baudrate=self.baudrate,
+            timeout=0.1,
+            write_timeout=self.write_timeout,
+        )
+
+    def _login(self, serial_session: Any) -> None:
+        if not self._user or not self._password:
+            raise KV260SerialUnavailable("KVFPGA serial credentials are incomplete")
+
+        self._write(serial_session, b"\r\n")
+        prompt, _buffer = self._read_until_prompt(
+            serial_session,
+            timeout=self.prompt_timeout,
+        )
+        if prompt == "login":
+            self._write_line(serial_session, self._user)
+            prompt, _buffer = self._read_until_prompt(
+                serial_session,
+                timeout=self.prompt_timeout,
+            )
+        if prompt == "password":
+            self._write_line(serial_session, self._password)
+            prompt, _buffer = self._read_until_prompt(
+                serial_session,
+                timeout=self.prompt_timeout,
+            )
+        if prompt != "shell":
+            raise KV260SerialError("serial shell prompt was not reached")
+
+    def _run_command(self, command: str) -> SerialCommandResult:
+        serial_session = self._active_serial
+        if serial_session is None:
+            raise KV260SerialError("serial session is not open")
+
+        wrapped = f"{command}; printf '\\n{END_MARKER}:%s\\n' \"$?\""
+        self._write_line(serial_session, wrapped)
+        raw = self._read_until_pattern(
+            serial_session,
+            COMMAND_DONE,
+            timeout=self.command_timeout,
+        )
+        match = COMMAND_DONE.search(raw)
+        if match is None:
+            raise KV260SerialError("command completion marker was not observed")
+
+        exit_status = int(match.group(1).decode("ascii"))
+        output = self._clean_command_output(command, raw[: match.start()])
+        return SerialCommandResult(exit_status=exit_status, output=output)
+
+    def _read_until_prompt(
+        self,
+        serial_session: Any,
+        timeout: float,
+    ) -> tuple[str | None, bytes]:
+        deadline = time.monotonic() + timeout
+        buffer = bytearray()
+        while time.monotonic() < deadline:
+            chunk = serial_session.read(READ_CHUNK_SIZE)
+            if chunk:
+                buffer.extend(chunk)
+                data = bytes(buffer)
+                if LOGIN_PROMPT.search(data):
+                    return "login", data
+                if PASSWORD_PROMPT.search(data):
+                    return "password", data
+                if SHELL_PROMPT.search(data):
+                    return "shell", data
+            else:
+                time.sleep(0.02)
+        return None, bytes(buffer)
+
+    def _read_until_pattern(
+        self,
+        serial_session: Any,
+        pattern: re.Pattern[bytes],
+        timeout: float,
+    ) -> bytes:
+        deadline = time.monotonic() + timeout
+        buffer = bytearray()
+        while time.monotonic() < deadline:
+            chunk = serial_session.read(READ_CHUNK_SIZE)
+            if chunk:
+                buffer.extend(chunk)
+                data = bytes(buffer)
+                if pattern.search(data):
+                    return data
+            else:
+                time.sleep(0.02)
+        raise KV260SerialError("serial read timed out")
+
+    def _write_line(self, serial_session: Any, line: str) -> None:
+        self._write(serial_session, line.encode("utf-8") + b"\r\n")
+
+    def _write(self, serial_session: Any, payload: bytes) -> None:
+        serial_session.write(payload)
+        flush = getattr(serial_session, "flush", None)
+        if flush is not None:
+            flush()
+
+    def _clean_command_output(self, command: str, raw: bytes) -> str:
+        text = raw.decode("utf-8", errors="replace").replace("\r", "")
+        lines = text.split("\n")
+        cleaned: list[str] = []
+        for line in lines:
+            stripped = line.strip()
+            if not stripped:
+                continue
+            if stripped == command or stripped.startswith(f"{command}; "):
+                continue
+            if (
+                command in stripped
+                and "printf" in stripped
+                and END_MARKER in stripped
+            ):
+                continue
+            if stripped.endswith("$") or stripped.endswith("#"):
+                continue
+            cleaned.append(line.rstrip())
+        return "\n".join(cleaned)
+
+    def _close_serial(self, serial_session: Any | None) -> None:
+        if serial_session is None:
+            return
+        close = getattr(serial_session, "close", None)
+        if close is not None:
+            close()

--- a/contracts/token_stream_over_serial.py
+++ b/contracts/token_stream_over_serial.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Token stream transport over the KV260 serial tty.
+
+This is first-pass framing; refine after first board run. The control-plane
+wire format uses ASCII begin/end markers around length-prefixed binary chunks,
+matching the lab trace framing shape while keeping token payloads binary.
+"""
+
+from __future__ import annotations
+
+import struct
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import Any, Iterator, List, Protocol, Sequence, runtime_checkable
+
+from contracts.axi_cmd_channel import AxiCmdChannel, NpuCmd
+from contracts.kv260_serial_connection import (
+    KV260SerialConnection,
+    detect_kv260_tty,
+)
+
+
+INPUT_BEGIN_MARKER = b"PCCX_TOKEN_INPUT_BEGIN_V1\n"
+INPUT_END_MARKER = b"PCCX_TOKEN_INPUT_END_V1\n"
+OUTPUT_BEGIN_MARKER = b"PCCX_TOKEN_OUTPUT_BEGIN_V1\n"
+OUTPUT_END_MARKER = b"PCCX_TOKEN_OUTPUT_END_V1\n"
+INPUT_CHUNK_TAG = b"ITOK"
+OUTPUT_CHUNK_TAG = b"OTOK"
+UINT32_MAX = 0xFFFF_FFFF
+DEFAULT_EOS_TOKEN_ID = 1
+DEFAULT_CHUNK_TOKEN_COUNT = 256
+DEFAULT_OUTPUT_TIMEOUT_S = 5.0
+READ_CHUNK_SIZE = 1024
+
+OP_BEGIN_INPUT = 0x31
+OP_END_INPUT = 0x32
+OP_READ_OUTPUT = 0x33
+
+
+class TokenStreamError(RuntimeError):
+    """Base error for token-stream transport failures."""
+
+
+class TokenStreamFramingError(TokenStreamError):
+    """Raised when received token framing is malformed."""
+
+
+@runtime_checkable
+class TokenStreamProtocol(Protocol):
+    """Method contract for launcher-side token streaming."""
+
+    def send_input_tokens(self, token_ids: List[int]) -> None:
+        """Send prompt token IDs to the KV260 control-plane tty."""
+
+    def recv_output_tokens(self, timeout_s: float) -> List[int]:
+        """Receive generated token IDs until EOS, end marker, or timeout."""
+
+    def infer(self, prompt_token_ids: List[int]) -> List[int]:
+        """Send prompt token IDs and return generated output token IDs."""
+
+
+@dataclass
+class TokenStreamOverSerial:
+    """Length-prefixed token transport using a KV260 serial connection."""
+
+    connection: KV260SerialConnection
+    axi_channel: AxiCmdChannel | None = None
+    eos_token_id: int = DEFAULT_EOS_TOKEN_ID
+    chunk_token_count: int = DEFAULT_CHUNK_TOKEN_COUNT
+    output_timeout_s: float = DEFAULT_OUTPUT_TIMEOUT_S
+    _active_serial: Any | None = field(default=None, init=False, repr=False)
+
+    @classmethod
+    def from_env(
+        cls,
+        serial_factory: Any | None = None,
+        axi_channel: AxiCmdChannel | None = None,
+    ) -> "TokenStreamOverSerial":
+        """Build a token stream from KV260 serial environment settings."""
+
+        return cls(
+            connection=KV260SerialConnection.from_env(
+                serial_factory=serial_factory,
+            ),
+            axi_channel=axi_channel,
+        )
+
+    def __post_init__(self) -> None:
+        if self.eos_token_id < 0 or self.eos_token_id > UINT32_MAX:
+            raise ValueError("eos_token_id must fit uint32")
+        if self.chunk_token_count <= 0:
+            raise ValueError("chunk_token_count must be positive")
+        if self.output_timeout_s < 0:
+            raise ValueError("output_timeout_s must be non-negative")
+
+    def __enter__(self) -> "TokenStreamOverSerial":
+        if self._active_serial is None:
+            self._active_serial = self.connection._open_serial()
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        self.close()
+
+    def close(self) -> None:
+        """Close the active serial session when this wrapper opened one."""
+
+        serial_session = self._active_serial
+        self._active_serial = None
+        self.connection._close_serial(serial_session)
+
+    def send_input_tokens(self, token_ids: List[int]) -> None:
+        """Encode prompt tokens and write them to the KV260 serial tty."""
+
+        tokens = _validate_tokens(token_ids)
+        self._issue_axi(OP_BEGIN_INPUT, len(tokens))
+        payload = encode_input_stream(tokens, self.chunk_token_count)
+        with self._serial_for_call() as serial_session:
+            self.connection._write(serial_session, payload)
+        self._issue_axi(OP_END_INPUT, len(tokens))
+
+    def recv_output_tokens(self, timeout_s: float) -> List[int]:
+        """Read output token framing until EOS, output end, or timeout."""
+
+        if timeout_s < 0:
+            raise ValueError("timeout_s must be non-negative")
+
+        self._issue_axi(OP_READ_OUTPUT, 0)
+        deadline = time.monotonic() + timeout_s
+        buffer = bytearray()
+        tokens: list[int] = []
+        parser_offset = 0
+        saw_begin = False
+
+        with self._serial_for_call() as serial_session:
+            while time.monotonic() <= deadline:
+                chunk = serial_session.read(READ_CHUNK_SIZE)
+                if chunk:
+                    buffer.extend(chunk)
+                    state = _parse_output_buffer(
+                        bytes(buffer),
+                        parser_offset,
+                        tokens,
+                        self.eos_token_id,
+                        saw_begin,
+                    )
+                    parser_offset = state.offset
+                    saw_begin = state.saw_begin
+                    if state.done:
+                        return list(tokens)
+                    continue
+                time.sleep(0.02)
+
+        return list(tokens)
+
+    def infer(self, prompt_token_ids: List[int]) -> List[int]:
+        """Send prompt tokens and return output tokens over one tty session."""
+
+        if self._active_serial is not None:
+            self.send_input_tokens(prompt_token_ids)
+            return self.recv_output_tokens(self.output_timeout_s)
+
+        with self:
+            self.send_input_tokens(prompt_token_ids)
+            return self.recv_output_tokens(self.output_timeout_s)
+
+    @contextmanager
+    def _serial_for_call(self) -> Iterator[Any]:
+        if self._active_serial is not None:
+            yield self._active_serial
+            return
+
+        serial_session = self.connection._open_serial()
+        try:
+            yield serial_session
+        finally:
+            self.connection._close_serial(serial_session)
+
+    def _issue_axi(self, opcode: int, arg0: int) -> None:
+        if self.axi_channel is None:
+            return
+        self.axi_channel.issue(NpuCmd(opcode=opcode, arg0=arg0))
+        stat = self.axi_channel.poll_stat()
+        if stat.error:
+            raise TokenStreamError(
+                f"AXI command {opcode} failed with status {stat.status_code}",
+            )
+
+
+@dataclass(frozen=True)
+class _ParseState:
+    offset: int
+    saw_begin: bool
+    done: bool = False
+
+
+def encode_input_stream(
+    token_ids: Sequence[int],
+    chunk_token_count: int = DEFAULT_CHUNK_TOKEN_COUNT,
+) -> bytes:
+    """Return first-pass control-plane input framing for token IDs."""
+
+    tokens = _validate_tokens(token_ids)
+    if chunk_token_count <= 0:
+        raise ValueError("chunk_token_count must be positive")
+
+    chunks = [INPUT_BEGIN_MARKER]
+    for start in range(0, len(tokens), chunk_token_count):
+        chunk_tokens = tokens[start : start + chunk_token_count]
+        payload = _pack_tokens(chunk_tokens)
+        chunks.append(INPUT_CHUNK_TAG + struct.pack(">I", len(payload)) + payload)
+    chunks.append(INPUT_END_MARKER)
+    return b"".join(chunks)
+
+
+def encode_output_stream(token_ids: Sequence[int]) -> bytes:
+    """Return output framing for mock tests and future fixture capture."""
+
+    tokens = _validate_tokens(token_ids)
+    payload = _pack_tokens(tokens)
+    return (
+        OUTPUT_BEGIN_MARKER
+        + OUTPUT_CHUNK_TAG
+        + struct.pack(">I", len(payload))
+        + payload
+        + OUTPUT_END_MARKER
+    )
+
+
+def _parse_output_buffer(
+    buffer: bytes,
+    offset: int,
+    tokens: list[int],
+    eos_token_id: int,
+    saw_begin: bool,
+) -> _ParseState:
+    if not saw_begin:
+        marker_at = buffer.find(OUTPUT_BEGIN_MARKER, offset)
+        if marker_at < 0:
+            keep_from = max(0, len(buffer) - len(OUTPUT_BEGIN_MARKER))
+            return _ParseState(offset=keep_from, saw_begin=False)
+        offset = marker_at + len(OUTPUT_BEGIN_MARKER)
+        saw_begin = True
+
+    while offset < len(buffer):
+        if buffer.startswith(OUTPUT_END_MARKER, offset):
+            return _ParseState(
+                offset=offset + len(OUTPUT_END_MARKER),
+                saw_begin=saw_begin,
+                done=True,
+            )
+        if OUTPUT_END_MARKER.startswith(buffer[offset:]):
+            return _ParseState(offset=offset, saw_begin=saw_begin)
+        header_size = len(OUTPUT_CHUNK_TAG) + 4
+        if len(buffer) - offset < header_size:
+            return _ParseState(offset=offset, saw_begin=saw_begin)
+        tag = buffer[offset : offset + len(OUTPUT_CHUNK_TAG)]
+        if tag != OUTPUT_CHUNK_TAG:
+            raise TokenStreamFramingError("unexpected output token chunk tag")
+        size_offset = offset + len(OUTPUT_CHUNK_TAG)
+        payload_len = struct.unpack(">I", buffer[size_offset : size_offset + 4])[0]
+        if payload_len % 4:
+            raise TokenStreamFramingError("token payload length must be uint32 aligned")
+        payload_offset = size_offset + 4
+        payload_end = payload_offset + payload_len
+        if len(buffer) < payload_end:
+            return _ParseState(offset=offset, saw_begin=saw_begin)
+        chunk_tokens = _unpack_tokens(buffer[payload_offset:payload_end])
+        tokens.extend(chunk_tokens)
+        if eos_token_id in chunk_tokens:
+            return _ParseState(offset=payload_end, saw_begin=saw_begin, done=True)
+        offset = payload_end
+
+    return _ParseState(offset=offset, saw_begin=saw_begin)
+
+
+def _validate_tokens(token_ids: Sequence[int]) -> list[int]:
+    tokens = list(token_ids)
+    for token_id in tokens:
+        if not isinstance(token_id, int):
+            raise TypeError("token IDs must be integers")
+        if token_id < 0 or token_id > UINT32_MAX:
+            raise ValueError("token IDs must fit uint32")
+    return tokens
+
+
+def _pack_tokens(token_ids: Sequence[int]) -> bytes:
+    if not token_ids:
+        return b""
+    return struct.pack(f">{len(token_ids)}I", *token_ids)
+
+
+def _unpack_tokens(payload: bytes) -> list[int]:
+    if not payload:
+        return []
+    return list(struct.unpack(f">{len(payload) // 4}I", payload))

--- a/scripts/tests/axi_cmd_mock_backend_test.py
+++ b/scripts/tests/axi_cmd_mock_backend_test.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Unit tests for the offline AXI command-channel mock backend."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "contracts" / "axi_cmd_channel.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location(
+        "axi_cmd_channel",
+        MODULE_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def assert_raises(error_type, callback) -> None:
+    try:
+        callback()
+    except error_type:
+        return
+    raise AssertionError(f"expected {error_type.__name__}")
+
+
+def test_basic_issue_poll_cycle_updates_register_model() -> None:
+    module = load_module()
+    cmd = module.NpuCmd(opcode=3, arg0=4, arg1=5, arg2=6, flags=7)
+
+    backend = module.AxiCmdMockBackend()
+    assert backend.snapshot_registers() == {
+        module.MMIO_CMD: 0,
+        module.MMIO_STAT: module.NpuStat().register_value(),
+    }
+
+    with backend as channel:
+        channel.issue(cmd)
+        first = channel.poll_stat()
+        second = channel.poll_stat()
+        registers = channel.snapshot_registers()
+
+    assert first == second
+    assert first == module.NpuStat(completion_count=1, last_opcode=3)
+    assert backend.completion_count == 1
+    assert backend.last_cmd == cmd
+    assert registers[module.MMIO_CMD] == cmd.register_value()
+    assert registers[module.MMIO_STAT] == first.register_value()
+    assert_raises(RuntimeError, lambda: backend.poll_stat())
+
+
+def test_multiple_issue_cycles_increment_fake_completion_counter() -> None:
+    module = load_module()
+
+    with module.AxiCmdMockBackend() as channel:
+        channel.issue(module.NpuCmd(opcode=1))
+        assert channel.poll_stat() == module.NpuStat(
+            completion_count=1,
+            last_opcode=1,
+        )
+
+        channel.issue(module.NpuCmd(opcode=2, arg0=10))
+        assert channel.poll_stat() == module.NpuStat(
+            completion_count=2,
+            last_opcode=2,
+        )
+
+
+def test_scripted_reply_mode_verifies_commands_and_returns_expected_status() -> None:
+    module = load_module()
+    first_cmd = module.NpuCmd(opcode=9, arg0=1)
+    second_cmd = module.NpuCmd(opcode=10, arg0=2)
+    first_stat = module.NpuStat(
+        completion_count=1,
+        last_opcode=9,
+        status_code=7,
+    )
+    second_stat = module.NpuStat(
+        completion_count=2,
+        last_opcode=10,
+        error=True,
+        status_code=12,
+    )
+
+    with module.AxiCmdMockBackend(
+        scripted_replies=[
+            (first_cmd, first_stat),
+            (second_cmd, second_stat),
+        ],
+    ) as channel:
+        channel.issue(first_cmd)
+        assert channel.poll_stat() == first_stat
+        assert channel.remaining_scripted_replies == 1
+
+        channel.issue(second_cmd)
+        assert channel.poll_stat() == second_stat
+        assert channel.completion_count == 2
+        assert channel.remaining_scripted_replies == 0
+        channel.assert_script_consumed()
+
+
+def test_scripted_reply_mode_rejects_unexpected_command_without_side_effect() -> None:
+    module = load_module()
+    expected_cmd = module.NpuCmd(opcode=1)
+    unexpected_cmd = module.NpuCmd(opcode=2)
+    expected_stat = module.NpuStat(completion_count=1, last_opcode=1)
+
+    with module.AxiCmdMockBackend(
+        scripted_replies=[(expected_cmd, expected_stat)],
+    ) as channel:
+        assert_raises(
+            module.ScriptedReplyMismatch,
+            lambda: channel.issue(unexpected_cmd),
+        )
+        assert channel.completion_count == 0
+        assert channel.remaining_scripted_replies == 1
+        assert channel.snapshot_registers() == {
+            module.MMIO_CMD: 0,
+            module.MMIO_STAT: module.NpuStat().register_value(),
+        }
+
+
+def test_issue_and_poll_are_safe_under_concurrent_test_use() -> None:
+    module = load_module()
+
+    with module.AxiCmdMockBackend() as channel:
+
+        def issue_and_poll(index: int):
+            channel.issue(module.NpuCmd(opcode=index + 1))
+            return channel.poll_stat()
+
+        with ThreadPoolExecutor(max_workers=4) as executor:
+            stats = list(executor.map(issue_and_poll, range(8)))
+
+        assert channel.completion_count == 8
+        assert len(stats) == 8
+        assert all(isinstance(stat, module.NpuStat) for stat in stats)
+        assert channel.poll_stat().completion_count == 8
+
+
+test_basic_issue_poll_cycle_updates_register_model()
+test_multiple_issue_cycles_increment_fake_completion_counter()
+test_scripted_reply_mode_verifies_commands_and_returns_expected_status()
+test_scripted_reply_mode_rejects_unexpected_command_without_side_effect()
+test_issue_and_poll_are_safe_under_concurrent_test_use()
+
+print("AXI command mock backend tests ok")

--- a/scripts/tests/full_mock_gemma_path_integration_test.py
+++ b/scripts/tests/full_mock_gemma_path_integration_test.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Full-mock Gemma W4 path integration test."""
+
+from __future__ import annotations
+
+import hashlib
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+TEST_PATH = Path(__file__).resolve()
+
+from contracts.axi_cmd_channel import AxiCmdMockBackend, NpuCmd, NpuStat
+from contracts.gemma_weight_prep_contract import GemmaWeightPrep
+from contracts.kv260_serial_connection import KV260SerialConnection
+from contracts.token_stream_over_serial import (
+    DEFAULT_EOS_TOKEN_ID,
+    OP_BEGIN_INPUT,
+    OP_END_INPUT,
+    OP_READ_OUTPUT,
+    TokenStreamOverSerial,
+    encode_input_stream,
+    encode_output_stream,
+)
+
+
+GROUP_SIZE = 64
+OP_LOAD_W4_MANIFEST = 0x40
+EXPECTED_PACKED_HEX = "103e5c7ac4a5a687"
+EXPECTED_PACKED_SHA256 = (
+    "fcd9cc6de77604e760378ed7f7bc7446317e418c2c457f304e3d47207090302d"
+)
+EXPECTED_OUTPUT_TOKENS = [4242132077, 3883271399, DEFAULT_EOS_TOKEN_ID]
+
+
+class FakeSerial:
+    instances: list["FakeSerial"] = []
+    reads: list[bytes] = []
+
+    def __init__(self, *args, **kwargs) -> None:
+        self.args = args
+        self.kwargs = kwargs
+        self.writes: list[bytes] = []
+        self.reads = list(type(self).reads)
+        self.closed = False
+        type(self).instances.append(self)
+
+    def read(self, _size: int) -> bytes:
+        if self.reads:
+            return self.reads.pop(0)
+        return b""
+
+    def write(self, payload: bytes) -> int:
+        self.writes.append(payload)
+        return len(payload)
+
+    def flush(self) -> None:
+        return None
+
+    def close(self) -> None:
+        self.closed = True
+
+
+@dataclass(frozen=True)
+class GemmaMockRun:
+    manifest_id: str
+    manifest_sha256: str
+    packed_hex: str
+    prompt_tokens: tuple[int, ...]
+    output_tokens: tuple[int, ...]
+    register_snapshot: tuple[tuple[str, int], ...]
+    serial_payload: bytes
+
+
+def reset_fake_serial(reads: list[bytes]) -> None:
+    FakeSerial.instances = []
+    FakeSerial.reads = list(reads)
+
+
+def fixed_bf16_shaped_weights() -> np.ndarray:
+    return np.array(
+        [
+            [0.0, 0.5, -1.0, 1.5, -2.0, 2.5, -3.0, 3.5],
+            [4.0, -4.5, 5.0, -5.5, 6.0, -6.5, 7.0, -7.5],
+        ],
+        dtype=np.float32,
+    )
+
+
+def make_connection() -> KV260SerialConnection:
+    return KV260SerialConnection.from_env(
+        {"KVFPGA_TTY": "/tmp/pccx-token-stream-mock"},
+        serial_factory=FakeSerial,
+    )
+
+
+def output_tokens_from_sha256(packed_sha256: str) -> list[int]:
+    return [
+        int(packed_sha256[0:8], 16),
+        int(packed_sha256[8:16], 16),
+        DEFAULT_EOS_TOKEN_ID,
+    ]
+
+
+def run_full_mock_gemma_path() -> GemmaMockRun:
+    manifest = GemmaWeightPrep().prepare_real(
+        fixed_bf16_shaped_weights(),
+        group_size=GROUP_SIZE,
+    )
+    tile = manifest.tiles[0]
+    packed = tile.packed_nibbles
+    prompt_tokens = list(packed)
+    output_tokens = output_tokens_from_sha256(manifest.packed_sha256)
+
+    reset_fake_serial([encode_output_stream(output_tokens)])
+    checksum_prefix = int(manifest.packed_sha256[0:8], 16)
+    commands = [
+        (
+            NpuCmd(
+                opcode=OP_LOAD_W4_MANIFEST,
+                arg0=len(packed),
+                arg1=GROUP_SIZE,
+                arg2=checksum_prefix,
+            ),
+            NpuStat(completion_count=1, last_opcode=OP_LOAD_W4_MANIFEST),
+        ),
+        (
+            NpuCmd(opcode=OP_BEGIN_INPUT, arg0=len(prompt_tokens)),
+            NpuStat(completion_count=2, last_opcode=OP_BEGIN_INPUT),
+        ),
+        (
+            NpuCmd(opcode=OP_END_INPUT, arg0=len(prompt_tokens)),
+            NpuStat(completion_count=3, last_opcode=OP_END_INPUT),
+        ),
+        (
+            NpuCmd(opcode=OP_READ_OUTPUT, arg0=0),
+            NpuStat(completion_count=4, last_opcode=OP_READ_OUTPUT),
+        ),
+    ]
+
+    with AxiCmdMockBackend(commands) as axi:
+        axi.issue(commands[0][0])
+        assert axi.poll_stat() == commands[0][1]
+        stream = TokenStreamOverSerial(
+            connection=make_connection(),
+            axi_channel=axi,
+            output_timeout_s=0.05,
+        )
+        observed_output = stream.infer(prompt_tokens)
+        axi.assert_script_consumed()
+        register_snapshot = tuple(sorted(axi.snapshot_registers().items()))
+
+    assert len(FakeSerial.instances) == 1
+    serial_payload = b"".join(FakeSerial.instances[0].writes)
+    assert FakeSerial.instances[0].closed is True
+
+    return GemmaMockRun(
+        manifest_id=manifest.manifest_id,
+        manifest_sha256=manifest.packed_sha256,
+        packed_hex=packed.hex(),
+        prompt_tokens=tuple(prompt_tokens),
+        output_tokens=tuple(observed_output),
+        register_snapshot=register_snapshot,
+        serial_payload=serial_payload,
+    )
+
+
+def test_full_mock_gemma_w4_path_is_deterministic() -> None:
+    first = run_full_mock_gemma_path()
+    second = run_full_mock_gemma_path()
+
+    assert first == second
+    assert first.manifest_id == "gemma_weight_prep_real_w4_fcd9cc6de776"
+    assert first.manifest_sha256 == EXPECTED_PACKED_SHA256
+    assert first.packed_hex == EXPECTED_PACKED_HEX
+    assert first.prompt_tokens == (16, 62, 92, 122, 196, 165, 166, 135)
+    assert first.output_tokens == tuple(EXPECTED_OUTPUT_TOKENS)
+    assert first.serial_payload == encode_input_stream(first.prompt_tokens)
+
+
+def test_manifest_checksum_matches_packed_bytes() -> None:
+    manifest = GemmaWeightPrep().prepare_real(
+        fixed_bf16_shaped_weights(),
+        group_size=GROUP_SIZE,
+    )
+    packed = manifest.tiles[0].packed_nibbles
+
+    assert manifest.group_size == GROUP_SIZE
+    assert manifest.hf_touched is False
+    assert manifest.tiles[0].packed_sha256 == EXPECTED_PACKED_SHA256
+    assert manifest.packed_sha256 == EXPECTED_PACKED_SHA256
+    assert packed == bytes.fromhex(EXPECTED_PACKED_HEX)
+    assert hashlib.sha256(packed).hexdigest() == EXPECTED_PACKED_SHA256
+
+
+def test_source_has_offline_and_claim_guards() -> None:
+    source = TEST_PATH.read_text(encoding="utf-8")
+    lowered = source.lower()
+
+    forbidden_runtime_terms = [
+        "trans" + "formers",
+        "hugging" + "face_hub",
+        "hf_hub_" + "download",
+        "from_" + "pretrained",
+        ".safe" + "tensors",
+        ".g" + "guf",
+        ".p" + "t",
+        ".p" + "th",
+        "req" + "uests",
+        "url" + "lib",
+        "sub" + "process",
+        "sock" + "et",
+        "/dev/" + "mem",
+        "/dev/" + "tty",
+        "serial" + ".serial",
+    ]
+    for term in forbidden_runtime_terms:
+        assert term not in lowered, term
+
+    forbidden_claims = [
+        "production-" + "ready",
+        "marketplace-" + "ready",
+        "stable " + "API",
+        "stable " + "ABI",
+        "KV260 inference " + "works",
+        "Gemma 3N E4B " + "runs on KV260",
+        "20 tok/s " + "achieved",
+        "timing " + "closed",
+        "bitstream " + "ready",
+    ]
+    for claim in forbidden_claims:
+        assert claim.lower() not in lowered, claim
+
+
+def test_source_headers_for_integration_test() -> None:
+    assert TEST_PATH.read_text(encoding="utf-8").splitlines()[:3] == [
+        "#!/usr/bin/env python3",
+        "# SPDX-License-Identifier: Apache-2.0",
+        "# Copyright 2026 pccxai",
+    ]
+
+
+test_full_mock_gemma_w4_path_is_deterministic()
+test_manifest_checksum_matches_packed_bytes()
+test_source_has_offline_and_claim_guards()
+test_source_headers_for_integration_test()
+
+print("full-mock Gemma W4 path integration test ok")

--- a/scripts/tests/gemma_weight_prep_contract_test.py
+++ b/scripts/tests/gemma_weight_prep_contract_test.py
@@ -1,13 +1,16 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 pccxai
-"""Tests for the stage-1 Gemma weight-prep contract."""
+"""Tests for the Gemma weight-prep contract."""
 
 from __future__ import annotations
 
+import hashlib
 import importlib.util
 import sys
 from pathlib import Path
+
+import numpy as np
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -83,14 +86,124 @@ def test_prepare_dummy_is_deterministic_and_seeded() -> None:
     assert manifest_a.tiles[0].packed_nibbles != manifest_c.tiles[0].packed_nibbles
 
 
-def test_real_w4_algo_is_stage_2_only() -> None:
+def test_prepare_real_quantizes_fixture_with_emax_bfp_scales() -> None:
     module = load_module()
-    try:
-        module.GemmaWeightPrep().prepare_real_w4()
-    except NotImplementedError as exc:
-        assert "real algo in stage 2" in str(exc)
-    else:
-        raise AssertionError("expected real W4 path to remain unimplemented")
+    weights = np.array(
+        [
+            [0.0, 1.0, -1.5, 3.25, -4.0],
+            [0.125, -0.25, 0.5, 8.0, -9.25],
+        ],
+        dtype=np.float32,
+    )
+
+    manifest = module.prepare_real(weights, group_size=3)
+
+    assert isinstance(manifest, module.Manifest)
+    assert manifest.schema_version == module.SCHEMA_VERSION
+    assert manifest.model_id == module.REAL_MODEL_ID
+    assert manifest.seed is None
+    assert manifest.source_dtype == "bf16"
+    assert manifest.weight_format == "w4_int4_emax_bfp_pow2"
+    assert manifest.pipeline_label == "prepare_real"
+    assert manifest.real_algo_stage == "stage2"
+    assert manifest.group_size == 3
+    assert manifest.act_scale_policy == module.ACT_SCALE_POLICY
+    assert manifest.hf_touched is False
+    assert manifest.limitations == (
+        "caller_supplied_weights_only",
+        "offline_quantization_only",
+        "no_hf_download_or_weight_load",
+    )
+
+    assert len(manifest.tiles) == 1
+    assert len(manifest.scales) == 1
+    tile = manifest.tiles[0]
+    scale = manifest.scales[0]
+    assert isinstance(tile, module.WeightTile)
+    assert isinstance(scale, module.Scale)
+    assert tile.source_shape == (2, 5)
+    assert tile.tile_shape == (2, 5)
+    assert tile.packed_dtype == "int4_packed_uint8"
+    assert tile.quantization_label == "w4_emax_bfp_pow2"
+    assert scale.dtype == "float32"
+    assert scale.shape == (2, 2)
+    assert scale.values == (0.25, 1.0, 0.125, 2.0)
+    assert scale.quantization_label == "w4_emax_bfp_pow2"
+    assert tile.scale_id == scale.scale_id
+    assert scale.tile_id == tile.tile_id
+
+    expected_packed = bytes.fromhex("403a1c4eb4")
+    expected_sha256 = "276f0bbe6289b92fff8b30b97a69588a33e2ccb96941edad9cd2c42496088af0"
+    assert tile.packed_nibbles == expected_packed
+    assert tile.packed_sha256 == expected_sha256
+    assert manifest.packed_sha256 == expected_sha256
+    assert hashlib.sha256(tile.packed_nibbles).hexdigest() == expected_sha256
+
+
+def test_prepare_real_seeded_numpy_fixture_is_deterministic_and_configurable() -> None:
+    module = load_module()
+    rng = np.random.default_rng(20260507)
+    weights = rng.normal(loc=0.0, scale=1.75, size=(3, 7)).astype(np.float32)
+    prep = module.GemmaWeightPrep()
+
+    manifest_a = prep.prepare_real(weights, group_size=4)
+    manifest_b = prep.prepare_real_w4(weights, group_size=4)
+    manifest_c = prep.prepare_real(weights, group_size=2)
+
+    assert manifest_a == manifest_b
+    assert manifest_a.group_size == 4
+    assert manifest_c.group_size == 2
+    assert manifest_a.scales[0].shape == (3, 2)
+    assert manifest_c.scales[0].shape == (3, 4)
+    assert len(manifest_a.tiles[0].packed_nibbles) == (weights.size + 1) // 2
+    assert len(manifest_c.tiles[0].packed_nibbles) == (weights.size + 1) // 2
+    assert manifest_a.tiles[0].packed_nibbles[-1] >> 4 == 0
+    assert manifest_a.packed_sha256 != manifest_c.packed_sha256
+    assert manifest_a.hf_touched is False
+    assert manifest_c.hf_touched is False
+
+
+def test_prepare_real_accepts_higher_rank_array_like_shapes() -> None:
+    module = load_module()
+    weights = (
+        np.arange(30, dtype=np.float32).reshape(2, 3, 5) / np.float32(8.0)
+    ) - np.float32(1.5)
+
+    manifest = module.GemmaWeightPrep().prepare_real(weights.tolist(), group_size=4)
+
+    assert manifest.tiles[0].source_shape == (2, 3, 5)
+    assert manifest.tiles[0].tile_shape == (2, 3, 5)
+    assert manifest.scales[0].shape == (2, 4)
+    assert len(manifest.scales[0].values) == 8
+    assert len(manifest.tiles[0].packed_nibbles) == (weights.size + 1) // 2
+    assert manifest.hf_touched is False
+
+
+def test_prepare_real_rejects_invalid_inputs() -> None:
+    module = load_module()
+    prep = module.GemmaWeightPrep()
+    valid = np.array([1.0, -1.0], dtype=np.float32)
+
+    for bad_group_size in (0, -1, True, 1.5):
+        try:
+            prep.prepare_real(valid, group_size=bad_group_size)
+        except ValueError as exc:
+            assert "group_size" in str(exc)
+        else:
+            raise AssertionError("expected invalid group_size to fail")
+
+    invalid_weight_sets = (
+        np.array([], dtype=np.float32),
+        np.array([1.0, np.inf], dtype=np.float32),
+        np.array([1.0, np.nan], dtype=np.float32),
+    )
+    for bad_weights in invalid_weight_sets:
+        try:
+            prep.prepare_real(bad_weights)
+        except ValueError as exc:
+            assert "weights" in str(exc)
+        else:
+            raise AssertionError("expected invalid weights to fail")
 
 
 def test_source_has_claim_and_hf_guards() -> None:
@@ -101,6 +214,7 @@ def test_source_has_claim_and_hf_guards() -> None:
         "transformers",
         "huggingface_hub",
         "hf_hub_download",
+        "from_pretrained",
         ".safetensors",
         ".gguf",
         ".pt",
@@ -108,6 +222,9 @@ def test_source_has_claim_and_hf_guards() -> None:
         "open(",
         "read_bytes",
         "read_text",
+        "np.load",
+        "fromfile",
+        "memmap",
         "requests",
         "urllib",
         "subprocess",
@@ -151,7 +268,10 @@ def test_source_headers_for_touched_code_files() -> None:
 
 test_prepare_dummy_seed_42_manifest_invariants()
 test_prepare_dummy_is_deterministic_and_seeded()
-test_real_w4_algo_is_stage_2_only()
+test_prepare_real_quantizes_fixture_with_emax_bfp_scales()
+test_prepare_real_seeded_numpy_fixture_is_deterministic_and_configurable()
+test_prepare_real_accepts_higher_rank_array_like_shapes()
+test_prepare_real_rejects_invalid_inputs()
 test_source_has_claim_and_hf_guards()
 test_source_headers_for_touched_code_files()
 

--- a/scripts/tests/gemma_weight_prep_contract_test.py
+++ b/scripts/tests/gemma_weight_prep_contract_test.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Tests for the stage-1 Gemma weight-prep contract."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "contracts" / "gemma_weight_prep_contract.py"
+TEST_PATH = Path(__file__).resolve()
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location(
+        "gemma_weight_prep_contract",
+        MODULE_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_prepare_dummy_seed_42_manifest_invariants() -> None:
+    module = load_module()
+    manifest = module.GemmaWeightPrep().prepare_dummy(42)
+
+    assert isinstance(manifest, module.Manifest)
+    assert manifest.schema_version == module.SCHEMA_VERSION
+    assert manifest.manifest_id == "gemma_weight_prep_seed_42_dummy"
+    assert manifest.model_id == module.DUMMY_MODEL_ID
+    assert manifest.seed == 42
+    assert manifest.source_dtype == "bf16_dummy"
+    assert manifest.weight_format == "w4_placeholder_dummy"
+    assert manifest.pipeline_label == "prepare_dummy"
+    assert manifest.real_algo_stage == "stage2"
+    assert manifest.hf_touched is False
+    assert "real_w4_algo_in_stage2" in manifest.limitations
+    assert "no_hf_download_or_weight_load" in manifest.limitations
+
+    assert len(manifest.tiles) == 1
+    assert len(manifest.scales) == 1
+    tile = manifest.tiles[0]
+    scale = manifest.scales[0]
+    assert isinstance(tile, module.WeightTile)
+    assert isinstance(scale, module.Scale)
+    assert tile.tile_id.endswith("_dummy")
+    assert scale.scale_id.endswith("_dummy")
+    assert tile.source_dtype == "bf16_dummy"
+    assert tile.source_shape == module.DUMMY_SOURCE_SHAPE
+    assert tile.tile_shape == module.DUMMY_TILE_SHAPE
+    assert tile.packed_dtype == "uint4_packed_dummy"
+    assert tile.quantization_label == "w4_placeholder_quantize_dummy"
+    assert scale.quantization_label == "w4_placeholder_scale_dummy"
+    assert tile.scale_id == scale.scale_id
+    assert scale.tile_id == tile.tile_id
+
+    expected_byte_count = (4 * 8 + 1) // 2
+    assert len(tile.packed_nibbles) == expected_byte_count
+    assert tile.packed_nibbles.hex() == "c3d6e639acddb4768c77b7a1f67236bb"
+    assert manifest.artifact_ids == ("gemma_weight_tile_0_memory_only_dummy",)
+    assert all(artifact.endswith("_dummy") for artifact in manifest.artifact_ids)
+
+
+def test_prepare_dummy_is_deterministic_and_seeded() -> None:
+    module = load_module()
+    prep = module.GemmaWeightPrep()
+    manifest_a = prep.prepare_dummy(42)
+    manifest_b = prep.prepare_dummy(42)
+    manifest_c = prep.prepare_dummy(43)
+
+    assert manifest_a == manifest_b
+    assert manifest_a.tiles[0].packed_nibbles != manifest_c.tiles[0].packed_nibbles
+
+
+def test_real_w4_algo_is_stage_2_only() -> None:
+    module = load_module()
+    try:
+        module.GemmaWeightPrep().prepare_real_w4()
+    except NotImplementedError as exc:
+        assert "real algo in stage 2" in str(exc)
+    else:
+        raise AssertionError("expected real W4 path to remain unimplemented")
+
+
+def test_source_has_claim_and_hf_guards() -> None:
+    source = read_text(MODULE_PATH)
+    lowered_source = source.lower()
+
+    forbidden_runtime_terms = [
+        "transformers",
+        "huggingface_hub",
+        "hf_hub_download",
+        ".safetensors",
+        ".gguf",
+        ".pt",
+        ".pth",
+        "open(",
+        "read_bytes",
+        "read_text",
+        "requests",
+        "urllib",
+        "subprocess",
+        "socket",
+    ]
+    for term in forbidden_runtime_terms:
+        assert term not in lowered_source, term
+
+    forbidden_claims = [
+        "production-ready",
+        "marketplace-ready",
+        "stable API",
+        "stable ABI",
+        "KV260 inference works",
+        "Gemma 3N E4B runs on KV260",
+        "20 tok/s achieved",
+        "timing closed",
+        "bitstream ready",
+    ]
+    scan_text = source.lower()
+    for claim in forbidden_claims:
+        assert claim.lower() not in scan_text, claim
+
+
+def test_source_headers_for_touched_code_files() -> None:
+    expected_headers = {
+        MODULE_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        TEST_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+    }
+    for path, header in expected_headers.items():
+        assert read_text(path).splitlines()[: len(header)] == header, path
+
+
+test_prepare_dummy_seed_42_manifest_invariants()
+test_prepare_dummy_is_deterministic_and_seeded()
+test_real_w4_algo_is_stage_2_only()
+test_source_has_claim_and_hf_guards()
+test_source_headers_for_touched_code_files()
+
+print("gemma weight prep contract tests ok")

--- a/scripts/tests/kv260_serial_connection_test.py
+++ b/scripts/tests/kv260_serial_connection_test.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Tests for the KV260 USB tty serial connection backend."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "contracts" / "kv260_serial_connection.py"
+TEST_PATH = Path(__file__).resolve()
+TEST_PASSWORD_VALUE = "kv260-" + "serial-" + "secret-for-test"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location(
+        "kv260_serial_connection",
+        MODULE_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+class FakeSerial:
+    instances: list["FakeSerial"] = []
+
+    def __init__(self, *args, **kwargs) -> None:
+        self.args = args
+        self.kwargs = kwargs
+        self.writes: list[bytes] = []
+        self.closed = False
+        self.reads = list(type(self).reads)
+        type(self).instances.append(self)
+
+    reads: list[bytes] = []
+
+    def read(self, _size: int) -> bytes:
+        if self.reads:
+            return self.reads.pop(0)
+        return b""
+
+    def write(self, payload: bytes) -> int:
+        self.writes.append(payload)
+        return len(payload)
+
+    def flush(self) -> None:
+        return None
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def reset_fake(reads: list[bytes]) -> None:
+    FakeSerial.instances = []
+    FakeSerial.reads = reads
+
+
+def test_type_contract_and_env_presence_only() -> None:
+    module = load_module()
+    fake_env = {
+        "KVFPGA_HOST": "ignored-host.example.invalid",
+        "KVFPGA_TTY": "/dev/ttyUSB-kv260-test",
+        "KVFPGA_USER": "kv260-user-for-test",
+        "KVFPGA_PASSWORD": TEST_PASSWORD_VALUE,
+    }
+    connection = module.KV260SerialConnection.from_env(
+        fake_env,
+        serial_factory=FakeSerial,
+    )
+    rendered = repr(connection)
+
+    assert isinstance(connection, module.KV260ConnectionProtocol)
+    assert connection.is_configured() is True
+    assert connection.tty_configured is True
+    assert connection.user_configured is True
+    assert connection.password_configured is True
+    assert "ignored-host" not in rendered
+    assert fake_env["KVFPGA_TTY"] not in rendered
+    assert fake_env["KVFPGA_USER"] not in rendered
+    assert fake_env["KVFPGA_PASSWORD"] not in rendered
+
+
+def test_tty_override_and_auto_detect_helpers() -> None:
+    module = load_module()
+
+    assert module.kv260_tty_candidates({"KVFPGA_TTY": "/tmp/tty-kv260"}) == (
+        "/tmp/tty-kv260",
+    )
+    assert module.detect_kv260_tty({"KVFPGA_TTY": "/tmp/tty-kv260"}) == (
+        "/tmp/tty-kv260"
+    )
+    assert isinstance(module.kv260_tty_candidates({}), tuple)
+
+
+def test_reachable_accepts_login_or_shell_prompt() -> None:
+    module = load_module()
+    fake_env = {"KVFPGA_TTY": "/tmp/tty-kv260"}
+
+    reset_fake([b"kv260 login: "])
+    login_connection = module.KV260SerialConnection.from_env(
+        fake_env,
+        serial_factory=FakeSerial,
+    )
+    assert login_connection.is_reachable() is True
+    assert FakeSerial.instances[-1].closed is True
+
+    reset_fake([b"root@kv260:~$ "])
+    shell_connection = module.KV260SerialConnection.from_env(
+        fake_env,
+        serial_factory=FakeSerial,
+    )
+    assert shell_connection.is_reachable() is True
+    assert FakeSerial.instances[-1].closed is True
+
+
+def test_login_uname_and_logout_over_serial() -> None:
+    module = load_module()
+    fake_env = {
+        "KVFPGA_TTY": "/tmp/tty-kv260",
+        "KVFPGA_USER": "kv260-user-for-test",
+        "KVFPGA_PASSWORD": TEST_PASSWORD_VALUE,
+    }
+    reset_fake(
+        [
+            b"kv260 login: ",
+            b"Password: ",
+            b"root@kv260:~$ ",
+            (
+                b"root@kv260:~$ uname -a; printf "
+                b"'\\n__PCCX_KV260_SERIAL_DONE__:%s\\n' \"$?\"\r\n"
+                b"Linux kv260 6.6.0-test #1 SMP PREEMPT aarch64 GNU/Linux\r\n"
+                b"__PCCX_KV260_SERIAL_DONE__:0\r\n"
+                b"root@kv260:~$ "
+            ),
+        ],
+    )
+    connection = module.KV260SerialConnection.from_env(
+        fake_env,
+        serial_factory=FakeSerial,
+    )
+
+    assert connection.kernel_uname() == (
+        "Linux kv260 6.6.0-test #1 SMP PREEMPT aarch64 GNU/Linux"
+    )
+    writes = b"".join(FakeSerial.instances[-1].writes)
+    assert b"uname -a" in writes
+    assert writes.endswith(b"exit\r\n")
+    assert FakeSerial.instances[-1].closed is True
+
+
+def test_xrt_present_and_xmutil_listapps_use_serial_commands() -> None:
+    module = load_module()
+    fake_env = {
+        "KVFPGA_TTY": "/tmp/tty-kv260",
+        "KVFPGA_USER": "kv260-user-for-test",
+        "KVFPGA_PASSWORD": TEST_PASSWORD_VALUE,
+    }
+
+    reset_fake([b"$ ", b"__PCCX_KV260_SERIAL_DONE__:0\r\n$ "])
+    connection = module.KV260SerialConnection.from_env(
+        fake_env,
+        serial_factory=FakeSerial,
+    )
+    assert connection.xrt_present() is True
+
+    reset_fake(
+        [
+            b"$ ",
+            (
+                b"$ xmutil listapps; printf "
+                b"'\\n__PCCX_KV260_SERIAL_DONE__:%s\\n' \"$?\"\r\n"
+                b"accelerated_app\r\n"
+                b"diagnostic_app\r\n"
+                b"__PCCX_KV260_SERIAL_DONE__:0\r\n$ "
+            ),
+        ],
+    )
+    listapps_connection = module.KV260SerialConnection.from_env(
+        fake_env,
+        serial_factory=FakeSerial,
+    )
+    assert listapps_connection.xmutil_listapps() == (
+        "accelerated_app",
+        "diagnostic_app",
+    )
+
+
+def test_live_serial_probe_skips_gracefully_without_tty() -> None:
+    module = load_module()
+    tty = module.detect_kv260_tty()
+    if tty is None:
+        print("skip: no KV260 tty device detected")
+        return
+    try:
+        import serial  # type: ignore[import-not-found]  # noqa: F401
+    except ImportError:
+        print("skip: pyserial is not installed")
+        return
+    if not os.environ.get("KVFPGA_USER") or not os.environ.get("KVFPGA_PASSWORD"):
+        print("skip: KVFPGA serial credentials are incomplete")
+        return
+
+    connection = module.KV260SerialConnection.from_env()
+    assert isinstance(connection.is_reachable(), bool)
+
+
+def test_source_has_no_credential_leaks_or_unsupported_paths() -> None:
+    source = read_text(MODULE_PATH)
+    test_source = read_text(TEST_PATH)
+    scan_text = source
+
+    forbidden_terms = [
+        "param" + "iko",
+        "s" + "cp ",
+        "subprocess",
+        "os.system",
+        "popen",
+        "socket",
+        "requests",
+        "urllib",
+        "transformers",
+        "huggingface_hub",
+        "/dev/mem",
+    ]
+    lowered_source = source.lower()
+    for term in forbidden_terms:
+        assert term not in lowered_source, term
+
+    assert "print(" not in source
+    assert "logging." not in source
+    assert TEST_PASSWORD_VALUE not in source
+    assert ("serial-" + "secret-for-test") not in test_source
+
+    forbidden_claims = [
+        "production-" + "ready",
+        "marketplace-" + "ready",
+        "stable " + "API",
+        "stable " + "ABI",
+        "KV260 inference " + "works",
+        "Gemma 3N E4B " + "runs on KV260",
+        "20 tok/s " + "achieved",
+        "timing " + "closed",
+        "bitstream " + "ready",
+    ]
+    lowered = scan_text.lower()
+    for claim in forbidden_claims:
+        assert claim.lower() not in lowered, claim
+
+    assert not re.search(r"\bssh\s+[^\"']+", source, re.IGNORECASE)
+
+
+def test_source_headers_for_touched_python_files() -> None:
+    expected_headers = {
+        MODULE_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        TEST_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+    }
+    for path, header in expected_headers.items():
+        assert read_text(path).splitlines()[: len(header)] == header, path
+
+
+test_type_contract_and_env_presence_only()
+test_tty_override_and_auto_detect_helpers()
+test_reachable_accepts_login_or_shell_prompt()
+test_login_uname_and_logout_over_serial()
+test_xrt_present_and_xmutil_listapps_use_serial_commands()
+test_live_serial_probe_skips_gracefully_without_tty()
+test_source_has_no_credential_leaks_or_unsupported_paths()
+test_source_headers_for_touched_python_files()
+
+print("kv260 serial connection tests ok")

--- a/scripts/tests/token_stream_over_serial_test.py
+++ b/scripts/tests/token_stream_over_serial_test.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Tests for first-pass token streaming over the KV260 serial tty."""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+MODULE_PATH = ROOT / "contracts" / "token_stream_over_serial.py"
+TEST_PATH = Path(__file__).resolve()
+
+from contracts.axi_cmd_channel import AxiCmdMockBackend, NpuCmd, NpuStat
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location(
+        "token_stream_over_serial",
+        MODULE_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+class FakeSerial:
+    instances: list["FakeSerial"] = []
+    reads: list[bytes] = []
+
+    def __init__(self, *args, **kwargs) -> None:
+        self.args = args
+        self.kwargs = kwargs
+        self.writes: list[bytes] = []
+        self.closed = False
+        self.reads = list(type(self).reads)
+        type(self).instances.append(self)
+
+    def read(self, _size: int) -> bytes:
+        if self.reads:
+            return self.reads.pop(0)
+        return b""
+
+    def write(self, payload: bytes) -> int:
+        self.writes.append(payload)
+        return len(payload)
+
+    def flush(self) -> None:
+        return None
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def reset_fake(reads: list[bytes] | None = None) -> None:
+    FakeSerial.instances = []
+    FakeSerial.reads = list(reads or [])
+
+
+def make_connection(module, fake_env: dict[str, str] | None = None):
+    env = fake_env or {"KVFPGA_TTY": "/tmp/tty-kv260-token-test"}
+    return module.KV260SerialConnection.from_env(
+        env,
+        serial_factory=FakeSerial,
+    )
+
+
+def test_type_contract_runs_without_tty_or_board() -> None:
+    module = load_module()
+    reset_fake()
+    stream = module.TokenStreamOverSerial(connection=make_connection(module))
+
+    assert isinstance(stream, module.TokenStreamProtocol)
+    assert stream.eos_token_id == module.DEFAULT_EOS_TOKEN_ID
+    assert stream.chunk_token_count == module.DEFAULT_CHUNK_TOKEN_COUNT
+
+
+def test_input_tokens_use_marker_wrapped_length_prefixed_binary_chunks() -> None:
+    module = load_module()
+    payload = module.encode_input_stream([2, 65536, 9], chunk_token_count=2)
+
+    assert payload.startswith(module.INPUT_BEGIN_MARKER)
+    assert payload.endswith(module.INPUT_END_MARKER)
+    assert payload.count(module.INPUT_CHUNK_TAG) == 2
+    assert b"\x00\x00\x00\x08\x00\x00\x00\x02\x00\x01\x00\x00" in payload
+    assert b"\x00\x00\x00\x04\x00\x00\x00\x09" in payload
+
+
+def test_mock_axi_backend_simulates_full_round_trip() -> None:
+    module = load_module()
+    reset_fake([module.encode_output_stream([201, 202, module.DEFAULT_EOS_TOKEN_ID])])
+    commands = [
+        (
+            NpuCmd(module.OP_BEGIN_INPUT, arg0=3),
+            NpuStat(completion_count=1, last_opcode=module.OP_BEGIN_INPUT),
+        ),
+        (
+            NpuCmd(module.OP_END_INPUT, arg0=3),
+            NpuStat(completion_count=2, last_opcode=module.OP_END_INPUT),
+        ),
+        (
+            NpuCmd(module.OP_READ_OUTPUT, arg0=0),
+            NpuStat(completion_count=3, last_opcode=module.OP_READ_OUTPUT),
+        ),
+    ]
+
+    with AxiCmdMockBackend(commands) as axi:
+        stream = module.TokenStreamOverSerial(
+            connection=make_connection(module),
+            axi_channel=axi,
+        )
+        output_tokens = stream.infer([101, 102, 103])
+        axi.assert_script_consumed()
+
+    assert output_tokens == [201, 202, module.DEFAULT_EOS_TOKEN_ID]
+    assert len(FakeSerial.instances) == 1
+    written = b"".join(FakeSerial.instances[0].writes)
+    assert written == module.encode_input_stream([101, 102, 103])
+    assert FakeSerial.instances[0].closed is True
+
+
+def test_recv_output_tokens_returns_partial_tokens_on_timeout() -> None:
+    module = load_module()
+    reset_fake([module.OUTPUT_BEGIN_MARKER])
+    stream = module.TokenStreamOverSerial(connection=make_connection(module))
+
+    assert stream.recv_output_tokens(timeout_s=0.01) == []
+    assert FakeSerial.instances[-1].closed is True
+
+
+def test_live_serial_probe_skips_without_tty() -> None:
+    module = load_module()
+    tty = module.detect_kv260_tty()
+    if tty is None:
+        print("skip: no KV260 tty device detected")
+        return
+    try:
+        import serial  # type: ignore[import-not-found]  # noqa: F401
+    except ImportError:
+        print("skip: pyserial is not installed")
+        return
+
+    stream = module.TokenStreamOverSerial.from_env()
+    assert isinstance(stream, module.TokenStreamProtocol)
+
+
+def test_source_has_no_credential_leaks_or_unsupported_paths() -> None:
+    source = read_text(MODULE_PATH)
+    test_source = read_text(TEST_PATH)
+    scan_text = source + "\n" + test_source
+
+    forbidden_terms = [
+        "param" + "iko",
+        "s" + "cp ",
+        "subprocess",
+        "os.system",
+        "popen",
+        "socket",
+        "requests",
+        "urllib",
+        "transformers",
+        "huggingface_hub",
+        "/dev/mem",
+    ]
+    lowered_source = source.lower()
+    for term in forbidden_terms:
+        assert term not in lowered_source, term
+
+    forbidden_claims = [
+        "production-" + "ready",
+        "marketplace-" + "ready",
+        "stable " + "API",
+        "stable " + "ABI",
+        "KV260 inference " + "works",
+        "Gemma 3N E4B " + "runs on KV260",
+        "20 tok/s " + "achieved",
+        "timing " + "closed",
+        "bitstream " + "ready",
+    ]
+    lowered = scan_text.lower()
+    for claim in forbidden_claims:
+        assert claim.lower() not in lowered, claim
+
+    assert not re.search(r"\bssh\s+[^\"']+", source, re.IGNORECASE)
+
+
+def test_source_headers_for_touched_python_files() -> None:
+    expected_headers = {
+        MODULE_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+        TEST_PATH: [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ],
+    }
+    for path, header in expected_headers.items():
+        assert read_text(path).splitlines()[: len(header)] == header, path
+
+
+test_type_contract_runs_without_tty_or_board()
+test_input_tokens_use_marker_wrapped_length_prefixed_binary_chunks()
+test_mock_axi_backend_simulates_full_round_trip()
+test_recv_output_tokens_returns_partial_tokens_on_timeout()
+test_live_serial_probe_skips_without_tty()
+test_source_has_no_credential_leaks_or_unsupported_paths()
+test_source_headers_for_touched_python_files()
+
+print("token stream over serial tests ok")


### PR DESCRIPTION
## Summary
- Merge the offline mock component branches used by refs #74, #83, and #84.
- Add a full-mock Gemma W4 integration test using a fixed caller-supplied tensor, prepare_real(group_size=64), packed manifest bytes, AxiCmdMockBackend, and TokenStreamOverSerial with fake serial output.
- Assert deterministic repeated runs, stable packed SHA256, exact packed bytes, scripted AXI command consumption, and encoded token-stream payloads without a board or external model assets.
- Add the integration test to CI.

## Validation
- python3 scripts/tests/full_mock_gemma_path_integration_test.py
- python3 scripts/tests/gemma_weight_prep_contract_test.py
- python3 scripts/tests/axi_cmd_mock_backend_test.py
- python3 scripts/tests/token_stream_over_serial_test.py
- python3 -m compileall -q contracts scripts/tests
- bash -n scripts/*.sh scripts/tests/*.sh
- git diff --check
- claim-scan clean
- for test in scripts/tests/*_test.py; do python3 "$test"; done

Refs #74 #83 #84