### PR TITLE
feat(err): typed error hierarchy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,6 +315,8 @@ jobs:
             exit 1
           fi
           echo "chat-stub correctly refused without --dry-run"
+      - name: run typed launcher error tests
+        run: python3 scripts/tests/pccx_launcher_errors_test.py
       - name: run launcher/IDE contract tests
         run: python3 scripts/tests/launcher_ide_contract_test.py
       - name: run model/runtime descriptor tests

--- a/contracts/chat_local_only_policy_contract.py
+++ b/contracts/chat_local_only_policy_contract.py
@@ -18,6 +18,13 @@ import argparse
 import copy
 import json
 import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from pccx_launcher.errors import TraceError
 
 
 SCHEMA_VERSION = "pccx.chatLocalOnlyPolicy.v0"
@@ -329,27 +336,27 @@ def _iter_state_values(value):
 
 def _validate_policy(policy: dict) -> None:
     if tuple(policy.keys()) != CHAT_LOCAL_ONLY_POLICY_FIELDS:
-        raise ValueError("chat local-only policy fields changed")
+        raise TraceError("chat local-only policy fields changed")
     if policy["schemaVersion"] != SCHEMA_VERSION:
-        raise ValueError("unexpected chat local-only policy schema version")
+        raise TraceError("unexpected chat local-only policy schema version")
 
     allowed = set(CHAT_LOCAL_ONLY_POLICY_STATE_VALUES)
     for state in _iter_state_values(policy):
         if state not in allowed:
-            raise ValueError(f"unexpected chat local-only policy state: {state}")
+            raise TraceError(f"unexpected chat local-only policy state: {state}")
 
     for control in policy["policyControls"]:
         if tuple(control.keys()) != POLICY_CONTROL_FIELDS:
-            raise ValueError("policy control fields changed")
+            raise TraceError("policy control fields changed")
     for check in policy["dependencyChecks"]:
         if tuple(check.keys()) != DEPENDENCY_CHECK_FIELDS:
-            raise ValueError("dependency check fields changed")
+            raise TraceError("dependency check fields changed")
     for reason in policy["blockedReasons"]:
         if tuple(reason.keys()) != BLOCKED_REASON_FIELDS:
-            raise ValueError("blocked reason fields changed")
+            raise TraceError("blocked reason fields changed")
     for ref in policy["handoffRefs"]:
         if tuple(ref.keys()) != HANDOFF_REF_FIELDS:
-            raise ValueError("handoff ref fields changed")
+            raise TraceError("handoff ref fields changed")
 
 
 def create_gemma3n_e4b_kv260_chat_local_only_policy() -> dict:

--- a/contracts/chat_preferences_contract.py
+++ b/contracts/chat_preferences_contract.py
@@ -17,6 +17,13 @@ import argparse
 import copy
 import json
 import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from pccx_launcher.errors import TraceError
 
 
 SCHEMA_VERSION = "pccx.chatPreferences.v0"
@@ -378,24 +385,24 @@ def _iter_state_values(value):
 
 def _validate_preferences(preferences: dict) -> None:
     if tuple(preferences.keys()) != CHAT_PREFERENCES_FIELDS:
-        raise ValueError("chat preferences fields changed")
+        raise TraceError("chat preferences fields changed")
     if preferences["schemaVersion"] != SCHEMA_VERSION:
-        raise ValueError("unexpected chat preferences schema version")
+        raise TraceError("unexpected chat preferences schema version")
 
     allowed = set(CHAT_PREFERENCES_STATE_VALUES)
     for state in _iter_state_values(preferences):
         if state not in allowed:
-            raise ValueError(f"unexpected chat preferences state: {state}")
+            raise TraceError(f"unexpected chat preferences state: {state}")
 
     for panel in preferences["preferencePanels"]:
         if tuple(panel.keys()) != PREFERENCE_PANEL_FIELDS:
-            raise ValueError("preference panel fields changed")
+            raise TraceError("preference panel fields changed")
     for control in preferences["preferenceControls"]:
         if tuple(control.keys()) != PREFERENCE_CONTROL_FIELDS:
-            raise ValueError("preference control fields changed")
+            raise TraceError("preference control fields changed")
     for reason in preferences["blockedReasons"]:
         if tuple(reason.keys()) != BLOCKED_REASON_FIELDS:
-            raise ValueError("blocked reason fields changed")
+            raise TraceError("blocked reason fields changed")
 
 
 def create_gemma3n_e4b_kv260_chat_preferences() -> dict:

--- a/pccx_launcher/__init__.py
+++ b/pccx_launcher/__init__.py
@@ -1,0 +1,17 @@
+"""PCCX launcher support package."""
+
+__all__ = [
+    "AxiError",
+    "GemmaError",
+    "KV260Error",
+    "PCCXLauncherError",
+    "TraceError",
+]
+
+
+def __getattr__(name: str) -> object:
+    if name in __all__:
+        from . import errors
+
+        return getattr(errors, name)
+    raise AttributeError(name)

--- a/pccx_launcher/errors.py
+++ b/pccx_launcher/errors.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Typed launcher error hierarchy and formatting helpers."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Mapping
+from typing import ClassVar
+
+
+class PCCXLauncherError(Exception):
+    """Base class for typed launcher failures."""
+
+    domain: ClassVar[str] = "launcher"
+    default_code: ClassVar[str] = "pccx_launcher_error"
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str | None = None,
+        hint: str | None = None,
+        details: Mapping[str, str] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.message = message
+        self.code = code or self.default_code
+        self.hint = hint
+        self.details = dict(details or {})
+
+    def as_dict(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "type": type(self).__name__,
+            "domain": self.domain,
+            "code": self.code,
+            "message": self.message,
+        }
+        if self.hint:
+            payload["hint"] = self.hint
+        if self.details:
+            payload["details"] = self.details
+        return payload
+
+
+class KV260Error(PCCXLauncherError):
+    """KV260 target detection, access, or support failure."""
+
+    domain = "kv260"
+    default_code = "kv260_error"
+
+
+class AxiError(PCCXLauncherError):
+    """AXI bridge, register, or FPGA fabric access failure."""
+
+    domain = "axi"
+    default_code = "axi_error"
+
+
+class GemmaError(PCCXLauncherError):
+    """Gemma model descriptor, asset, or runtime handoff failure."""
+
+    domain = "gemma"
+    default_code = "gemma_error"
+
+
+class TraceError(PCCXLauncherError):
+    """Launcher trace, diagnostics, fixture, or argument failure."""
+
+    domain = "trace"
+    default_code = "trace_error"
+
+
+ERROR_TYPES: dict[str, type[PCCXLauncherError]] = {
+    cls.__name__: cls
+    for cls in (
+        PCCXLauncherError,
+        KV260Error,
+        AxiError,
+        GemmaError,
+        TraceError,
+    )
+}
+
+
+def format_error(error: PCCXLauncherError) -> str:
+    text = f"[ERROR] {type(error).__name__}({error.code}): {error.message}"
+    if error.hint:
+        text = f"{text}\n        hint: {error.hint}"
+    return text
+
+
+def create_error(
+    error_type: str,
+    message: str,
+    *,
+    code: str | None = None,
+    hint: str | None = None,
+) -> PCCXLauncherError:
+    try:
+        error_cls = ERROR_TYPES[error_type]
+    except KeyError as exc:
+        supported = ", ".join(sorted(ERROR_TYPES))
+        raise TraceError(
+            f"unknown launcher error type: {error_type}",
+            code="unknown_error_type",
+            hint=f"supported types: {supported}",
+        ) from exc
+    return error_cls(message, code=code, hint=hint)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Format a typed PCCX launcher error for shell stubs.",
+    )
+    parser.add_argument("error_type", choices=tuple(sorted(ERROR_TYPES)))
+    parser.add_argument("message")
+    parser.add_argument("--code", default=None)
+    parser.add_argument("--hint", default=None)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    error = create_error(
+        args.error_type,
+        args.message,
+        code=args.code,
+        hint=args.hint,
+    )
+    sys.stderr.write(format_error(error) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/chat-audit-event-stub.sh
+++ b/scripts/chat-audit-event-stub.sh
@@ -12,6 +12,9 @@ set -eu
 
 SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
 ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+PCCX_LAUNCHER_ROOT="$ROOT_DIR"
+# shellcheck source=scripts/lib/errors.sh
+. "$ROOT_DIR/scripts/lib/errors.sh"
 
 MODEL="gemma3n-e4b"
 TARGET="kv260"
@@ -21,7 +24,7 @@ while [ $# -gt 0 ]; do
         --model)
             MODEL="${2:-}"
             if [ -z "$MODEL" ]; then
-                printf '[ERROR] --model requires an argument\n' >&2
+                TRACE_ERROR "--model requires an argument"
                 exit 2
             fi
             shift 2
@@ -29,13 +32,13 @@ while [ $# -gt 0 ]; do
         --target)
             TARGET="${2:-}"
             if [ -z "$TARGET" ]; then
-                printf '[ERROR] --target requires an argument\n' >&2
+                TRACE_ERROR "--target requires an argument"
                 exit 2
             fi
             shift 2
             ;;
         *)
-            printf '[ERROR] unknown option: %s\n' "$1" >&2
+            TRACE_ERROR "unknown option: $1"
             exit 2
             ;;
     esac

--- a/scripts/chat-composer-stub.sh
+++ b/scripts/chat-composer-stub.sh
@@ -11,6 +11,9 @@ set -eu
 
 SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
 ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+PCCX_LAUNCHER_ROOT="$ROOT_DIR"
+# shellcheck source=scripts/lib/errors.sh
+. "$ROOT_DIR/scripts/lib/errors.sh"
 
 MODEL="gemma3n-e4b"
 TARGET="kv260"
@@ -20,7 +23,7 @@ while [ $# -gt 0 ]; do
         --model)
             MODEL="${2:-}"
             if [ -z "$MODEL" ]; then
-                printf '[ERROR] --model requires an argument\n' >&2
+                TRACE_ERROR "--model requires an argument"
                 exit 2
             fi
             shift 2
@@ -28,13 +31,13 @@ while [ $# -gt 0 ]; do
         --target)
             TARGET="${2:-}"
             if [ -z "$TARGET" ]; then
-                printf '[ERROR] --target requires an argument\n' >&2
+                TRACE_ERROR "--target requires an argument"
                 exit 2
             fi
             shift 2
             ;;
         *)
-            printf '[ERROR] unknown option: %s\n' "$1" >&2
+            TRACE_ERROR "unknown option: $1"
             exit 2
             ;;
     esac

--- a/scripts/chat-model-status-stub.sh
+++ b/scripts/chat-model-status-stub.sh
@@ -10,6 +10,9 @@ set -eu
 
 SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
 ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+PCCX_LAUNCHER_ROOT="$ROOT_DIR"
+# shellcheck source=scripts/lib/errors.sh
+. "$ROOT_DIR/scripts/lib/errors.sh"
 
 MODEL="gemma3n-e4b"
 TARGET="kv260"
@@ -19,7 +22,7 @@ while [ $# -gt 0 ]; do
         --model)
             MODEL="${2:-}"
             if [ -z "$MODEL" ]; then
-                printf '[ERROR] --model requires an argument\n' >&2
+                TRACE_ERROR "--model requires an argument"
                 exit 2
             fi
             shift 2
@@ -27,13 +30,13 @@ while [ $# -gt 0 ]; do
         --target)
             TARGET="${2:-}"
             if [ -z "$TARGET" ]; then
-                printf '[ERROR] --target requires an argument\n' >&2
+                TRACE_ERROR "--target requires an argument"
                 exit 2
             fi
             shift 2
             ;;
         *)
-            printf '[ERROR] unknown option: %s\n' "$1" >&2
+            TRACE_ERROR "unknown option: $1"
             exit 2
             ;;
     esac

--- a/scripts/chat-readiness-stub.sh
+++ b/scripts/chat-readiness-stub.sh
@@ -11,6 +11,9 @@ set -eu
 
 SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
 ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+PCCX_LAUNCHER_ROOT="$ROOT_DIR"
+# shellcheck source=scripts/lib/errors.sh
+. "$ROOT_DIR/scripts/lib/errors.sh"
 
 MODEL="gemma3n-e4b"
 TARGET="kv260"
@@ -20,7 +23,7 @@ while [ $# -gt 0 ]; do
         --model)
             MODEL="${2:-}"
             if [ -z "$MODEL" ]; then
-                printf '[ERROR] --model requires an argument\n' >&2
+                TRACE_ERROR "--model requires an argument"
                 exit 2
             fi
             shift 2
@@ -28,13 +31,13 @@ while [ $# -gt 0 ]; do
         --target)
             TARGET="${2:-}"
             if [ -z "$TARGET" ]; then
-                printf '[ERROR] --target requires an argument\n' >&2
+                TRACE_ERROR "--target requires an argument"
                 exit 2
             fi
             shift 2
             ;;
         *)
-            printf '[ERROR] unknown option: %s\n' "$1" >&2
+            TRACE_ERROR "unknown option: $1"
             exit 2
             ;;
     esac

--- a/scripts/chat-send-result-stub.sh
+++ b/scripts/chat-send-result-stub.sh
@@ -11,6 +11,9 @@ set -eu
 
 SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
 ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+PCCX_LAUNCHER_ROOT="$ROOT_DIR"
+# shellcheck source=scripts/lib/errors.sh
+. "$ROOT_DIR/scripts/lib/errors.sh"
 
 MODEL="gemma3n-e4b"
 TARGET="kv260"
@@ -20,7 +23,7 @@ while [ $# -gt 0 ]; do
         --model)
             MODEL="${2:-}"
             if [ -z "$MODEL" ]; then
-                printf '[ERROR] --model requires an argument\n' >&2
+                TRACE_ERROR "--model requires an argument"
                 exit 2
             fi
             shift 2
@@ -28,13 +31,13 @@ while [ $# -gt 0 ]; do
         --target)
             TARGET="${2:-}"
             if [ -z "$TARGET" ]; then
-                printf '[ERROR] --target requires an argument\n' >&2
+                TRACE_ERROR "--target requires an argument"
                 exit 2
             fi
             shift 2
             ;;
         *)
-            printf '[ERROR] unknown option: %s\n' "$1" >&2
+            TRACE_ERROR "unknown option: $1"
             exit 2
             ;;
     esac

--- a/scripts/chat-session-lifecycle-stub.sh
+++ b/scripts/chat-session-lifecycle-stub.sh
@@ -5,7 +5,11 @@
 
 set -eu
 
-ERROR() { printf '[ERROR] %s\n' "$*" >&2; }
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+PCCX_LAUNCHER_ROOT="$ROOT_DIR"
+# shellcheck source=scripts/lib/errors.sh
+. "$ROOT_DIR/scripts/lib/errors.sh"
 
 usage() {
     cat <<'EOF'
@@ -25,7 +29,7 @@ while [ $# -gt 0 ]; do
     case "$1" in
         --model)
             if [ -z "${2:-}" ]; then
-                ERROR "--model requires an argument"
+                TRACE_ERROR "--model requires an argument"
                 exit 1
             fi
             MODEL="$2"
@@ -33,7 +37,7 @@ while [ $# -gt 0 ]; do
             ;;
         --target)
             if [ -z "${2:-}" ]; then
-                ERROR "--target requires an argument"
+                TRACE_ERROR "--target requires an argument"
                 exit 1
             fi
             TARGET="$2"
@@ -44,15 +48,12 @@ while [ $# -gt 0 ]; do
             exit 0
             ;;
         *)
-            ERROR "unknown option: $1"
+            TRACE_ERROR "unknown option: $1"
             usage >&2
             exit 1
             ;;
     esac
 done
-
-SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
-ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
 
 python3 "$ROOT_DIR/contracts/chat_session_lifecycle_contract.py" \
     --model "$MODEL" \

--- a/scripts/chat-stub.sh
+++ b/scripts/chat-stub.sh
@@ -5,6 +5,12 @@
 
 set -u
 
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+PCCX_LAUNCHER_ROOT="$ROOT_DIR"
+# shellcheck source=scripts/lib/errors.sh
+. "$ROOT_DIR/scripts/lib/errors.sh"
+
 INFO() { printf '[INFO]  %s\n' "$*"; }
 NOTE() { printf '[NOTE]  %s\n' "$*"; }
 HEAD() { printf '\n=== %s ===\n' "$*"; }
@@ -23,20 +29,20 @@ while [ $# -gt 0 ]; do
             shift 2
             ;;
         *)
-            printf '[ERROR] unknown option: %s\n' "$1" >&2
+            TRACE_ERROR "unknown option: $1"
             exit 1
             ;;
     esac
 done
 
 if [ "$DRY_RUN" -eq 0 ]; then
-    printf '[ERROR] --dry-run is required. No model is available for execution.\n' >&2
+    GEMMA_ERROR "--dry-run is required. No model is available for execution."
     printf '        Real chat requires pccx-FPGA verified bring-up.\n' >&2
     exit 1
 fi
 
 if [ -z "$PROMPT" ] && [ -t 0 ]; then
-    printf '[ERROR] provide --prompt "..." or pipe input via stdin.\n' >&2
+    TRACE_ERROR 'provide --prompt "..." or pipe input via stdin.'
     exit 1
 fi
 

--- a/scripts/chat-surface-preview.sh
+++ b/scripts/chat-surface-preview.sh
@@ -5,7 +5,11 @@
 
 set -eu
 
-ERROR() { printf '[ERROR] %s\n' "$*" >&2; }
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+PCCX_LAUNCHER_ROOT="$ROOT_DIR"
+# shellcheck source=scripts/lib/errors.sh
+. "$ROOT_DIR/scripts/lib/errors.sh"
 
 usage() {
     cat <<'EOF'
@@ -24,7 +28,7 @@ while [ $# -gt 0 ]; do
     case "$1" in
         --model)
             if [ -z "${2:-}" ]; then
-                ERROR "--model requires an argument"
+                TRACE_ERROR "--model requires an argument"
                 exit 1
             fi
             MODEL="$2"
@@ -32,7 +36,7 @@ while [ $# -gt 0 ]; do
             ;;
         --target)
             if [ -z "${2:-}" ]; then
-                ERROR "--target requires an argument"
+                TRACE_ERROR "--target requires an argument"
                 exit 1
             fi
             TARGET="$2"
@@ -43,24 +47,22 @@ while [ $# -gt 0 ]; do
             exit 0
             ;;
         *)
-            ERROR "unknown option: $1"
+            TRACE_ERROR "unknown option: $1"
             usage >&2
             exit 1
             ;;
     esac
 done
 
-SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
-ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
 CHAT_SESSION_STUB="$ROOT_DIR/scripts/chat-session-stub.sh"
 
 if [ ! -f "$CHAT_SESSION_STUB" ]; then
-    ERROR "chat/session stub not found: $CHAT_SESSION_STUB"
+    TRACE_ERROR "chat/session stub not found: $CHAT_SESSION_STUB"
     exit 1
 fi
 
 if ! CHAT_SESSION_JSON="$(bash "$CHAT_SESSION_STUB" --model "$MODEL" --target "$TARGET" 2>&1)"; then
-    ERROR "chat/session stub failed"
+    TRACE_ERROR "chat/session stub failed"
     printf '%s\n' "$CHAT_SESSION_JSON" >&2
     exit 1
 fi

--- a/scripts/chat-transcript-policy-stub.sh
+++ b/scripts/chat-transcript-policy-stub.sh
@@ -12,6 +12,9 @@ set -eu
 
 SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
 ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+PCCX_LAUNCHER_ROOT="$ROOT_DIR"
+# shellcheck source=scripts/lib/errors.sh
+. "$ROOT_DIR/scripts/lib/errors.sh"
 
 MODEL="gemma3n-e4b"
 TARGET="kv260"
@@ -21,7 +24,7 @@ while [ $# -gt 0 ]; do
         --model)
             MODEL="${2:-}"
             if [ -z "$MODEL" ]; then
-                printf '[ERROR] --model requires an argument\n' >&2
+                TRACE_ERROR "--model requires an argument"
                 exit 2
             fi
             shift 2
@@ -29,13 +32,13 @@ while [ $# -gt 0 ]; do
         --target)
             TARGET="${2:-}"
             if [ -z "$TARGET" ]; then
-                printf '[ERROR] --target requires an argument\n' >&2
+                TRACE_ERROR "--target requires an argument"
                 exit 2
             fi
             shift 2
             ;;
         *)
-            printf '[ERROR] unknown option: %s\n' "$1" >&2
+            TRACE_ERROR "unknown option: $1"
             exit 2
             ;;
     esac

--- a/scripts/device-session-status-stub.sh
+++ b/scripts/device-session-status-stub.sh
@@ -5,17 +5,21 @@
 
 set -eu
 
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+PCCX_LAUNCHER_ROOT="$ROOT_DIR"
+# shellcheck source=scripts/lib/errors.sh
+. "$ROOT_DIR/scripts/lib/errors.sh"
+
 MODEL="gemma3n-e4b"
 TARGET="kv260"
-
-ERROR() { printf '[ERROR] %s\n' "$*" >&2; }
 
 while [ $# -gt 0 ]; do
     case "$1" in
         --model)
             MODEL="${2:-}"
             if [ -z "$MODEL" ]; then
-                ERROR "--model requires an argument"
+                TRACE_ERROR "--model requires an argument"
                 exit 1
             fi
             shift 2
@@ -23,30 +27,27 @@ while [ $# -gt 0 ]; do
         --target)
             TARGET="${2:-}"
             if [ -z "$TARGET" ]; then
-                ERROR "--target requires an argument"
+                TRACE_ERROR "--target requires an argument"
                 exit 1
             fi
             shift 2
             ;;
         *)
-            ERROR "unknown option: $1"
+            TRACE_ERROR "unknown option: $1"
             exit 1
             ;;
     esac
 done
 
 if [ "$MODEL" != "gemma3n-e4b" ]; then
-    ERROR "unsupported model: $MODEL (supported: gemma3n-e4b)"
+    GEMMA_ERROR "unsupported model: $MODEL (supported: gemma3n-e4b)"
     exit 1
 fi
 
 if [ "$TARGET" != "kv260" ]; then
-    ERROR "unsupported target: $TARGET (supported: kv260)"
+    KV260_ERROR "unsupported target: $TARGET (supported: kv260)"
     exit 1
 fi
-
-SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
-ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
 
 python3 "$ROOT_DIR/contracts/device_session_status_contract.py" \
     --model "$MODEL" \

--- a/scripts/launch-stub.sh
+++ b/scripts/launch-stub.sh
@@ -13,6 +13,12 @@
 
 set -u
 
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+PCCX_LAUNCHER_ROOT="$ROOT_DIR"
+# shellcheck source=scripts/lib/errors.sh
+. "$ROOT_DIR/scripts/lib/errors.sh"
+
 INFO()  { printf '[INFO]  %s\n' "$*"; }
 NOTE()  { printf '[NOTE]  %s\n' "$*"; }
 HEAD()  { printf '\n=== %s ===\n' "$*"; }
@@ -21,12 +27,12 @@ DRY_RUN=0
 while [ $# -gt 0 ]; do
     case "$1" in
         --dry-run) DRY_RUN=1; shift ;;
-        *) printf '[ERROR] unknown option: %s\n' "$1" >&2; exit 1 ;;
+        *) TRACE_ERROR "unknown option: $1"; exit 1 ;;
     esac
 done
 
 if [ "$DRY_RUN" -eq 0 ]; then
-    printf '[ERROR] --dry-run is required. This stub does not execute a real launch.\n' >&2
+    GEMMA_ERROR "--dry-run is required. This stub does not execute a real launch."
     printf '        Pass --dry-run to see the planned launch sequence preview.\n' >&2
     exit 1
 fi

--- a/scripts/lib/errors.sh
+++ b/scripts/lib/errors.sh
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+
+launcher_error() {
+    if [ "$#" -lt 2 ]; then
+        printf '[ERROR] TraceError(trace_error): launcher_error requires a type and message\n' >&2
+        return 1
+    fi
+
+    local root_dir="${PCCX_LAUNCHER_ROOT:-}"
+    if [ -z "$root_dir" ]; then
+        printf '[ERROR] TraceError(trace_error): PCCX_LAUNCHER_ROOT is not set\n' >&2
+        return 1
+    fi
+
+    local error_type="$1"
+    shift
+    python3 "$root_dir/pccx_launcher/errors.py" "$error_type" "$*" >&2
+}
+
+AXI_ERROR() { launcher_error AxiError "$*"; }
+GEMMA_ERROR() { launcher_error GemmaError "$*"; }
+KV260_ERROR() { launcher_error KV260Error "$*"; }
+TRACE_ERROR() { launcher_error TraceError "$*"; }

--- a/scripts/runtime-readiness-stub.sh
+++ b/scripts/runtime-readiness-stub.sh
@@ -9,7 +9,11 @@
 
 set -eu
 
-ERROR() { printf '[ERROR] %s\n' "$*" >&2; }
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+PCCX_LAUNCHER_ROOT="$ROOT_DIR"
+# shellcheck source=scripts/lib/errors.sh
+. "$ROOT_DIR/scripts/lib/errors.sh"
 
 MODEL=""
 TARGET=""
@@ -23,7 +27,7 @@ while [ $# -gt 0 ]; do
         --model)
             MODEL="${2:-}"
             if [ -z "$MODEL" ]; then
-                ERROR "--model requires an argument"
+                TRACE_ERROR "--model requires an argument"
                 exit 1
             fi
             shift 2
@@ -31,7 +35,7 @@ while [ $# -gt 0 ]; do
         --target)
             TARGET="${2:-}"
             if [ -z "$TARGET" ]; then
-                ERROR "--target requires an argument"
+                TRACE_ERROR "--target requires an argument"
                 exit 1
             fi
             shift 2
@@ -41,7 +45,7 @@ while [ $# -gt 0 ]; do
             exit 0
             ;;
         *)
-            ERROR "unknown option: $1"
+            TRACE_ERROR "unknown option: $1"
             usage >&2
             exit 1
             ;;
@@ -49,17 +53,14 @@ while [ $# -gt 0 ]; do
 done
 
 if [ "$MODEL" != "gemma3n-e4b" ]; then
-    ERROR "--model must be gemma3n-e4b"
+    GEMMA_ERROR "--model must be gemma3n-e4b"
     exit 1
 fi
 
 if [ "$TARGET" != "kv260" ]; then
-    ERROR "--target must be kv260"
+    KV260_ERROR "--target must be kv260"
     exit 1
 fi
-
-SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
-ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
 
 python3 "$ROOT_DIR/contracts/runtime_readiness_contract.py" \
     --model "$MODEL" \

--- a/scripts/status-stub.sh
+++ b/scripts/status-stub.sh
@@ -109,9 +109,15 @@
 
 set -u
 
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+ROOT_DIR="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+PCCX_LAUNCHER_ROOT="$ROOT_DIR"
+# shellcheck source=scripts/lib/errors.sh
+. "$ROOT_DIR/scripts/lib/errors.sh"
+
 INFO()  { printf '[INFO]  %s\n' "$*"; }
 NOTE()  { printf '[NOTE]  %s\n' "$*"; }
-ERROR() { printf '[ERROR] %s\n' "$*" >&2; }
+ERROR() { TRACE_ERROR "$*"; }
 HEAD()  { printf '\n=== %s ===\n' "$*"; }
 
 BACKEND=""

--- a/scripts/tests/pccx_launcher_errors_test.py
+++ b/scripts/tests/pccx_launcher_errors_test.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+"""Tests for the launcher typed error hierarchy."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+from pccx_launcher.errors import (  # noqa: E402
+    AxiError,
+    GemmaError,
+    KV260Error,
+    PCCXLauncherError,
+    TraceError,
+    format_error,
+)
+
+
+def test_error_hierarchy_and_domains() -> None:
+    expected = [
+        (KV260Error, "kv260"),
+        (AxiError, "axi"),
+        (GemmaError, "gemma"),
+        (TraceError, "trace"),
+    ]
+    for error_cls, domain in expected:
+        error = error_cls("fixture failure")
+        assert isinstance(error, PCCXLauncherError)
+        assert error.domain == domain
+        assert error.as_dict()["type"] == error_cls.__name__
+
+
+def test_format_error_includes_type_code_and_message() -> None:
+    error = GemmaError(
+        "Gemma assets are not configured",
+        code="gemma_assets_missing",
+    )
+    assert (
+        format_error(error)
+        == "[ERROR] GemmaError(gemma_assets_missing): Gemma assets are not configured"
+    )
+
+
+def test_error_cli_formats_shell_stub_output() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "pccx_launcher" / "errors.py"),
+            "KV260Error",
+            "--target must be kv260",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert result.stdout == ""
+    assert result.stderr == "[ERROR] KV260Error(kv260_error): --target must be kv260\n"
+
+
+test_error_hierarchy_and_domains()
+test_format_error_includes_type_code_and_message()
+test_error_cli_formats_shell_stub_output()


### PR DESCRIPTION
## Summary
- add pccx_launcher.errors typed launcher hierarchy for KV260, AXI, Gemma, and trace failures
- route launcher stub error output through typed shell helpers
- replace remaining generic fixture validation raises with TraceError and add CI coverage

## Tests
- python3 scripts/tests/pccx_launcher_errors_test.py
- set -e; for f in scripts/chat-accessibility-stub.sh
scripts/chat-action-bar-stub.sh
scripts/chat-attachment-policy-stub.sh
scripts/chat-audit-event-stub.sh
scripts/chat-clipboard-policy-stub.sh
scripts/chat-composer-stub.sh
scripts/chat-context-policy-stub.sh
scripts/chat-empty-state-stub.sh
scripts/chat-error-taxonomy-stub.sh
scripts/chat-evidence-manifest-stub.sh
scripts/chat-gap-matrix-stub.sh
scripts/chat-local-only-policy-stub.sh
scripts/chat-message-list-stub.sh
scripts/chat-model-load-request-stub.sh
scripts/chat-model-selection-policy-stub.sh
scripts/chat-model-status-stub.sh
scripts/chat-preferences-stub.sh
scripts/chat-readiness-stub.sh
scripts/chat-redaction-policy-stub.sh
scripts/chat-response-stream-stub.sh
scripts/chat-review-packet-stub.sh
scripts/chat-send-result-stub.sh
scripts/chat-session-index-stub.sh
scripts/chat-session-lifecycle-stub.sh
scripts/chat-session-store-policy-stub.sh
scripts/chat-session-stub.sh
scripts/chat-session-title-policy-stub.sh
scripts/chat-shortcut-map-stub.sh
scripts/chat-status-summary-stub.sh
scripts/chat-stub.sh
scripts/chat-surface-layout-stub.sh
scripts/chat-surface-preview.sh
scripts/chat-transcript-policy-stub.sh
scripts/check-device-stub.sh
scripts/check.sh
scripts/device-session-status-stub.sh
scripts/install-stub.sh
scripts/launch-stub.sh
scripts/lib/errors.sh
scripts/runtime-readiness-stub.sh
scripts/status-stub.sh
scripts/tests/status-backend.sh
scripts/tests/status-chat-accessibility.sh
scripts/tests/status-chat-action-bar.sh
scripts/tests/status-chat-attachment-policy.sh
scripts/tests/status-chat-audit-event.sh
scripts/tests/status-chat-clipboard-policy.sh
scripts/tests/status-chat-composer.sh
scripts/tests/status-chat-context-policy.sh
scripts/tests/status-chat-empty-state.sh
scripts/tests/status-chat-error-taxonomy.sh
scripts/tests/status-chat-evidence-manifest.sh
scripts/tests/status-chat-gap-matrix.sh
scripts/tests/status-chat-local-only-policy.sh
scripts/tests/status-chat-message-list.sh
scripts/tests/status-chat-model-load-request.sh
scripts/tests/status-chat-model-selection-policy.sh
scripts/tests/status-chat-model-status.sh
scripts/tests/status-chat-preferences.sh
scripts/tests/status-chat-readiness.sh
scripts/tests/status-chat-redaction-policy.sh
scripts/tests/status-chat-response-stream.sh
scripts/tests/status-chat-review-packet.sh
scripts/tests/status-chat-send-result.sh
scripts/tests/status-chat-session-index.sh
scripts/tests/status-chat-session-store-policy.sh
scripts/tests/status-chat-session-title-policy.sh
scripts/tests/status-chat-session.sh
scripts/tests/status-chat-shortcut-map.sh
scripts/tests/status-chat-status-summary.sh
scripts/tests/status-chat-surface-layout.sh
scripts/tests/status-chat-transcript-policy.sh
scripts/tests/status-device-session.sh
scripts/tests/status-readiness.sh; do bash -n ""; done
- set -e; for f in scripts/tests/*_test.py; do python3 ""; done
- bash scripts/tests/status-chat-local-only-policy.sh && bash scripts/tests/status-chat-preferences.sh
- claim-scan clean

Note: shellcheck is not installed in this local container.