### PR TITLE
Add PCCX source headers and SPDX notices

### DIFF
--- a/assets/icon.svg
+++ b/assets/icon.svg
@@ -1,3 +1,9 @@
+<!--
+PCCX™ — reusable AI accelerator project.
+SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+SPDX-License-Identifier: Apache-2.0
+-->
+
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
   <rect width="64" height="64" rx="14" fill="#0a0a0f"/>
   <text x="32" y="44" font-size="36" text-anchor="middle" fill="#8b5cf6">✦</text>

--- a/contracts/diagnostics_handoff_contract.py
+++ b/contracts/diagnostics_handoff_contract.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# PCCX(TM) — reusable AI accelerator project.
+# SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+# SPDX-License-Identifier: Apache-2.0
+
 """Data-only diagnostics handoff contract placeholder.
 
 The contract describes a future read-only handoff from pccx-llm-launcher

--- a/contracts/launcher_ide_status_contract.py
+++ b/contracts/launcher_ide_status_contract.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# PCCX(TM) — reusable AI accelerator project.
+# SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+# SPDX-License-Identifier: Apache-2.0
+
 """Data-only launcher/IDE status contract placeholder.
 
 The contract is intentionally static. It describes planned boundaries for

--- a/contracts/model_runtime_descriptor_contract.py
+++ b/contracts/model_runtime_descriptor_contract.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# PCCX(TM) — reusable AI accelerator project.
+# SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+# SPDX-License-Identifier: Apache-2.0
+
 """Data-only model/runtime descriptor contract placeholder.
 
 The contract describes model and runtime vocabulary for future launcher

--- a/scripts/chat-stub.sh
+++ b/scripts/chat-stub.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# PCCX(TM) — reusable AI accelerator project.
+# SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+# SPDX-License-Identifier: Apache-2.0
+
 # scripts/chat-stub.sh — dry-run chat stub
 # Requires --dry-run. No model is executed. No network call is made.
 # Accepts a prompt via --prompt "..." or stdin.

--- a/scripts/check-device-stub.sh
+++ b/scripts/check-device-stub.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# PCCX(TM) — reusable AI accelerator project.
+# SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+# SPDX-License-Identifier: Apache-2.0
+
 # scripts/check-device-stub.sh — narrowly-scoped device probe.
 #
 # A focused complement to scripts/check.sh: this stub only inspects what

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# PCCX(TM) — reusable AI accelerator project.
+# SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+# SPDX-License-Identifier: Apache-2.0
+
 # scripts/check.sh — minimal environment / target-device check for
 # pccx-llm-launcher. This is intentionally a lightweight, honest probe:
 # it reports what is present, but it does NOT claim that any particular

--- a/scripts/install-stub.sh
+++ b/scripts/install-stub.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# PCCX(TM) — reusable AI accelerator project.
+# SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+# SPDX-License-Identifier: Apache-2.0
+
 # scripts/install-stub.sh — preview of the *intended* install flow.
 #
 # This script does NOT install anything. It only describes which package

--- a/scripts/launch-stub.sh
+++ b/scripts/launch-stub.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# PCCX(TM) — reusable AI accelerator project.
+# SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+# SPDX-License-Identifier: Apache-2.0
+
 # scripts/launch-stub.sh — dry-run preview of the *intended* launcher
 # sequence. This script does NOT run inference, does NOT open a model,
 # and does NOT talk to a target device. It only describes what the

--- a/scripts/tests/diagnostics_handoff_contract_test.py
+++ b/scripts/tests/diagnostics_handoff_contract_test.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# PCCX(TM) — reusable AI accelerator project.
+# SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+# SPDX-License-Identifier: Apache-2.0
+
 """Fixture tests for the launcher diagnostics handoff contract."""
 
 from __future__ import annotations

--- a/scripts/tests/launcher_ide_contract_test.py
+++ b/scripts/tests/launcher_ide_contract_test.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# PCCX(TM) — reusable AI accelerator project.
+# SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+# SPDX-License-Identifier: Apache-2.0
+
 """Fixture tests for the launcher/IDE status contract."""
 
 from __future__ import annotations

--- a/scripts/tests/model_runtime_descriptor_test.py
+++ b/scripts/tests/model_runtime_descriptor_test.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# PCCX(TM) — reusable AI accelerator project.
+# SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+# SPDX-License-Identifier: Apache-2.0
+
 """Fixture tests for the model/runtime descriptor boundary."""
 
 from __future__ import annotations

--- a/scripts/tests/status-backend.sh
+++ b/scripts/tests/status-backend.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# PCCX(TM) — reusable AI accelerator project.
+# SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+# SPDX-License-Identifier: Apache-2.0
+
 # scripts/tests/status-backend.sh — pccx-lab backend smoke tests for status-stub.sh
 #
 # Usage: bash scripts/tests/status-backend.sh [path/to/status-stub.sh]


### PR DESCRIPTION
Adds `PCCX(TM)` + `SPDX-FileCopyrightText` + `SPDX-License-Identifier: Apache-2.0` to source files that lack a header. No identifiers/modules/packages renamed; no behavior changes; no `PCCX®` claim; no private filing materials. Generated/vendor/lock/binary files skipped.