### PR TITLE
feat(template): gemma chat template formatter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -337,6 +337,8 @@ jobs:
         run: python3 scripts/tests/full_mock_gemma_path_integration_test.py
       - name: run Gemma tokenizer and arch spec tests
         run: python3 scripts/tests/gemma_tokenizer_arch_spec_test.py
+      - name: run Gemma chat-template tests
+        run: python3 scripts/tests/gemma_chat_template_test.py
       - name: run Gemma E2E orchestrator tests
         run: python3 scripts/tests/gemma_e2e_orchestrator_test.py
       - name: run pccx-launcher CLI tests

--- a/contracts/gemma_chat_template.py
+++ b/contracts/gemma_chat_template.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Gemma chat-template formatting for launcher-side prompt construction."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping, Sequence
+
+
+GEMMA3N_E4B_CHAT_TEMPLATE_URL = (
+    "https://huggingface.co/google/gemma-3n-E4B-it/blob/main/chat_template.jinja"
+)
+
+
+class GemmaChatTemplateError(ValueError):
+    """Raised when chat messages cannot be formatted as Gemma turns."""
+
+
+@dataclass(frozen=True)
+class GemmaChatMessage:
+    """One normalized chat message consumed by GemmaChatTemplate."""
+
+    role: str
+    content: str
+
+
+@dataclass(frozen=True)
+class GemmaChatTemplate:
+    """Format chat messages with Gemma user/model turn markers.
+
+    Source: Gemma 3N E4B IT documents this shape in chat_template.jinja at
+    https://huggingface.co/google/gemma-3n-E4B-it/blob/main/chat_template.jinja
+    """
+
+    bos_token: str = ""
+
+    def format(
+        self,
+        messages: Sequence[GemmaChatMessage | Mapping[str, str]],
+        add_generation_prompt: bool = True,
+    ) -> str:
+        """Return the rendered Gemma chat-template string."""
+
+        normalized = tuple(_normalize_message(message) for message in messages)
+        if not normalized:
+            raise GemmaChatTemplateError("messages must not be empty")
+
+        system_prefix = ""
+        loop_messages = normalized
+        if normalized[0].role == "system":
+            system_prefix = normalized[0].content.strip() + "\n\n"
+            loop_messages = normalized[1:]
+        if not loop_messages:
+            raise GemmaChatTemplateError("a user message is required")
+
+        rendered: list[str] = []
+        if self.bos_token:
+            rendered.append(self.bos_token)
+
+        for index, message in enumerate(loop_messages):
+            role = _template_role(message.role)
+            expected_role = "user" if index % 2 == 0 else "model"
+            if role != expected_role:
+                raise GemmaChatTemplateError(
+                    "conversation roles must alternate user/assistant/user/assistant",
+                )
+
+            content = message.content.strip()
+            if index == 0:
+                content = system_prefix + content
+            rendered.append(f"<start_of_turn>{role}\n{content}<end_of_turn>\n")
+
+        if add_generation_prompt:
+            if _template_role(loop_messages[-1].role) != "user":
+                raise GemmaChatTemplateError(
+                    "generation prompts require the last message to be user",
+                )
+            rendered.append("<start_of_turn>model\n")
+
+        return "".join(rendered)
+
+
+def _normalize_message(
+    message: GemmaChatMessage | Mapping[str, str],
+) -> GemmaChatMessage:
+    if isinstance(message, GemmaChatMessage):
+        normalized = message
+    else:
+        try:
+            normalized = GemmaChatMessage(
+                role=message["role"],
+                content=message["content"],
+            )
+        except KeyError as exc:
+            raise GemmaChatTemplateError("messages require role and content") from exc
+
+    if normalized.role not in {"system", "user", "assistant", "model"}:
+        raise GemmaChatTemplateError(f"unsupported role: {normalized.role}")
+    if not isinstance(normalized.content, str):
+        raise TypeError("message content must be a string")
+    return normalized
+
+
+def _template_role(role: str) -> str:
+    if role == "assistant":
+        return "model"
+    return role

--- a/contracts/gemma_e2e_orchestrator.py
+++ b/contracts/gemma_e2e_orchestrator.py
@@ -13,6 +13,7 @@ import numpy as np
 
 from contracts.axi_cmd_channel import AxiCmdChannel, AxiCmdMockBackend, NpuCmd, NpuStat
 from contracts.gemma_arch_spec import GemmaArchSpec, default_gemma3n_e4b_kv260_arch_spec
+from contracts.gemma_chat_template import GemmaChatMessage, GemmaChatTemplate
 from contracts.gemma_tokenizer import GemmaTokenizer
 from contracts.gemma_weight_prep_contract import GemmaWeightPrep, Manifest
 from contracts.kv260_connection_mock import KV260ConnectionMock
@@ -58,6 +59,7 @@ class ChatSession:
     arch_spec: GemmaArchSpec | None = None
     seed: int = 0
     history: list[tuple[str, str]] = field(default_factory=list)
+    chat_template: GemmaChatTemplate = field(default_factory=GemmaChatTemplate)
 
     def send(self, prompt: str) -> GemmaE2EResult:
         """Send one user turn through the mock orchestrator and store the reply."""
@@ -70,27 +72,12 @@ class ChatSession:
     def context_for(self, prompt: str) -> str:
         """Build a Gemma-style chat prompt including prior turns."""
 
-        turns: list[str] = []
+        messages: list[GemmaChatMessage] = []
         for user_text, assistant_text in self.history:
-            turns.extend(
-                [
-                    "<start_of_turn>user",
-                    user_text,
-                    "<end_of_turn>",
-                    "<start_of_turn>model",
-                    assistant_text,
-                    "<end_of_turn>",
-                ],
-            )
-        turns.extend(
-            [
-                "<start_of_turn>user",
-                prompt,
-                "<end_of_turn>",
-                "<start_of_turn>model",
-            ],
-        )
-        return "\n".join(turns)
+            messages.append(GemmaChatMessage(role="user", content=user_text))
+            messages.append(GemmaChatMessage(role="assistant", content=assistant_text))
+        messages.append(GemmaChatMessage(role="user", content=prompt))
+        return self.chat_template.format(messages, add_generation_prompt=True)
 
 
 class ScriptedSerialSession:

--- a/scripts/tests/gemma_chat_template_test.py
+++ b/scripts/tests/gemma_chat_template_test.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Type-only string tests for Gemma chat-template formatting."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+TEST_PATH = Path(__file__).resolve()
+
+from contracts.gemma_chat_template import (
+    GEMMA3N_E4B_CHAT_TEMPLATE_URL,
+    GemmaChatMessage,
+    GemmaChatTemplate,
+    GemmaChatTemplateError,
+)
+
+
+def assert_raises(error_type, callback) -> None:
+    try:
+        callback()
+    except error_type:
+        return
+    raise AssertionError(f"expected {error_type.__name__}")
+
+
+def test_gemma_chat_template_formats_documented_turn_string() -> None:
+    formatted: str = GemmaChatTemplate().format(
+        [
+            GemmaChatMessage(role="system", content="You are concise."),
+            GemmaChatMessage(role="user", content=" first "),
+            GemmaChatMessage(role="assistant", content=" reply "),
+            GemmaChatMessage(role="user", content="second"),
+        ],
+    )
+    expected: str = (
+        "<start_of_turn>user\n"
+        "You are concise.\n\n"
+        "first<end_of_turn>\n"
+        "<start_of_turn>model\n"
+        "reply<end_of_turn>\n"
+        "<start_of_turn>user\n"
+        "second<end_of_turn>\n"
+        "<start_of_turn>model\n"
+    )
+
+    assert isinstance(formatted, str)
+    assert formatted == expected
+
+
+def test_gemma_chat_template_accepts_mapping_messages_and_optional_bos() -> None:
+    formatted: str = GemmaChatTemplate(bos_token="<bos>").format(
+        [{"role": "user", "content": "hello"}],
+    )
+
+    assert formatted == (
+        "<bos><start_of_turn>user\n"
+        "hello<end_of_turn>\n"
+        "<start_of_turn>model\n"
+    )
+
+
+def test_gemma_chat_template_rejects_non_alternating_roles() -> None:
+    assert_raises(
+        GemmaChatTemplateError,
+        lambda: GemmaChatTemplate().format(
+            [
+                GemmaChatMessage(role="user", content="one"),
+                GemmaChatMessage(role="user", content="two"),
+            ],
+        ),
+    )
+
+
+def test_source_url_is_recorded_without_runtime_claims() -> None:
+    source = (ROOT / "contracts" / "gemma_chat_template.py").read_text(
+        encoding="utf-8",
+    )
+
+    assert GEMMA3N_E4B_CHAT_TEMPLATE_URL in source
+    assert "Gemma 3N E4B runs on KV260" not in source
+
+
+def test_source_headers_for_touched_python_files() -> None:
+    for path in [ROOT / "contracts" / "gemma_chat_template.py", TEST_PATH]:
+        assert path.read_text(encoding="utf-8").splitlines()[:3] == [
+            "#!/usr/bin/env python3",
+            "# SPDX-License-Identifier: Apache-2.0",
+            "# Copyright 2026 pccxai",
+        ]
+
+
+test_gemma_chat_template_formats_documented_turn_string()
+test_gemma_chat_template_accepts_mapping_messages_and_optional_bos()
+test_gemma_chat_template_rejects_non_alternating_roles()
+test_source_url_is_recorded_without_runtime_claims()
+test_source_headers_for_touched_python_files()
+
+print("Gemma chat-template tests ok")

--- a/scripts/tests/gemma_e2e_orchestrator_test.py
+++ b/scripts/tests/gemma_e2e_orchestrator_test.py
@@ -70,7 +70,12 @@ def test_chat_session_records_history_and_passes_context() -> None:
     second_context = session.context_for("second turn")
     assert "first turn" in second_context
     assert first.output_text in second_context
-    assert second_context.endswith("<start_of_turn>model")
+    assert second_context.endswith("<start_of_turn>model\n")
+    assert (
+        "<start_of_turn>user\n"
+        "first turn<end_of_turn>\n"
+        "<start_of_turn>model\n"
+    ) in second_context
 
     second = session.send("second turn")
     assert second.prompt_tokens == tuple(GemmaTokenizer(spec).encode(second_context))


### PR DESCRIPTION
## Summary
- add `GemmaChatTemplate` and `GemmaChatMessage` for Gemma user/model turn formatting
- cite the documented Gemma 3N E4B IT chat template URL in the formatter source
- route `ChatSession.context_for()` through the formatter before mock orchestrator calls
- add a type-only formatted-string test and CI entry

## Tests
- python3 scripts/tests/gemma_chat_template_test.py
- python3 scripts/tests/gemma_e2e_orchestrator_test.py
- python3 scripts/tests/pccx_launcher_cli_test.py
- python3 -m py_compile contracts/gemma_chat_template.py contracts/gemma_e2e_orchestrator.py pccx-launcher scripts/tests/gemma_chat_template_test.py scripts/tests/gemma_e2e_orchestrator_test.py scripts/tests/pccx_launcher_cli_test.py
- git diff --check
- ./scripts/check.sh
- python3 -m pytest -q scripts/tests