### PR TITLE
feat(chat): persist history to jsonl file

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ bash scripts/chat-evidence-manifest-stub.sh --model gemma3n-e4b --target kv260
 bash scripts/chat-surface-preview.sh --model gemma3n-e4b --target kv260
 ./pccx-launcher gemma chat --prompt "hello"
 bash scripts/launch-stub.sh --dry-run
+python3 pccx-launcher gemma chat --prompt "hello" --history-file /tmp/pccx-chat-history.jsonl
 bash scripts/chat-stub.sh --dry-run --prompt "hello"
 ```
 

--- a/contracts/gemma_e2e_orchestrator.py
+++ b/contracts/gemma_e2e_orchestrator.py
@@ -6,7 +6,9 @@
 from __future__ import annotations
 
 import hashlib
+import json
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Sequence
 
 import numpy as np
@@ -57,28 +59,34 @@ class ChatSession:
 
     arch_spec: GemmaArchSpec | None = None
     seed: int = 0
+    history_file: Path | None = None
     history: list[tuple[str, str]] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if self.history_file is not None:
+            self.history.extend(load_chat_history(self.history_file))
 
     def send(self, prompt: str) -> GemmaE2EResult:
         """Send one user turn through the mock orchestrator and store the reply."""
 
         context = self.context_for(prompt)
         result = run_mock_gemma_chat(context, self.arch_spec, seed=self.seed)
-        self.history.append((prompt, result.output_text))
+        turn = (("user", prompt), ("assistant", result.output_text))
+        self.history.extend(turn)
+        if self.history_file is not None:
+            append_chat_history(self.history_file, turn)
         return result
 
     def context_for(self, prompt: str) -> str:
         """Build a Gemma-style chat prompt including prior turns."""
 
         turns: list[str] = []
-        for user_text, assistant_text in self.history:
+        for role, content in self.history:
+            gemma_role = "model" if role == "assistant" else role
             turns.extend(
                 [
-                    "<start_of_turn>user",
-                    user_text,
-                    "<end_of_turn>",
-                    "<start_of_turn>model",
-                    assistant_text,
+                    f"<start_of_turn>{gemma_role}",
+                    content,
                     "<end_of_turn>",
                 ],
             )
@@ -91,6 +99,45 @@ class ChatSession:
             ],
         )
         return "\n".join(turns)
+
+
+def load_chat_history(path: Path) -> list[tuple[str, str]]:
+    """Load role/content history tuples from a JSONL file if it exists."""
+
+    if not path.exists():
+        return []
+    history: list[tuple[str, str]] = []
+    with path.open("r", encoding="utf-8") as history_stream:
+        for line_number, line in enumerate(history_stream, start=1):
+            line = line.strip()
+            if line == "":
+                continue
+            value = json.loads(line)
+            if (
+                not isinstance(value, list)
+                or len(value) != 2
+                or not isinstance(value[0], str)
+                or not isinstance(value[1], str)
+            ):
+                raise ValueError(
+                    f"invalid chat history tuple at {path}:{line_number}",
+                )
+            role, content = value
+            if role not in {"user", "assistant"}:
+                raise ValueError(
+                    f"invalid chat history role at {path}:{line_number}: {role}",
+                )
+            history.append((role, content))
+    return history
+
+
+def append_chat_history(path: Path, entries: Sequence[tuple[str, str]]) -> None:
+    """Append role/content history tuples to a JSONL file."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as history_stream:
+        for role, content in entries:
+            history_stream.write(json.dumps([role, content], sort_keys=True) + "\n")
 
 
 class ScriptedSerialSession:

--- a/pccx-launcher
+++ b/pccx-launcher
@@ -35,6 +35,11 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     chat_input.add_argument("--interactive", action="store_true")
     chat.add_argument("--seed", type=int, default=0)
     chat.add_argument(
+        "--history-file",
+        type=Path,
+        help="load and append local chat history JSONL role/content tuples",
+    )
+    chat.add_argument(
         "--transport",
         choices=("mock", "serial"),
         default="mock",
@@ -47,12 +52,13 @@ def run_interactive_gemma_chat(
     stdin: TextIO | None = None,
     stdout: TextIO | None = None,
     seed: int = 0,
+    history_file: Path | None = None,
 ) -> int:
     """Run a local-only mock Gemma chat REPL."""
 
     input_stream = sys.stdin if stdin is None else stdin
     output_stream = sys.stdout if stdout is None else stdout
-    session = ChatSession(seed=seed)
+    session = ChatSession(seed=seed, history_file=history_file)
     while True:
         output_stream.write("user> ")
         output_stream.flush()
@@ -77,8 +83,16 @@ def main(argv: list[str] | None = None) -> int:
                 "serial Gemma chat is stubbed pending board evidence",
             )
         if args.interactive:
-            return run_interactive_gemma_chat(seed=args.seed)
-        result = run_mock_gemma_chat(args.prompt, seed=args.seed)
+            return run_interactive_gemma_chat(
+                seed=args.seed,
+                history_file=args.history_file,
+            )
+        if args.history_file is not None:
+            result = ChatSession(seed=args.seed, history_file=args.history_file).send(
+                args.prompt,
+            )
+        else:
+            result = run_mock_gemma_chat(args.prompt, seed=args.seed)
         sys.stdout.write(result.output_text + "\n")
         return 0
     raise SystemExit("unhandled command")

--- a/scripts/tests/gemma_e2e_orchestrator_test.py
+++ b/scripts/tests/gemma_e2e_orchestrator_test.py
@@ -5,8 +5,10 @@
 
 from __future__ import annotations
 
+import json
 import re
 import sys
+import tempfile
 from pathlib import Path
 
 
@@ -20,6 +22,7 @@ from contracts.gemma_e2e_orchestrator import (
     ChatSession,
     GemmaE2EOrchestrator,
     RealSerialGemmaE2ENotImplemented,
+    load_chat_history,
     run_mock_gemma_chat,
 )
 from contracts.gemma_tokenizer import GemmaTokenizer
@@ -65,7 +68,10 @@ def test_chat_session_records_history_and_passes_context() -> None:
     first_context = session.context_for("first turn")
     first = session.send("first turn")
     assert first.prompt_tokens == tuple(GemmaTokenizer(spec).encode(first_context))
-    assert session.history == [("first turn", first.output_text)]
+    assert session.history == [
+        ("user", "first turn"),
+        ("assistant", first.output_text),
+    ]
 
     second_context = session.context_for("second turn")
     assert "first turn" in second_context
@@ -75,8 +81,10 @@ def test_chat_session_records_history_and_passes_context() -> None:
     second = session.send("second turn")
     assert second.prompt_tokens == tuple(GemmaTokenizer(spec).encode(second_context))
     assert session.history == [
-        ("first turn", first.output_text),
-        ("second turn", second.output_text),
+        ("user", "first turn"),
+        ("assistant", first.output_text),
+        ("user", "second turn"),
+        ("assistant", second.output_text),
     ]
 
 
@@ -89,6 +97,39 @@ def test_chat_session_same_seed_and_prompts_is_deterministic() -> None:
 
     assert run_session(7) == run_session(7)
     assert run_session(7) != run_session(8)
+
+
+def test_chat_session_persists_jsonl_and_reload_is_deterministic() -> None:
+    prompts = ("alpha", "beta", "gamma")
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        history_path = Path(temp_dir) / "history.jsonl"
+        first_session = ChatSession(seed=31, history_file=history_path)
+        first = first_session.send(prompts[0])
+        second = first_session.send(prompts[1])
+
+        reloaded_session = ChatSession(seed=31, history_file=history_path)
+        third = reloaded_session.send(prompts[2])
+
+        continuous_session = ChatSession(seed=31)
+        continuous_results = [continuous_session.send(prompt) for prompt in prompts]
+
+        assert [first.output_text, second.output_text, third.output_text] == [
+            result.output_text for result in continuous_results
+        ]
+        assert reloaded_session.history == continuous_session.history
+        assert load_chat_history(history_path) == continuous_session.history
+        assert [
+            json.loads(line)
+            for line in history_path.read_text(encoding="utf-8").splitlines()
+        ] == [
+            ["user", prompts[0]],
+            ["assistant", first.output_text],
+            ["user", prompts[1]],
+            ["assistant", second.output_text],
+            ["user", prompts[2]],
+            ["assistant", third.output_text],
+        ]
 
 
 def test_orchestrator_uses_kv260_connection_mock_contract() -> None:
@@ -169,6 +210,7 @@ test_mock_orchestrator_runs_full_prompt_to_text_path()
 test_same_prompt_is_deterministic_and_different_prompt_changes_output()
 test_chat_session_records_history_and_passes_context()
 test_chat_session_same_seed_and_prompts_is_deterministic()
+test_chat_session_persists_jsonl_and_reload_is_deterministic()
 test_orchestrator_uses_kv260_connection_mock_contract()
 test_real_serial_path_is_stubbed()
 test_source_has_offline_and_claim_guards()

--- a/scripts/tests/pccx_launcher_cli_test.py
+++ b/scripts/tests/pccx_launcher_cli_test.py
@@ -5,8 +5,10 @@
 
 from __future__ import annotations
 
+import json
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 
@@ -15,18 +17,25 @@ CLI = ROOT / "pccx-launcher"
 TEST_PATH = Path(__file__).resolve()
 
 
-def run_cli(prompt: str, seed: int = 0) -> subprocess.CompletedProcess[str]:
+def run_cli(
+    prompt: str,
+    seed: int = 0,
+    history_file: Path | None = None,
+) -> subprocess.CompletedProcess[str]:
+    command = [
+        sys.executable,
+        str(CLI),
+        "gemma",
+        "chat",
+        "--prompt",
+        prompt,
+        "--seed",
+        str(seed),
+    ]
+    if history_file is not None:
+        command.extend(["--history-file", str(history_file)])
     return subprocess.run(
-        [
-            sys.executable,
-            str(CLI),
-            "gemma",
-            "chat",
-            "--prompt",
-            prompt,
-            "--seed",
-            str(seed),
-        ],
+        command,
         cwd=ROOT,
         check=False,
         text=True,
@@ -38,17 +47,21 @@ def run_cli(prompt: str, seed: int = 0) -> subprocess.CompletedProcess[str]:
 def run_interactive_cli(
     prompts: list[str],
     seed: int = 0,
+    history_file: Path | None = None,
 ) -> subprocess.CompletedProcess[str]:
+    command = [
+        sys.executable,
+        str(CLI),
+        "gemma",
+        "chat",
+        "--interactive",
+        "--seed",
+        str(seed),
+    ]
+    if history_file is not None:
+        command.extend(["--history-file", str(history_file)])
     return subprocess.run(
-        [
-            sys.executable,
-            str(CLI),
-            "gemma",
-            "chat",
-            "--interactive",
-            "--seed",
-            str(seed),
-        ],
+        command,
         cwd=ROOT,
         check=False,
         input="\n".join(prompts) + "\n",
@@ -104,6 +117,37 @@ def test_gemma_chat_interactive_repl_keeps_multi_turn_state() -> None:
     assert first.stdout.count("assistant> mock-gemma:") == 2
 
 
+def test_gemma_chat_history_file_loads_and_appends_jsonl() -> None:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        history_path = Path(temp_dir) / "history.jsonl"
+        first = run_cli("persist one", seed=9, history_file=history_path)
+        second = run_cli("persist two", seed=9, history_file=history_path)
+
+        replay_path = Path(temp_dir) / "replay.jsonl"
+        replay_first = run_cli("persist one", seed=9, history_file=replay_path)
+        replay_second = run_cli("persist two", seed=9, history_file=replay_path)
+
+        assert first.returncode == 0
+        assert second.returncode == 0
+        assert replay_first.returncode == 0
+        assert replay_second.returncode == 0
+        assert first.stderr == ""
+        assert second.stderr == ""
+        assert replay_first.stderr == ""
+        assert replay_second.stderr == ""
+        assert first.stdout == replay_first.stdout
+        assert second.stdout == replay_second.stdout
+        assert [
+            json.loads(line)
+            for line in history_path.read_text(encoding="utf-8").splitlines()
+        ] == [
+            ["user", "persist one"],
+            ["assistant", first.stdout.strip()],
+            ["user", "persist two"],
+            ["assistant", second.stdout.strip()],
+        ]
+
+
 def test_serial_transport_is_stubbed() -> None:
     result = subprocess.run(
         [
@@ -141,6 +185,7 @@ test_gemma_chat_cli_prints_mock_output_text_only()
 test_gemma_chat_cli_is_deterministic_for_same_prompt()
 test_gemma_chat_cli_seed_controls_deterministic_output()
 test_gemma_chat_interactive_repl_keeps_multi_turn_state()
+test_gemma_chat_history_file_loads_and_appends_jsonl()
 test_serial_transport_is_stubbed()
 test_source_headers_for_cli_files()
 


### PR DESCRIPTION
## Summary
- add ChatSession JSONL history load/append support with role/content tuples
- thread --history-file through prompt and interactive Gemma mock chat CLI modes
- cover mid-session history reload determinism and CLI append format

Refs #90

## Tests
- python3 scripts/tests/gemma_e2e_orchestrator_test.py
- python3 scripts/tests/pccx_launcher_cli_test.py
- python3 -m py_compile contracts/gemma_e2e_orchestrator.py pccx-launcher scripts/tests/gemma_e2e_orchestrator_test.py scripts/tests/pccx_launcher_cli_test.py
- git diff --check
- pytest -q scripts/tests
- ./scripts/check.sh