### PR TITLE
feat(gemma): mock end-to-end orchestrator + chat cli

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,6 +307,8 @@ jobs:
         run: ./scripts/chat-surface-preview.sh --model gemma3n-e4b --target kv260
       - name: run scripts/chat-stub.sh --dry-run
         run: ./scripts/chat-stub.sh --dry-run --prompt "hello"
+      - name: run pccx-launcher Gemma mock chat
+        run: ./pccx-launcher gemma chat --prompt "hello"
       - name: chat-stub refuses without --dry-run
         run: |
           set -e
@@ -333,6 +335,12 @@ jobs:
         run: python3 scripts/tests/token_stream_over_serial_test.py
       - name: run full-mock Gemma W4 path integration tests
         run: python3 scripts/tests/full_mock_gemma_path_integration_test.py
+      - name: run Gemma tokenizer and arch spec tests
+        run: python3 scripts/tests/gemma_tokenizer_arch_spec_test.py
+      - name: run Gemma E2E orchestrator tests
+        run: python3 scripts/tests/gemma_e2e_orchestrator_test.py
+      - name: run pccx-launcher CLI tests
+        run: python3 scripts/tests/pccx_launcher_cli_test.py
       - name: run chat/session contract tests
         run: python3 scripts/tests/chat_session_contract_test.py
       - name: run chat model status contract tests

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ and verify host-side prerequisites before the real engine lands.
 | [`scripts/chat-audit-event-stub.sh`](./scripts/chat-audit-event-stub.sh) | Data-only chat audit-event JSON for the Gemma 3N E4B + KV260 target. Reports blocked send metadata, redaction policy, absent prompt/response/transcript content, and disabled audit persistence. |
 | [`scripts/chat-error-taxonomy-stub.sh`](./scripts/chat-error-taxonomy-stub.sh) | Data-only chat error taxonomy JSON for the Gemma 3N E4B + KV260 target. Groups blocked readiness, model/runtime, session, and policy errors without reading prompts, providers, configs, model paths, logs, stores, or artifacts. |
 | [`scripts/chat-surface-preview.sh`](./scripts/chat-surface-preview.sh) | Read-only terminal preview of the standalone chat surface. Renders the checked chat/session contract as blocked UI state without accepting prompts, executing a model, or writing artifacts. |
+| [`pccx-launcher`](./pccx-launcher) | Local CLI helper. `pccx-launcher gemma chat --prompt "..."` runs a deterministic mock-only Gemma path through tokenizer, W4 prep, scripted serial token stream, AXI mock, and decode; it does not touch a board, load HF assets, or use the real serial path. |
 | [`scripts/launch-stub.sh`](./scripts/launch-stub.sh) | Dry-run preview of the intended launch sequence. Requires `--dry-run`; exits 1 without it. |
 | [`scripts/chat-stub.sh`](./scripts/chat-stub.sh) | Dry-run chat stub. Requires `--dry-run`; exits 1 without it. Accepts `--prompt "..."` or stdin. No model is executed. |
 
@@ -196,6 +197,7 @@ bash scripts/chat-review-packet-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-gap-matrix-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-evidence-manifest-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-surface-preview.sh --model gemma3n-e4b --target kv260
+./pccx-launcher gemma chat --prompt "hello"
 bash scripts/launch-stub.sh --dry-run
 bash scripts/chat-stub.sh --dry-run --prompt "hello"
 ```

--- a/contracts/gemma_arch_spec.py
+++ b/contracts/gemma_arch_spec.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Offline Gemma architecture spec used by launcher-side mock paths."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+DEFAULT_MODEL_ID = "gemma3n-e4b"
+DEFAULT_TARGET = "kv260"
+DEFAULT_CONTEXT_LENGTH = 8192
+DEFAULT_VOCAB_SIZE = 32000
+DEFAULT_EOS_TOKEN_ID = 1
+DEFAULT_BOS_TOKEN_ID = 2
+DEFAULT_BYTE_TOKEN_OFFSET = 256
+DEFAULT_GROUP_SIZE = 64
+
+
+@dataclass(frozen=True)
+class GemmaArchSpec:
+    """Small validated config object for Gemma launcher mock orchestration."""
+
+    model_id: str = DEFAULT_MODEL_ID
+    target: str = DEFAULT_TARGET
+    context_length: int = DEFAULT_CONTEXT_LENGTH
+    vocab_size: int = DEFAULT_VOCAB_SIZE
+    eos_token_id: int = DEFAULT_EOS_TOKEN_ID
+    bos_token_id: int = DEFAULT_BOS_TOKEN_ID
+    byte_token_offset: int = DEFAULT_BYTE_TOKEN_OFFSET
+    w4_group_size: int = DEFAULT_GROUP_SIZE
+
+    def __post_init__(self) -> None:
+        if not self.model_id:
+            raise ValueError("model_id must be non-empty")
+        if not self.target:
+            raise ValueError("target must be non-empty")
+        for field_name in (
+            "context_length",
+            "vocab_size",
+            "eos_token_id",
+            "bos_token_id",
+            "byte_token_offset",
+            "w4_group_size",
+        ):
+            value = getattr(self, field_name)
+            if isinstance(value, bool) or not isinstance(value, int):
+                raise TypeError(f"{field_name} must be an int")
+            if value <= 0:
+                raise ValueError(f"{field_name} must be positive")
+        if self.byte_token_offset + 255 >= self.vocab_size:
+            raise ValueError("byte token range must fit vocab_size")
+        if self.bos_token_id == self.eos_token_id:
+            raise ValueError("BOS and EOS token IDs must differ")
+
+
+def default_gemma3n_e4b_kv260_arch_spec() -> GemmaArchSpec:
+    """Return the default local Gemma 3N E4B plus KV260 mock config."""
+
+    return GemmaArchSpec()

--- a/contracts/gemma_e2e_orchestrator.py
+++ b/contracts/gemma_e2e_orchestrator.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Mock-only Gemma end-to-end launcher orchestrator."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import Any, Sequence
+
+import numpy as np
+
+from contracts.axi_cmd_channel import AxiCmdChannel, AxiCmdMockBackend, NpuCmd, NpuStat
+from contracts.gemma_arch_spec import GemmaArchSpec, default_gemma3n_e4b_kv260_arch_spec
+from contracts.gemma_tokenizer import GemmaTokenizer
+from contracts.gemma_weight_prep_contract import GemmaWeightPrep, Manifest
+from contracts.kv260_connection_mock import KV260ConnectionMock
+from contracts.kv260_serial_connection import KV260ConnectionProtocol, KV260SerialConnection
+from contracts.token_stream_over_serial import (
+    OP_BEGIN_INPUT,
+    OP_END_INPUT,
+    OP_READ_OUTPUT,
+    TokenStreamOverSerial,
+    encode_output_stream,
+)
+
+
+OP_LOAD_W4_MANIFEST = 0x40
+MOCK_TTY = "/tmp/pccx-gemma-e2e-mock"
+
+
+class GemmaE2EOrchestratorError(RuntimeError):
+    """Raised when the mock Gemma orchestration path cannot continue."""
+
+
+class RealSerialGemmaE2ENotImplemented(NotImplementedError):
+    """Raised when callers request the future real serial path."""
+
+
+@dataclass(frozen=True)
+class GemmaE2EResult:
+    """Observable output from one Gemma mock orchestration run."""
+
+    output_text: str
+    prompt_tokens: tuple[int, ...]
+    output_tokens: tuple[int, ...]
+    manifest_id: str
+    manifest_sha256: str
+    serial_payload: bytes
+    axi_completion_count: int
+
+
+class ScriptedSerialSession:
+    """Small serial-session fake used by TokenStreamOverSerial in mock mode."""
+
+    def __init__(self, read_chunks: Sequence[bytes]) -> None:
+        self.reads = list(read_chunks)
+        self.writes: list[bytes] = []
+        self.closed = False
+
+    def read(self, _size: int) -> bytes:
+        if self.reads:
+            return self.reads.pop(0)
+        return b""
+
+    def write(self, payload: bytes) -> int:
+        self.writes.append(payload)
+        return len(payload)
+
+    def flush(self) -> None:
+        return None
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class ScriptedSerialFactory:
+    """Factory that records mock serial sessions created by the stream layer."""
+
+    def __init__(self, read_chunks: Sequence[bytes]) -> None:
+        self.read_chunks = list(read_chunks)
+        self.instances: list[ScriptedSerialSession] = []
+
+    def __call__(self, *args: Any, **kwargs: Any) -> ScriptedSerialSession:
+        session = ScriptedSerialSession(self.read_chunks)
+        self.instances.append(session)
+        return session
+
+    def written_payload(self) -> bytes:
+        """Return all bytes written across created mock sessions."""
+
+        return b"".join(
+            payload for session in self.instances for payload in session.writes
+        )
+
+
+@dataclass
+class GemmaE2EOrchestrator:
+    """Wire tokenizer, W4 prep, token stream, and decode for mock Gemma chat."""
+
+    arch_spec: GemmaArchSpec
+    connection: KV260ConnectionProtocol
+    tokenizer: GemmaTokenizer
+    token_stream: TokenStreamOverSerial
+    weight_prep: GemmaWeightPrep
+    serial_factory: ScriptedSerialFactory | None = None
+    axi_backend: AxiCmdMockBackend | None = None
+
+    @classmethod
+    def create_mock(
+        cls,
+        prompt: str,
+        arch_spec: GemmaArchSpec | None = None,
+    ) -> "GemmaE2EOrchestrator":
+        """Create a full offline mock path with scripted serial and AXI replies."""
+
+        spec = arch_spec or default_gemma3n_e4b_kv260_arch_spec()
+        tokenizer = GemmaTokenizer(spec)
+        prompt_tokens = tokenizer.encode(prompt)
+        manifest = _prepare_mock_manifest(spec)
+        reply_tokens = tokenizer.encode_generated_text(
+            deterministic_mock_reply(prompt, spec, manifest),
+        )
+        serial_factory = ScriptedSerialFactory([encode_output_stream(reply_tokens)])
+        axi = AxiCmdMockBackend(_scripted_axi_replies(prompt_tokens, manifest, spec))
+        serial_connection = KV260SerialConnection.from_env(
+            {"KVFPGA_TTY": MOCK_TTY},
+            serial_factory=serial_factory,
+        )
+        stream = TokenStreamOverSerial(
+            connection=serial_connection,
+            axi_channel=axi,
+            eos_token_id=spec.eos_token_id,
+            output_timeout_s=0.05,
+        )
+        return cls(
+            arch_spec=spec,
+            connection=KV260ConnectionMock.happy_path(),
+            tokenizer=tokenizer,
+            token_stream=stream,
+            weight_prep=GemmaWeightPrep(),
+            serial_factory=serial_factory,
+            axi_backend=axi,
+        )
+
+    @classmethod
+    def create_real_serial_stub(
+        cls,
+        _arch_spec: GemmaArchSpec | None = None,
+    ) -> "GemmaE2EOrchestrator":
+        """Future real serial path placeholder."""
+
+        raise RealSerialGemmaE2ENotImplemented(
+            "real Gemma serial orchestration is stubbed pending board evidence",
+        )
+
+    def run(self, prompt: str) -> GemmaE2EResult:
+        """Run prompt -> encode -> send -> poll/recv -> decode in mock mode."""
+
+        if not self.connection.is_reachable():
+            raise GemmaE2EOrchestratorError("KV260 connection is not reachable")
+
+        manifest = self.weight_prep.prepare_real(
+            _mock_weights_for_arch(self.arch_spec),
+            group_size=self.arch_spec.w4_group_size,
+        )
+        self._issue_manifest_load(manifest)
+        prompt_tokens = self.tokenizer.encode(prompt)
+        output_tokens = self.token_stream.infer(prompt_tokens)
+        output_text = self.tokenizer.decode(output_tokens)
+
+        if self.axi_backend is not None:
+            self.axi_backend.assert_script_consumed()
+
+        return GemmaE2EResult(
+            output_text=output_text,
+            prompt_tokens=tuple(prompt_tokens),
+            output_tokens=tuple(output_tokens),
+            manifest_id=manifest.manifest_id,
+            manifest_sha256=manifest.packed_sha256,
+            serial_payload=(
+                self.serial_factory.written_payload()
+                if self.serial_factory is not None
+                else b""
+            ),
+            axi_completion_count=(
+                self.axi_backend.completion_count
+                if self.axi_backend is not None
+                else 0
+            ),
+        )
+
+    def _issue_manifest_load(self, manifest: Manifest) -> None:
+        axi_channel = self.token_stream.axi_channel
+        if axi_channel is None:
+            return
+        cmd = _manifest_load_cmd(manifest, self.arch_spec)
+        axi_channel.issue(cmd)
+        stat = axi_channel.poll_stat()
+        if stat.error:
+            raise GemmaE2EOrchestratorError(
+                f"manifest load failed with status {stat.status_code}",
+            )
+
+
+def run_mock_gemma_chat(
+    prompt: str,
+    arch_spec: GemmaArchSpec | None = None,
+) -> GemmaE2EResult:
+    """Convenience entry point for the CLI mock chat path."""
+
+    orchestrator = GemmaE2EOrchestrator.create_mock(prompt, arch_spec)
+    return orchestrator.run(prompt)
+
+
+def deterministic_mock_reply(
+    prompt: str,
+    arch_spec: GemmaArchSpec,
+    manifest: Manifest,
+) -> str:
+    """Return stable local mock output text for a prompt/config pair."""
+
+    digest = hashlib.sha256(
+        "|".join(
+            [
+                arch_spec.model_id,
+                arch_spec.target,
+                manifest.packed_sha256,
+                prompt,
+            ],
+        ).encode("utf-8"),
+    ).hexdigest()
+    return f"mock-gemma:{digest[:16]}"
+
+
+def _prepare_mock_manifest(arch_spec: GemmaArchSpec) -> Manifest:
+    return GemmaWeightPrep().prepare_real(
+        _mock_weights_for_arch(arch_spec),
+        group_size=arch_spec.w4_group_size,
+    )
+
+
+def _mock_weights_for_arch(arch_spec: GemmaArchSpec) -> np.ndarray:
+    seed = hashlib.sha256(
+        f"{arch_spec.model_id}|{arch_spec.target}|{arch_spec.w4_group_size}".encode(
+            "utf-8",
+        ),
+    ).digest()
+    values = [((seed[index] % 17) - 8) / 2.0 for index in range(16)]
+    return np.asarray(values, dtype=np.float32).reshape(2, 8)
+
+
+def _scripted_axi_replies(
+    prompt_tokens: Sequence[int],
+    manifest: Manifest,
+    arch_spec: GemmaArchSpec,
+) -> tuple[tuple[NpuCmd, NpuStat], ...]:
+    commands = (
+        _manifest_load_cmd(manifest, arch_spec),
+        NpuCmd(opcode=OP_BEGIN_INPUT, arg0=len(prompt_tokens)),
+        NpuCmd(opcode=OP_END_INPUT, arg0=len(prompt_tokens)),
+        NpuCmd(opcode=OP_READ_OUTPUT, arg0=0),
+    )
+    return tuple(
+        (
+            cmd,
+            NpuStat(completion_count=index + 1, last_opcode=cmd.opcode),
+        )
+        for index, cmd in enumerate(commands)
+    )
+
+
+def _manifest_load_cmd(manifest: Manifest, arch_spec: GemmaArchSpec) -> NpuCmd:
+    packed_len = sum(len(tile.packed_nibbles) for tile in manifest.tiles)
+    checksum_prefix = int(manifest.packed_sha256[:8], 16)
+    return NpuCmd(
+        opcode=OP_LOAD_W4_MANIFEST,
+        arg0=packed_len,
+        arg1=arch_spec.w4_group_size,
+        arg2=checksum_prefix,
+    )

--- a/contracts/gemma_tokenizer.py
+++ b/contracts/gemma_tokenizer.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Deterministic local tokenizer shim for Gemma mock orchestration.
+
+This tokenizer is intentionally byte-level and local-only. It does not load
+SentencePiece, Hugging Face assets, model files, or tokenizer configuration.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+from contracts.gemma_arch_spec import GemmaArchSpec
+
+
+class GemmaTokenizerError(ValueError):
+    """Raised when token IDs cannot be encoded or decoded."""
+
+
+@dataclass(frozen=True)
+class GemmaTokenizer:
+    """Byte-level deterministic tokenizer for offline Gemma launcher tests."""
+
+    arch_spec: GemmaArchSpec
+
+    def encode(self, text: str) -> list[int]:
+        """Encode prompt text to local mock token IDs."""
+
+        if not isinstance(text, str):
+            raise TypeError("text must be a string")
+        byte_values = text.encode("utf-8")
+        tokens = [self.arch_spec.bos_token_id]
+        tokens.extend(self.arch_spec.byte_token_offset + value for value in byte_values)
+        tokens.append(self.arch_spec.eos_token_id)
+        if len(tokens) > self.arch_spec.context_length:
+            raise GemmaTokenizerError("encoded prompt exceeds context_length")
+        return tokens
+
+    def encode_generated_text(self, text: str) -> list[int]:
+        """Encode generated text without adding a BOS token."""
+
+        if not isinstance(text, str):
+            raise TypeError("text must be a string")
+        tokens = [
+            self.arch_spec.byte_token_offset + value
+            for value in text.encode("utf-8")
+        ]
+        tokens.append(self.arch_spec.eos_token_id)
+        return tokens
+
+    def decode(self, token_ids: Sequence[int]) -> str:
+        """Decode mock output token IDs to text, stopping at EOS."""
+
+        byte_values: list[int] = []
+        for token_id in token_ids:
+            if not isinstance(token_id, int):
+                raise TypeError("token IDs must be integers")
+            if token_id == self.arch_spec.eos_token_id:
+                break
+            if token_id == self.arch_spec.bos_token_id:
+                continue
+            value = token_id - self.arch_spec.byte_token_offset
+            if value < 0 or value > 255:
+                raise GemmaTokenizerError(f"token ID is outside byte range: {token_id}")
+            byte_values.append(value)
+        return bytes(byte_values).decode("utf-8", errors="strict")

--- a/contracts/kv260_connection_mock.py
+++ b/contracts/kv260_connection_mock.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Board-less KV260 connection mock for launcher integration tests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+from contracts.kv260_serial_connection import KV260ConnectionProtocol
+
+
+@dataclass(frozen=True)
+class KV260MockBoardState:
+    """In-memory KV260 board state returned by the mock connection."""
+
+    kernel_uname: str
+    xrt_present: bool
+    xrt_version: str
+    xmutil_listapps: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if not self.kernel_uname:
+            raise ValueError("kernel_uname must be non-empty")
+        if not isinstance(self.xrt_present, bool):
+            raise TypeError("xrt_present must be a bool")
+        if not isinstance(self.xrt_version, str):
+            raise TypeError("xrt_version must be a string")
+        if not all(isinstance(app, str) and app for app in self.xmutil_listapps):
+            raise ValueError("xmutil_listapps must contain non-empty strings")
+
+
+@dataclass(frozen=True)
+class KV260ConnectionMock(KV260ConnectionProtocol):
+    """Board-less implementation of the KV260 connection method contract."""
+
+    state: KV260MockBoardState
+
+    @classmethod
+    def happy_path(cls) -> "KV260ConnectionMock":
+        """Build the default reachable board-less target."""
+
+        return cls.from_state(
+            kernel_uname=(
+                "Linux kv260-mock 6.6.0-pccx-mock #1 SMP PREEMPT "
+                "aarch64 GNU/Linux"
+            ),
+            xrt_present=True,
+            xrt_version="XRT mock 2.16.0",
+            xmutil_listapps=("app: pccx-npu", "app: diagnostics"),
+        )
+
+    @classmethod
+    def from_state(
+        cls,
+        *,
+        kernel_uname: str,
+        xrt_present: bool | None = None,
+        xrt_version: str = "",
+        xmutil_listapps: Sequence[str] = (),
+    ) -> "KV260ConnectionMock":
+        """Build a mock directly from in-memory state."""
+
+        if xrt_present is None:
+            xrt_present = bool(xrt_version)
+        return cls(
+            KV260MockBoardState(
+                kernel_uname=kernel_uname,
+                xrt_present=xrt_present,
+                xrt_version=xrt_version,
+                xmutil_listapps=tuple(xmutil_listapps),
+            ),
+        )
+
+    def is_reachable(self) -> bool:
+        """Return true for board-less tests without touching hardware."""
+
+        return True
+
+    def kernel_uname(self) -> str:
+        """Return the configured mock uname string."""
+
+        return self.state.kernel_uname
+
+    def xrt_present(self) -> bool:
+        """Return the configured mock XRT availability."""
+
+        return self.state.xrt_present
+
+    def xrt_version(self) -> str:
+        """Return the configured mock XRT version string."""
+
+        return self.state.xrt_version
+
+    def xmutil_listapps(self) -> Sequence[str]:
+        """Return the configured mock xmutil listapps output lines."""
+
+        return self.state.xmutil_listapps

--- a/pccx-launcher
+++ b/pccx-launcher
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Command-line entry point for local pccx launcher helpers."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from contracts.gemma_e2e_orchestrator import (
+    RealSerialGemmaE2ENotImplemented,
+    run_mock_gemma_chat,
+)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(prog="pccx-launcher")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    gemma = subparsers.add_parser("gemma")
+    gemma_subparsers = gemma.add_subparsers(dest="gemma_command", required=True)
+
+    chat = gemma_subparsers.add_parser("chat")
+    chat.add_argument("--prompt", required=True)
+    chat.add_argument(
+        "--transport",
+        choices=("mock", "serial"),
+        default="mock",
+        help="mock is local-only; serial is a placeholder",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    if args.command == "gemma" and args.gemma_command == "chat":
+        if args.transport != "mock":
+            raise RealSerialGemmaE2ENotImplemented(
+                "serial Gemma chat is stubbed pending board evidence",
+            )
+        result = run_mock_gemma_chat(args.prompt)
+        sys.stdout.write(result.output_text + "\n")
+        return 0
+    raise SystemExit("unhandled command")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/gemma_e2e_orchestrator_test.py
+++ b/scripts/tests/gemma_e2e_orchestrator_test.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Unit tests for the mock Gemma E2E orchestrator."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+TEST_PATH = Path(__file__).resolve()
+
+from contracts.gemma_arch_spec import GemmaArchSpec
+from contracts.gemma_e2e_orchestrator import (
+    GemmaE2EOrchestrator,
+    RealSerialGemmaE2ENotImplemented,
+    run_mock_gemma_chat,
+)
+from contracts.kv260_connection_mock import KV260ConnectionMock
+from contracts.token_stream_over_serial import encode_input_stream
+
+
+def assert_raises(error_type, callback) -> None:
+    try:
+        callback()
+    except error_type:
+        return
+    raise AssertionError(f"expected {error_type.__name__}")
+
+
+def test_mock_orchestrator_runs_full_prompt_to_text_path() -> None:
+    prompt = "hello from lane b"
+    result = run_mock_gemma_chat(prompt, GemmaArchSpec())
+
+    assert result.output_text.startswith("mock-gemma:")
+    assert len(result.output_text) == len("mock-gemma:") + 16
+    assert result.prompt_tokens[0] == 2
+    assert result.output_tokens[-1] == 1
+    assert result.serial_payload == encode_input_stream(result.prompt_tokens)
+    assert result.axi_completion_count == 4
+    assert result.manifest_id.startswith("gemma_weight_prep_real_w4_")
+    assert len(result.manifest_sha256) == 64
+
+
+def test_same_prompt_is_deterministic_and_different_prompt_changes_output() -> None:
+    first = run_mock_gemma_chat("same prompt")
+    second = run_mock_gemma_chat("same prompt")
+    third = run_mock_gemma_chat("different prompt")
+
+    assert first == second
+    assert first.output_text != third.output_text
+
+
+def test_orchestrator_uses_kv260_connection_mock_contract() -> None:
+    orchestrator = GemmaE2EOrchestrator.create_mock("contract")
+
+    assert isinstance(orchestrator.connection, KV260ConnectionMock)
+    assert orchestrator.connection.is_reachable() is True
+    assert orchestrator.connection.xrt_present() is True
+
+
+def test_real_serial_path_is_stubbed() -> None:
+    assert_raises(
+        RealSerialGemmaE2ENotImplemented,
+        lambda: GemmaE2EOrchestrator.create_real_serial_stub(),
+    )
+
+
+def test_source_has_offline_and_claim_guards() -> None:
+    paths = [
+        ROOT / "contracts" / "gemma_e2e_orchestrator.py",
+        ROOT / "contracts" / "kv260_connection_mock.py",
+        TEST_PATH,
+    ]
+    source = "\n".join(path.read_text(encoding="utf-8") for path in paths)
+    lowered = source.lower()
+
+    forbidden_runtime_terms = [
+        "trans" + "formers",
+        "hugging" + "face_hub",
+        "hf_hub_" + "download",
+        "from_" + "pretrained",
+        ".safe" + "tensors",
+        ".g" + "guf",
+        ".p" + "th",
+        "req" + "uests",
+        "url" + "lib",
+        "sub" + "process",
+        "sock" + "et",
+        "/dev/" + "mem",
+        "serial" + ".serial",
+        "KVFPGA_PASSWORD",
+        "KVFPGA_USER",
+        "KVFPGA_HOST",
+    ]
+    for term in forbidden_runtime_terms:
+        assert term not in lowered, term
+
+    forbidden_claims = [
+        "production-" + "ready",
+        "marketplace-" + "ready",
+        "stable " + "API",
+        "stable " + "ABI",
+        "KV260 inference " + "works",
+        "Gemma 3N E4B " + "runs on KV260",
+        "20 tok/s " + "achieved",
+        "timing " + "closed",
+        "bitstream " + "ready",
+    ]
+    for claim in forbidden_claims:
+        assert claim.lower() not in lowered, claim
+    assert not re.search(r"\bHF_[A-Z0-9_]+\b", source)
+
+
+def test_source_headers_for_touched_python_files() -> None:
+    for path in [
+        ROOT / "contracts" / "gemma_e2e_orchestrator.py",
+        ROOT / "contracts" / "kv260_connection_mock.py",
+        TEST_PATH,
+    ]:
+        assert path.read_text(encoding="utf-8").splitlines()[:3] == [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ]
+
+
+test_mock_orchestrator_runs_full_prompt_to_text_path()
+test_same_prompt_is_deterministic_and_different_prompt_changes_output()
+test_orchestrator_uses_kv260_connection_mock_contract()
+test_real_serial_path_is_stubbed()
+test_source_has_offline_and_claim_guards()
+test_source_headers_for_touched_python_files()
+
+print("Gemma E2E orchestrator tests ok")

--- a/scripts/tests/gemma_tokenizer_arch_spec_test.py
+++ b/scripts/tests/gemma_tokenizer_arch_spec_test.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Unit tests for Gemma mock tokenizer and architecture spec."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+TEST_PATH = Path(__file__).resolve()
+
+from contracts.gemma_arch_spec import GemmaArchSpec
+from contracts.gemma_tokenizer import GemmaTokenizer
+
+
+def assert_raises(error_type, callback) -> None:
+    try:
+        callback()
+    except error_type:
+        return
+    raise AssertionError(f"expected {error_type.__name__}")
+
+
+def test_arch_spec_validates_token_ranges() -> None:
+    spec = GemmaArchSpec(vocab_size=1024, byte_token_offset=512)
+
+    assert spec.model_id == "gemma3n-e4b"
+    assert spec.target == "kv260"
+    assert spec.w4_group_size == 64
+    assert_raises(ValueError, lambda: GemmaArchSpec(vocab_size=300))
+    assert_raises(ValueError, lambda: GemmaArchSpec(eos_token_id=2))
+
+
+def test_tokenizer_round_trips_prompt_and_generated_text() -> None:
+    tokenizer = GemmaTokenizer(GemmaArchSpec())
+
+    prompt_tokens = tokenizer.encode("hello kv260")
+    generated_tokens = tokenizer.encode_generated_text("mock-gemma:abcd")
+
+    assert prompt_tokens[0] == tokenizer.arch_spec.bos_token_id
+    assert prompt_tokens[-1] == tokenizer.arch_spec.eos_token_id
+    assert tokenizer.decode(prompt_tokens) == "hello kv260"
+    assert tokenizer.decode(generated_tokens) == "mock-gemma:abcd"
+
+
+def test_source_has_offline_and_claim_guards() -> None:
+    paths = [
+        ROOT / "contracts" / "gemma_arch_spec.py",
+        ROOT / "contracts" / "gemma_tokenizer.py",
+        TEST_PATH,
+    ]
+    source = "\n".join(path.read_text(encoding="utf-8") for path in paths)
+    lowered = source.lower()
+
+    forbidden_runtime_terms = [
+        "trans" + "formers",
+        "hugging" + "face_hub",
+        "hf_hub_" + "download",
+        "from_" + "pretrained",
+        ".safe" + "tensors",
+        "req" + "uests",
+        "url" + "lib",
+        "sub" + "process",
+        "sock" + "et",
+        "/dev/" + "mem",
+    ]
+    for term in forbidden_runtime_terms:
+        assert term not in lowered, term
+
+    forbidden_claims = [
+        "production-" + "ready",
+        "marketplace-" + "ready",
+        "stable " + "API",
+        "stable " + "ABI",
+        "KV260 inference " + "works",
+        "Gemma 3N E4B " + "runs on KV260",
+        "20 tok/s " + "achieved",
+        "timing " + "closed",
+        "bitstream " + "ready",
+    ]
+    for claim in forbidden_claims:
+        assert claim.lower() not in lowered, claim
+    assert not re.search(r"\bHF_[A-Z0-9_]+\b", source)
+
+
+def test_source_headers_for_touched_python_files() -> None:
+    for path in [
+        ROOT / "contracts" / "gemma_arch_spec.py",
+        ROOT / "contracts" / "gemma_tokenizer.py",
+        TEST_PATH,
+    ]:
+        assert path.read_text(encoding="utf-8").splitlines()[:3] == [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ]
+
+
+test_arch_spec_validates_token_ranges()
+test_tokenizer_round_trips_prompt_and_generated_text()
+test_source_has_offline_and_claim_guards()
+test_source_headers_for_touched_python_files()
+
+print("Gemma tokenizer and arch spec tests ok")

--- a/scripts/tests/pccx_launcher_cli_test.py
+++ b/scripts/tests/pccx_launcher_cli_test.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""CLI tests for pccx-launcher Gemma mock chat."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CLI = ROOT / "pccx-launcher"
+TEST_PATH = Path(__file__).resolve()
+
+
+def run_cli(prompt: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(CLI), "gemma", "chat", "--prompt", prompt],
+        cwd=ROOT,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def test_gemma_chat_cli_prints_mock_output_text_only() -> None:
+    result = run_cli("hello cli")
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    assert result.stdout.startswith("mock-gemma:")
+    assert len(result.stdout.strip()) == len("mock-gemma:") + 16
+
+
+def test_gemma_chat_cli_is_deterministic_for_same_prompt() -> None:
+    first = run_cli("same cli prompt")
+    second = run_cli("same cli prompt")
+    third = run_cli("different cli prompt")
+
+    assert first.returncode == 0
+    assert second.returncode == 0
+    assert third.returncode == 0
+    assert first.stdout == second.stdout
+    assert first.stdout != third.stdout
+
+
+def test_serial_transport_is_stubbed() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(CLI),
+            "gemma",
+            "chat",
+            "--transport",
+            "serial",
+            "--prompt",
+            "hello",
+        ],
+        cwd=ROOT,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode != 0
+    assert result.stdout == ""
+    assert "stubbed pending board evidence" in result.stderr
+
+
+def test_source_headers_for_cli_files() -> None:
+    for path in [CLI, TEST_PATH]:
+        assert path.read_text(encoding="utf-8").splitlines()[:3] == [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ]
+
+
+test_gemma_chat_cli_prints_mock_output_text_only()
+test_gemma_chat_cli_is_deterministic_for_same_prompt()
+test_serial_transport_is_stubbed()
+test_source_headers_for_cli_files()
+
+print("pccx-launcher CLI tests ok")


### PR DESCRIPTION
## Summary
- add mock-only GemmaE2EOrchestrator wiring prompt encode, W4 prep, scripted token stream, AXI mock polling, output recv, and decode
- add local byte-level GemmaTokenizer, GemmaArchSpec, and board-less KV260ConnectionMock surfaces for offline orchestration
- add `pccx-launcher gemma chat --prompt "..."` CLI that prints deterministic mock output text

## Tests
- python3 scripts/tests/gemma_tokenizer_arch_spec_test.py
- python3 scripts/tests/gemma_e2e_orchestrator_test.py
- python3 scripts/tests/pccx_launcher_cli_test.py
- python3 scripts/tests/token_stream_over_serial_test.py && python3 scripts/tests/full_mock_gemma_path_integration_test.py
- for f in scripts/tests/*_test.py; do python3 "$f"; done
- python3 -m compileall contracts pccx-launcher scripts/tests
- CI-style claim-scan clean

## Notes
- mock-only; no real board access, no HF asset load, no env value printing
- real serial Gemma chat remains a stub pending board evidence

Refs #74, #75, #77, #78, #79, #80, #83, #84.
Refs tokenizer and arch spec slices introduced with this PR.