### PR TITLE
chore(deps): dev dependency snapshot

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+
+# Current Python development dependency snapshot.
+#
+# The repository's Python contract checks use only the standard library.
+# Shell linting depends on shellcheck, installed by CI as an OS package.
+# No third-party pip development packages are required at this time.


### PR DESCRIPTION
## Summary
- add requirements-dev.txt documenting the current Python dev dependency snapshot
- note that current contract checks use only the Python standard library and shellcheck is installed as an OS package in CI

## Tests
- /tmp/launcher-dep-frz-pipcheck/bin/python -m pip install --dry-run -r requirements-dev.txt
- bash scripts/check.sh