### PR TITLE
feat(gemma): multi-turn chat session with history

### DIFF
--- a/contracts/gemma_e2e_orchestrator.py
+++ b/contracts/gemma_e2e_orchestrator.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 import hashlib
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Sequence
 
 import numpy as np
@@ -49,6 +49,48 @@ class GemmaE2EResult:
     manifest_sha256: str
     serial_payload: bytes
     axi_completion_count: int
+
+
+@dataclass
+class ChatSession:
+    """Stateful mock Gemma chat session with deterministic turn history."""
+
+    arch_spec: GemmaArchSpec | None = None
+    seed: int = 0
+    history: list[tuple[str, str]] = field(default_factory=list)
+
+    def send(self, prompt: str) -> GemmaE2EResult:
+        """Send one user turn through the mock orchestrator and store the reply."""
+
+        context = self.context_for(prompt)
+        result = run_mock_gemma_chat(context, self.arch_spec, seed=self.seed)
+        self.history.append((prompt, result.output_text))
+        return result
+
+    def context_for(self, prompt: str) -> str:
+        """Build a Gemma-style chat prompt including prior turns."""
+
+        turns: list[str] = []
+        for user_text, assistant_text in self.history:
+            turns.extend(
+                [
+                    "<start_of_turn>user",
+                    user_text,
+                    "<end_of_turn>",
+                    "<start_of_turn>model",
+                    assistant_text,
+                    "<end_of_turn>",
+                ],
+            )
+        turns.extend(
+            [
+                "<start_of_turn>user",
+                prompt,
+                "<end_of_turn>",
+                "<start_of_turn>model",
+            ],
+        )
+        return "\n".join(turns)
 
 
 class ScriptedSerialSession:
@@ -112,6 +154,7 @@ class GemmaE2EOrchestrator:
         cls,
         prompt: str,
         arch_spec: GemmaArchSpec | None = None,
+        seed: int = 0,
     ) -> "GemmaE2EOrchestrator":
         """Create a full offline mock path with scripted serial and AXI replies."""
 
@@ -120,7 +163,7 @@ class GemmaE2EOrchestrator:
         prompt_tokens = tokenizer.encode(prompt)
         manifest = _prepare_mock_manifest(spec)
         reply_tokens = tokenizer.encode_generated_text(
-            deterministic_mock_reply(prompt, spec, manifest),
+            deterministic_mock_reply(prompt, spec, manifest, seed),
         )
         serial_factory = ScriptedSerialFactory([encode_output_stream(reply_tokens)])
         axi = AxiCmdMockBackend(_scripted_axi_replies(prompt_tokens, manifest, spec))
@@ -207,10 +250,11 @@ class GemmaE2EOrchestrator:
 def run_mock_gemma_chat(
     prompt: str,
     arch_spec: GemmaArchSpec | None = None,
+    seed: int = 0,
 ) -> GemmaE2EResult:
     """Convenience entry point for the CLI mock chat path."""
 
-    orchestrator = GemmaE2EOrchestrator.create_mock(prompt, arch_spec)
+    orchestrator = GemmaE2EOrchestrator.create_mock(prompt, arch_spec, seed)
     return orchestrator.run(prompt)
 
 
@@ -218,6 +262,7 @@ def deterministic_mock_reply(
     prompt: str,
     arch_spec: GemmaArchSpec,
     manifest: Manifest,
+    seed: int = 0,
 ) -> str:
     """Return stable local mock output text for a prompt/config pair."""
 
@@ -227,6 +272,7 @@ def deterministic_mock_reply(
                 arch_spec.model_id,
                 arch_spec.target,
                 manifest.packed_sha256,
+                str(seed),
                 prompt,
             ],
         ).encode("utf-8"),

--- a/pccx-launcher
+++ b/pccx-launcher
@@ -8,6 +8,7 @@ from __future__ import annotations
 import argparse
 import sys
 from pathlib import Path
+from typing import TextIO
 
 
 ROOT = Path(__file__).resolve().parent
@@ -15,6 +16,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from contracts.gemma_e2e_orchestrator import (
+    ChatSession,
     RealSerialGemmaE2ENotImplemented,
     run_mock_gemma_chat,
 )
@@ -28,7 +30,10 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     gemma_subparsers = gemma.add_subparsers(dest="gemma_command", required=True)
 
     chat = gemma_subparsers.add_parser("chat")
-    chat.add_argument("--prompt", required=True)
+    chat_input = chat.add_mutually_exclusive_group(required=True)
+    chat_input.add_argument("--prompt")
+    chat_input.add_argument("--interactive", action="store_true")
+    chat.add_argument("--seed", type=int, default=0)
     chat.add_argument(
         "--transport",
         choices=("mock", "serial"),
@@ -38,6 +43,32 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
+def run_interactive_gemma_chat(
+    stdin: TextIO | None = None,
+    stdout: TextIO | None = None,
+    seed: int = 0,
+) -> int:
+    """Run a local-only mock Gemma chat REPL."""
+
+    input_stream = sys.stdin if stdin is None else stdin
+    output_stream = sys.stdout if stdout is None else stdout
+    session = ChatSession(seed=seed)
+    while True:
+        output_stream.write("user> ")
+        output_stream.flush()
+        prompt = input_stream.readline()
+        if prompt == "":
+            break
+        prompt = prompt.rstrip("\n")
+        if prompt.strip() in {":exit", ":quit", "exit", "quit"}:
+            break
+        if prompt == "":
+            continue
+        result = session.send(prompt)
+        output_stream.write(f"assistant> {result.output_text}\n")
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(sys.argv[1:] if argv is None else argv)
     if args.command == "gemma" and args.gemma_command == "chat":
@@ -45,7 +76,9 @@ def main(argv: list[str] | None = None) -> int:
             raise RealSerialGemmaE2ENotImplemented(
                 "serial Gemma chat is stubbed pending board evidence",
             )
-        result = run_mock_gemma_chat(args.prompt)
+        if args.interactive:
+            return run_interactive_gemma_chat(seed=args.seed)
+        result = run_mock_gemma_chat(args.prompt, seed=args.seed)
         sys.stdout.write(result.output_text + "\n")
         return 0
     raise SystemExit("unhandled command")

--- a/scripts/tests/gemma_e2e_orchestrator_test.py
+++ b/scripts/tests/gemma_e2e_orchestrator_test.py
@@ -17,10 +17,12 @@ TEST_PATH = Path(__file__).resolve()
 
 from contracts.gemma_arch_spec import GemmaArchSpec
 from contracts.gemma_e2e_orchestrator import (
+    ChatSession,
     GemmaE2EOrchestrator,
     RealSerialGemmaE2ENotImplemented,
     run_mock_gemma_chat,
 )
+from contracts.gemma_tokenizer import GemmaTokenizer
 from contracts.kv260_connection_mock import KV260ConnectionMock
 from contracts.token_stream_over_serial import encode_input_stream
 
@@ -54,6 +56,39 @@ def test_same_prompt_is_deterministic_and_different_prompt_changes_output() -> N
 
     assert first == second
     assert first.output_text != third.output_text
+
+
+def test_chat_session_records_history_and_passes_context() -> None:
+    spec = GemmaArchSpec()
+    session = ChatSession(arch_spec=spec, seed=19)
+
+    first_context = session.context_for("first turn")
+    first = session.send("first turn")
+    assert first.prompt_tokens == tuple(GemmaTokenizer(spec).encode(first_context))
+    assert session.history == [("first turn", first.output_text)]
+
+    second_context = session.context_for("second turn")
+    assert "first turn" in second_context
+    assert first.output_text in second_context
+    assert second_context.endswith("<start_of_turn>model")
+
+    second = session.send("second turn")
+    assert second.prompt_tokens == tuple(GemmaTokenizer(spec).encode(second_context))
+    assert session.history == [
+        ("first turn", first.output_text),
+        ("second turn", second.output_text),
+    ]
+
+
+def test_chat_session_same_seed_and_prompts_is_deterministic() -> None:
+    prompts = ("alpha", "beta", "gamma")
+
+    def run_session(seed: int) -> tuple[str, ...]:
+        session = ChatSession(seed=seed)
+        return tuple(session.send(prompt).output_text for prompt in prompts)
+
+    assert run_session(7) == run_session(7)
+    assert run_session(7) != run_session(8)
 
 
 def test_orchestrator_uses_kv260_connection_mock_contract() -> None:
@@ -132,6 +167,8 @@ def test_source_headers_for_touched_python_files() -> None:
 
 test_mock_orchestrator_runs_full_prompt_to_text_path()
 test_same_prompt_is_deterministic_and_different_prompt_changes_output()
+test_chat_session_records_history_and_passes_context()
+test_chat_session_same_seed_and_prompts_is_deterministic()
 test_orchestrator_uses_kv260_connection_mock_contract()
 test_real_serial_path_is_stubbed()
 test_source_has_offline_and_claim_guards()

--- a/scripts/tests/pccx_launcher_cli_test.py
+++ b/scripts/tests/pccx_launcher_cli_test.py
@@ -15,11 +15,43 @@ CLI = ROOT / "pccx-launcher"
 TEST_PATH = Path(__file__).resolve()
 
 
-def run_cli(prompt: str) -> subprocess.CompletedProcess[str]:
+def run_cli(prompt: str, seed: int = 0) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
-        [sys.executable, str(CLI), "gemma", "chat", "--prompt", prompt],
+        [
+            sys.executable,
+            str(CLI),
+            "gemma",
+            "chat",
+            "--prompt",
+            prompt,
+            "--seed",
+            str(seed),
+        ],
         cwd=ROOT,
         check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def run_interactive_cli(
+    prompts: list[str],
+    seed: int = 0,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(CLI),
+            "gemma",
+            "chat",
+            "--interactive",
+            "--seed",
+            str(seed),
+        ],
+        cwd=ROOT,
+        check=False,
+        input="\n".join(prompts) + "\n",
         text=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -45,6 +77,31 @@ def test_gemma_chat_cli_is_deterministic_for_same_prompt() -> None:
     assert third.returncode == 0
     assert first.stdout == second.stdout
     assert first.stdout != third.stdout
+
+
+def test_gemma_chat_cli_seed_controls_deterministic_output() -> None:
+    first = run_cli("seeded cli prompt", seed=123)
+    second = run_cli("seeded cli prompt", seed=123)
+    third = run_cli("seeded cli prompt", seed=124)
+
+    assert first.returncode == 0
+    assert second.returncode == 0
+    assert third.returncode == 0
+    assert first.stdout == second.stdout
+    assert first.stdout != third.stdout
+
+
+def test_gemma_chat_interactive_repl_keeps_multi_turn_state() -> None:
+    first = run_interactive_cli(["first repl turn", "second repl turn", ":quit"], seed=3)
+    second = run_interactive_cli(["first repl turn", "second repl turn", ":quit"], seed=3)
+    third = run_interactive_cli(["first repl turn", "second repl turn", ":quit"], seed=4)
+
+    assert first.returncode == 0
+    assert first.stderr == ""
+    assert first.stdout == second.stdout
+    assert first.stdout != third.stdout
+    assert first.stdout.count("user> ") == 3
+    assert first.stdout.count("assistant> mock-gemma:") == 2
 
 
 def test_serial_transport_is_stubbed() -> None:
@@ -82,6 +139,8 @@ def test_source_headers_for_cli_files() -> None:
 
 test_gemma_chat_cli_prints_mock_output_text_only()
 test_gemma_chat_cli_is_deterministic_for_same_prompt()
+test_gemma_chat_cli_seed_controls_deterministic_output()
+test_gemma_chat_interactive_repl_keeps_multi_turn_state()
 test_serial_transport_is_stubbed()
 test_source_headers_for_cli_files()
 


### PR DESCRIPTION
## Summary
- add ChatSession over the mock Gemma E2E orchestrator with Gemma-style history context
- add seeded deterministic mock replies and interactive mock chat REPL
- add multi-turn session and CLI determinism coverage

Refs #87
Refs #88
Refs #89

## Tests
- python3 scripts/tests/gemma_e2e_orchestrator_test.py
- python3 scripts/tests/pccx_launcher_cli_test.py
- python3 -m py_compile contracts/gemma_e2e_orchestrator.py pccx-launcher scripts/tests/gemma_e2e_orchestrator_test.py scripts/tests/pccx_launcher_cli_test.py
- git diff --check
- pytest -q scripts/tests
- ./scripts/check.sh
- claim guard over touched Gemma chat files