### PR TITLE
Tauri config + package metadata follow-up for pccx-launcher rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-# pccx-llm-launcher
+# pccx-launcher
 
-Lightweight launcher for PCCX-oriented local LLM workflows.
+Lightweight launcher for PCCX-oriented local LLM workflows. PCCX™
+technology and Altifigence™ are owned by Hyun Woo Kim.
 
 ## What this repo is
 

--- a/contracts/chat_accessibility_contract.py
+++ b/contracts/chat_accessibility_contract.py
@@ -556,7 +556,7 @@ _CHAT_ACCESSIBILITY = {
         "No pccx-lab invocation, systemverilog-ide invocation, MCP server, LSP, compatibility promise, storage layer, runtime, model-loader, or hardware implementation is included.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_action_bar_contract.py
+++ b/contracts/chat_action_bar_contract.py
@@ -465,7 +465,7 @@ _CHAT_ACTION_BAR = {
         "This is not a release, tag, compatibility commitment, MCP, LSP, IDE, marketplace, telemetry, or runtime implementation.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_attachment_policy_contract.py
+++ b/contracts/chat_attachment_policy_contract.py
@@ -447,7 +447,7 @@ _CHAT_ATTACHMENT_POLICY = {
         "This is not a release, tag, compatibility commitment, MCP, LSP, IDE, marketplace, telemetry, runtime, model, parser, file-input, or storage implementation.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_audit_event_contract.py
+++ b/contracts/chat_audit_event_contract.py
@@ -436,7 +436,7 @@ _CHAT_AUDIT_EVENT = {
         "This is not a release, tag, versioned compatibility commitment, MCP, LSP, IDE, marketplace, or telemetry implementation.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_clipboard_policy_contract.py
+++ b/contracts/chat_clipboard_policy_contract.py
@@ -416,7 +416,7 @@ _CHAT_CLIPBOARD_POLICY = {
         "This is not a release, tag, compatibility commitment, MCP, LSP, IDE, marketplace, telemetry, or runtime implementation.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_composer_contract.py
+++ b/contracts/chat_composer_contract.py
@@ -326,7 +326,7 @@ _CHAT_COMPOSER = {
         "This is not a release, tag, versioned compatibility commitment, MCP, LSP, IDE, marketplace, or telemetry implementation.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_context_policy_contract.py
+++ b/contracts/chat_context_policy_contract.py
@@ -410,7 +410,7 @@ _CHAT_CONTEXT_POLICY = {
         "This is not a release, tag, compatibility commitment, marketplace flow, storage layer, tokenizer implementation, context manager, runtime, model-loader, or hardware implementation.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_empty_state_contract.py
+++ b/contracts/chat_empty_state_contract.py
@@ -403,7 +403,7 @@ _CHAT_EMPTY_STATE = {
         "No pccx-lab invocation, systemverilog-ide invocation, MCP server, LSP, compatibility promise, storage layer, runtime, model-loader, or hardware implementation is included.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_error_taxonomy_contract.py
+++ b/contracts/chat_error_taxonomy_contract.py
@@ -369,7 +369,7 @@ _CHAT_ERROR_TAXONOMY = {
         "no compatibility promise is made",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_evidence_manifest_contract.py
+++ b/contracts/chat_evidence_manifest_contract.py
@@ -544,7 +544,7 @@ _CHAT_EVIDENCE_MANIFEST = {
         "This manifest does not close issue #9, approve review gates, accept evidence, close gaps, or enable standalone chat.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_gap_matrix_contract.py
+++ b/contracts/chat_gap_matrix_contract.py
@@ -451,7 +451,7 @@ _CHAT_GAP_MATRIX = {
         "This matrix does not close issue #9 or approve standalone chat enablement; it records remaining blocker rows only.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_local_only_policy_contract.py
+++ b/contracts/chat_local_only_policy_contract.py
@@ -307,7 +307,7 @@ _CHAT_LOCAL_ONLY_POLICY = {
         "send controls remain disabled until separate reviewed boundaries exist",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_message_list_contract.py
+++ b/contracts/chat_message_list_contract.py
@@ -346,7 +346,7 @@ _CHAT_MESSAGE_LIST = {
         "This is not a release, tag, compatibility commitment, MCP, LSP, IDE, marketplace, telemetry, or runtime implementation.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_model_load_request_contract.py
+++ b/contracts/chat_model_load_request_contract.py
@@ -481,7 +481,7 @@ _CHAT_MODEL_LOAD_REQUEST = {
         "This is not a release, tag, compatibility commitment, MCP, LSP, IDE, marketplace, telemetry, runtime, model-loader, provider, storage, or hardware implementation.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_model_selection_policy_contract.py
+++ b/contracts/chat_model_selection_policy_contract.py
@@ -381,7 +381,7 @@ _CHAT_MODEL_SELECTION_POLICY = {
         "This is not a release, tag, compatibility commitment, marketplace flow, provider integration, storage layer, runtime, model-loader, or hardware implementation.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_model_status_contract.py
+++ b/contracts/chat_model_status_contract.py
@@ -325,7 +325,7 @@ _CHAT_MODEL_STATUS = {
         "This is not a release, tag, versioned compatibility commitment, MCP, LSP, IDE, marketplace, or telemetry implementation.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_preferences_contract.py
+++ b/contracts/chat_preferences_contract.py
@@ -356,7 +356,7 @@ _CHAT_PREFERENCES = {
         "no compatibility promise is made",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_readiness_contract.py
+++ b/contracts/chat_readiness_contract.py
@@ -388,7 +388,7 @@ _CHAT_READINESS = {
         "This is not a release, tag, versioned compatibility commitment, MCP, LSP, IDE, marketplace, or telemetry implementation.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_redaction_policy_contract.py
+++ b/contracts/chat_redaction_policy_contract.py
@@ -499,7 +499,7 @@ _CHAT_REDACTION_POLICY = {
         "This is not a release, tag, compatibility commitment, MCP, LSP, IDE, marketplace, telemetry, or runtime implementation.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_response_stream_contract.py
+++ b/contracts/chat_response_stream_contract.py
@@ -378,7 +378,7 @@ _CHAT_RESPONSE_STREAM = {
         "This is not a release, tag, versioned compatibility commitment, MCP, LSP, IDE, marketplace, or telemetry implementation.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_review_packet_contract.py
+++ b/contracts/chat_review_packet_contract.py
@@ -399,7 +399,7 @@ _CHAT_REVIEW_PACKET = {
         "This packet does not approve standalone chat enablement; it records remaining review and evidence gates only.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_send_result_contract.py
+++ b/contracts/chat_send_result_contract.py
@@ -288,7 +288,7 @@ _CHAT_SEND_RESULT = {
         "This is not a release, tag, versioned compatibility commitment, MCP, LSP, IDE, marketplace, or telemetry implementation.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_session_contract.py
+++ b/contracts/chat_session_contract.py
@@ -251,7 +251,7 @@ _CHAT_SESSION_STATUS = {
         "This is not a release, tag, versioned compatibility commitment, MCP, LSP, IDE, marketplace, or telemetry implementation.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_session_index_contract.py
+++ b/contracts/chat_session_index_contract.py
@@ -340,7 +340,7 @@ _CHAT_SESSION_INDEX = {
         "This is not a release, tag, versioned compatibility commitment, MCP, LSP, IDE, marketplace, telemetry, or session-store implementation.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_session_lifecycle_contract.py
+++ b/contracts/chat_session_lifecycle_contract.py
@@ -367,7 +367,7 @@ _CHAT_SESSION_LIFECYCLE = {
         "This is not a release, tag, versioned compatibility commitment, MCP, LSP, IDE, marketplace, or telemetry implementation.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_session_store_policy_contract.py
+++ b/contracts/chat_session_store_policy_contract.py
@@ -482,7 +482,7 @@ _CHAT_SESSION_STORE_POLICY = {
         "This is not a release, tag, compatibility commitment, MCP, LSP, IDE, marketplace, telemetry, runtime, model, session-store, migration, or storage implementation.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_session_title_policy_contract.py
+++ b/contracts/chat_session_title_policy_contract.py
@@ -344,7 +344,7 @@ _CHAT_SESSION_TITLE_POLICY = {
         "This is not a release, tag, versioned compatibility commitment, MCP, LSP, IDE, marketplace, telemetry, runtime, model, or session-store implementation.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_shortcut_map_contract.py
+++ b/contracts/chat_shortcut_map_contract.py
@@ -485,7 +485,7 @@ _CHAT_SHORTCUT_MAP = {
         "This is not a release, tag, compatibility commitment, MCP, LSP, IDE, marketplace, telemetry, or runtime implementation.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_status_summary_contract.py
+++ b/contracts/chat_status_summary_contract.py
@@ -363,7 +363,7 @@ _CHAT_STATUS_SUMMARY = {
         "Send and response streaming remain disabled until separate reviewed runtime, model, device-session, content, and persistence boundaries exist.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_surface_layout_contract.py
+++ b/contracts/chat_surface_layout_contract.py
@@ -435,7 +435,7 @@ _CHAT_SURFACE_LAYOUT = {
         "This is not a release, tag, versioned compatibility commitment, MCP, LSP, IDE, marketplace, telemetry, or app-shell implementation.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_transcript_policy_contract.py
+++ b/contracts/chat_transcript_policy_contract.py
@@ -309,7 +309,7 @@ _CHAT_TRANSCRIPT_POLICY = {
         "This is not a release, tag, versioned compatibility commitment, MCP, LSP, IDE, marketplace, or telemetry implementation.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/device_session_status_contract.py
+++ b/contracts/device_session_status_contract.py
@@ -391,8 +391,8 @@ _DEVICE_SESSION_STATUS = {
         "This is not a release, tag, versioned compatibility commitment, MCP, LSP, IDE, marketplace, or telemetry implementation.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#10",
-        "pccxai/pccx-llm-launcher#2",
+        "pccxai/pccx-launcher#10",
+        "pccxai/pccx-launcher#2",
     ],
 }
 

--- a/contracts/diagnostics_handoff_contract.py
+++ b/contracts/diagnostics_handoff_contract.py
@@ -5,7 +5,7 @@
 
 """Data-only diagnostics handoff contract placeholder.
 
-The contract describes a future read-only handoff from pccx-llm-launcher
+The contract describes a future read-only handoff from pccx-launcher
 to pccx-lab. It does not execute pccx-lab, start launcher runtime code,
 probe hardware, load models, call providers, or write artifacts.
 """
@@ -77,7 +77,7 @@ _DIAGNOSTICS_HANDOFF = {
     "handoffId": "launcher_diagnostics_handoff_gemma3n_e4b_kv260_placeholder",
     "handoffKind": "read_only_handoff",
     "producer": {
-        "id": "pccx-llm-launcher",
+        "id": "pccx-launcher",
         "role": "launcher_generated_summary",
         "execution": "data_only",
     },
@@ -120,7 +120,7 @@ _DIAGNOSTICS_HANDOFF = {
             "diagnosticId": "launcher_target_not_configured",
             "severity": "warning",
             "category": "configuration",
-            "source": "pccx-llm-launcher",
+            "source": "pccx-launcher",
             "title": "Launcher target is not configured",
             "summary": "The handoff records a placeholder target state only.",
             "relatedContractRefs": [
@@ -134,7 +134,7 @@ _DIAGNOSTICS_HANDOFF = {
             "diagnosticId": "gemma3n_e4b_descriptor_reference_only",
             "severity": "info",
             "category": "model_descriptor",
-            "source": "pccx-llm-launcher",
+            "source": "pccx-launcher",
             "title": "Model descriptor is referenced by id",
             "summary": "Gemma 3N E4B is represented as descriptor_ref_only with no bundled assets.",
             "relatedContractRefs": [
@@ -148,7 +148,7 @@ _DIAGNOSTICS_HANDOFF = {
             "diagnosticId": "kv260_runtime_placeholder_not_configured",
             "severity": "blocked",
             "category": "runtime_descriptor",
-            "source": "pccx-llm-launcher",
+            "source": "pccx-launcher",
             "title": "KV260 runtime remains placeholder",
             "summary": "The runtime descriptor is planned, unavailable, and not configured.",
             "relatedContractRefs": [
@@ -163,7 +163,7 @@ _DIAGNOSTICS_HANDOFF = {
             "diagnosticId": "hardware_and_measurement_evidence_missing",
             "severity": "blocked",
             "category": "evidence",
-            "source": "pccx-llm-launcher",
+            "source": "pccx-launcher",
             "title": "Hardware and measurement evidence are missing",
             "summary": "Compatibility stays provisional until checked evidence exists.",
             "relatedContractRefs": [
@@ -177,7 +177,7 @@ _DIAGNOSTICS_HANDOFF = {
             "diagnosticId": "read_only_privacy_boundary",
             "severity": "info",
             "category": "safety",
-            "source": "pccx-llm-launcher",
+            "source": "pccx-launcher",
             "title": "Read-only privacy boundary is active",
             "summary": "The fixture carries no telemetry, upload, write-back, raw logs, prompts, or private paths.",
             "relatedContractRefs": [
@@ -290,9 +290,9 @@ _DIAGNOSTICS_HANDOFF = {
         "The contract is not a versioned compatibility commitment.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#5",
-        "pccxai/pccx-llm-launcher#3",
-        "pccxai/pccx-llm-launcher#12",
+        "pccxai/pccx-launcher#5",
+        "pccxai/pccx-launcher#3",
+        "pccxai/pccx-launcher#12",
     ],
 }
 

--- a/contracts/fixtures/chat-accessibility.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-accessibility.gemma3n-e4b-kv260-placeholder.json
@@ -234,7 +234,7 @@
   ],
   "inputState": "disabled",
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ],
   "landmarkRegions": [
     {

--- a/contracts/fixtures/chat-action-bar.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-action-bar.gemma3n-e4b-kv260-placeholder.json
@@ -259,7 +259,7 @@
     }
   ],
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ],
   "lastUpdatedSource": "pccx_launcher_issue_9_chat_action_bar_boundary_2026-05-04",
   "limitations": [

--- a/contracts/fixtures/chat-attachment-policy.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-attachment-policy.gemma3n-e4b-kv260-placeholder.json
@@ -234,7 +234,7 @@
   ],
   "importState": "disabled",
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ],
   "lastUpdatedSource": "pccx_launcher_issue_9_chat_attachment_policy_boundary_2026-05-04",
   "limitations": [

--- a/contracts/fixtures/chat-audit-event.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-audit-event.gemma3n-e4b-kv260-placeholder.json
@@ -206,7 +206,7 @@
     }
   ],
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ],
   "lastUpdatedSource": "pccx_launcher_issue_9_chat_audit_event_boundary_2026-05-04",
   "limitations": [

--- a/contracts/fixtures/chat-clipboard-policy.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-clipboard-policy.gemma3n-e4b-kv260-placeholder.json
@@ -208,7 +208,7 @@
     }
   ],
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ],
   "lastUpdatedSource": "pccx_launcher_issue_9_chat_clipboard_policy_boundary_2026-05-05",
   "limitations": [

--- a/contracts/fixtures/chat-composer.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-composer.gemma3n-e4b-kv260-placeholder.json
@@ -111,7 +111,7 @@
     "summary": "Composer fixture carries input control state only; no draft text is stored."
   },
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ],
   "lastUpdatedSource": "pccx_launcher_issue_9_chat_composer_boundary_2026-05-04",
   "limitations": [

--- a/contracts/fixtures/chat-context-policy.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-context-policy.gemma3n-e4b-kv260-placeholder.json
@@ -203,7 +203,7 @@
     }
   ],
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ],
   "lastUpdatedSource": "pccx_launcher_issue_9_chat_context_policy_boundary_2026-05-05",
   "limitations": [

--- a/contracts/fixtures/chat-empty-state.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-empty-state.gemma3n-e4b-kv260-placeholder.json
@@ -209,7 +209,7 @@
     }
   ],
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ],
   "lastUpdatedSource": "pccx_launcher_issue_9_chat_empty_state_boundary_2026-05-05",
   "limitations": [

--- a/contracts/fixtures/chat-error-taxonomy.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-error-taxonomy.gemma3n-e4b-kv260-placeholder.json
@@ -199,7 +199,7 @@
   ],
   "inputContentState": "unavailable",
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ],
   "lastUpdatedSource": "pccx_launcher_issue_9_chat_error_taxonomy_boundary_2026-05-04",
   "limitations": [

--- a/contracts/fixtures/chat-evidence-manifest.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-evidence-manifest.gemma3n-e4b-kv260-placeholder.json
@@ -222,7 +222,7 @@
   "fixtureVersion": "chat-evidence-manifest.gemma3n-e4b-kv260.2026-05-06-empty-state-ref",
   "gapState": "blocked",
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ],
   "lastUpdatedSource": "pccx_launcher_issue_9_chat_empty_state_evidence_ref_2026-05-06",
   "limitations": [

--- a/contracts/fixtures/chat-gap-matrix.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-gap-matrix.gemma3n-e4b-kv260-placeholder.json
@@ -276,7 +276,7 @@
     }
   ],
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ],
   "lastUpdatedSource": "pccx_launcher_issue_9_chat_gap_matrix_boundary_2026-05-05",
   "limitations": [

--- a/contracts/fixtures/chat-local-only-policy.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-local-only-policy.gemma3n-e4b-kv260-placeholder.json
@@ -201,6 +201,6 @@
     "send controls remain disabled until separate reviewed boundaries exist"
   ],
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ]
 }

--- a/contracts/fixtures/chat-message-list.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-message-list.gemma3n-e4b-kv260-placeholder.json
@@ -76,7 +76,7 @@
     }
   ],
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ],
   "lastUpdatedSource": "pccx_launcher_issue_9_chat_message_list_boundary_2026-05-04",
   "limitations": [

--- a/contracts/fixtures/chat-model-load-request.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-model-load-request.gemma3n-e4b-kv260-placeholder.json
@@ -97,7 +97,7 @@
     }
   ],
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ],
   "lastUpdatedSource": "pccx_launcher_issue_9_chat_model_load_request_boundary_2026-05-04",
   "limitations": [

--- a/contracts/fixtures/chat-model-selection-policy.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-model-selection-policy.gemma3n-e4b-kv260-placeholder.json
@@ -83,7 +83,7 @@
     }
   ],
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ],
   "lastUpdatedSource": "pccx_launcher_issue_9_chat_model_selection_policy_boundary_2026-05-05",
   "limitations": [

--- a/contracts/fixtures/chat-model-status.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-model-status.gemma3n-e4b-kv260-placeholder.json
@@ -61,7 +61,7 @@
     }
   ],
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ],
   "lastUpdatedSource": "pccx_launcher_issue_9_model_status_boundary_2026-05-04",
   "limitations": [

--- a/contracts/fixtures/chat-preferences.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-preferences.gemma3n-e4b-kv260-placeholder.json
@@ -260,6 +260,6 @@
     "no compatibility promise is made"
   ],
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ]
 }

--- a/contracts/fixtures/chat-readiness.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-readiness.gemma3n-e4b-kv260-placeholder.json
@@ -89,7 +89,7 @@
   ],
   "inputReadinessState": "available_as_data",
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ],
   "lastUpdatedSource": "pccx_launcher_issue_9_chat_readiness_boundary_2026-05-04",
   "limitations": [

--- a/contracts/fixtures/chat-redaction-policy.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-redaction-policy.gemma3n-e4b-kv260-placeholder.json
@@ -95,7 +95,7 @@
     }
   ],
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ],
   "lastUpdatedSource": "pccx_launcher_issue_9_chat_redaction_policy_boundary_2026-05-05",
   "limitations": [

--- a/contracts/fixtures/chat-response-stream.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-response-stream.gemma3n-e4b-kv260-placeholder.json
@@ -110,7 +110,7 @@
     }
   ],
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ],
   "lastUpdatedSource": "pccx_launcher_issue_9_chat_response_stream_boundary_2026-05-04",
   "limitations": [

--- a/contracts/fixtures/chat-review-packet.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-review-packet.gemma3n-e4b-kv260-placeholder.json
@@ -81,7 +81,7 @@
     }
   ],
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ],
   "lastUpdatedSource": "pccx_launcher_issue_9_chat_review_packet_boundary_2026-05-05",
   "limitations": [

--- a/contracts/fixtures/chat-send-result.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-send-result.gemma3n-e4b-kv260-placeholder.json
@@ -91,7 +91,7 @@
     }
   ],
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ],
   "lastUpdatedSource": "pccx_launcher_issue_9_chat_send_result_boundary_2026-05-04",
   "limitations": [

--- a/contracts/fixtures/chat-session-index.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-session-index.gemma3n-e4b-kv260-placeholder.json
@@ -226,6 +226,6 @@
     "This is not a release, tag, versioned compatibility commitment, MCP, LSP, IDE, marketplace, telemetry, or session-store implementation."
   ],
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ]
 }

--- a/contracts/fixtures/chat-session-lifecycle.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-session-lifecycle.gemma3n-e4b-kv260-placeholder.json
@@ -58,7 +58,7 @@
     }
   ],
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ],
   "lastUpdatedSource": "pccx_launcher_issue_9_lifecycle_boundary_2026-05-04",
   "lifecycleId": "chat_session_lifecycle_gemma3n_e4b_kv260_placeholder",

--- a/contracts/fixtures/chat-session-store-policy.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-session-store-policy.gemma3n-e4b-kv260-placeholder.json
@@ -102,7 +102,7 @@
     }
   ],
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ],
   "lastUpdatedSource": "pccx_launcher_issue_9_chat_session_store_policy_boundary_2026-05-04",
   "limitations": [

--- a/contracts/fixtures/chat-session-title-policy.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-session-title-policy.gemma3n-e4b-kv260-placeholder.json
@@ -228,6 +228,6 @@
     "This is not a release, tag, versioned compatibility commitment, MCP, LSP, IDE, marketplace, telemetry, runtime, model, or session-store implementation."
   ],
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ]
 }

--- a/contracts/fixtures/chat-session.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-session.gemma3n-e4b-kv260-placeholder.json
@@ -46,7 +46,7 @@
   ],
   "inputState": "ready_for_inputs",
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ],
   "lastUpdatedSource": "pccx_launcher_issue_9_boundary_2026-05-03",
   "limitations": [

--- a/contracts/fixtures/chat-shortcut-map.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-shortcut-map.gemma3n-e4b-kv260-placeholder.json
@@ -101,7 +101,7 @@
     }
   ],
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ],
   "keyboardCaptureState": "not_installed",
   "lastUpdatedSource": "pccx_launcher_issue_9_chat_shortcut_map_boundary_2026-05-04",

--- a/contracts/fixtures/chat-status-summary.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-status-summary.gemma3n-e4b-kv260-placeholder.json
@@ -72,7 +72,7 @@
     }
   ],
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ],
   "lastUpdatedSource": "pccx_launcher_issue_9_chat_status_summary_boundary_2026-05-05",
   "limitations": [

--- a/contracts/fixtures/chat-surface-layout.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-surface-layout.gemma3n-e4b-kv260-placeholder.json
@@ -313,6 +313,6 @@
     "This is not a release, tag, versioned compatibility commitment, MCP, LSP, IDE, marketplace, telemetry, or app-shell implementation."
   ],
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ]
 }

--- a/contracts/fixtures/chat-transcript-policy.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-transcript-policy.gemma3n-e4b-kv260-placeholder.json
@@ -78,7 +78,7 @@
     }
   ],
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ],
   "lastUpdatedSource": "pccx_launcher_issue_9_chat_transcript_policy_boundary_2026-05-04",
   "limitations": [

--- a/contracts/fixtures/device-session-status.gemma3n-e4b-kv260.json
+++ b/contracts/fixtures/device-session-status.gemma3n-e4b-kv260.json
@@ -193,8 +193,8 @@
   ],
   "fixtureVersion": "device-session-status.gemma3n-e4b-kv260.2026-05-03",
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#10",
-    "pccxai/pccx-llm-launcher#2"
+    "pccxai/pccx-launcher#10",
+    "pccxai/pccx-launcher#2"
   ],
   "lastUpdatedSource": "pccx_launcher_issues_2_10_boundary_2026-05-03",
   "limitations": [

--- a/contracts/fixtures/diagnostics-handoff.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/diagnostics-handoff.gemma3n-e4b-kv260-placeholder.json
@@ -30,7 +30,7 @@
         "pccx.launcherIdeStatus.v0"
       ],
       "severity": "warning",
-      "source": "pccx-llm-launcher",
+      "source": "pccx-launcher",
       "suggestedNextAction": "Keep the handoff read-only until target configuration evidence exists.",
       "summary": "The handoff records a placeholder target state only.",
       "title": "Launcher target is not configured"
@@ -44,7 +44,7 @@
         "pccx.modelDescriptor.v0"
       ],
       "severity": "info",
-      "source": "pccx-llm-launcher",
+      "source": "pccx-launcher",
       "suggestedNextAction": "Collect descriptor and asset evidence before runtime claims.",
       "summary": "Gemma 3N E4B is represented as descriptor_ref_only with no bundled assets.",
       "title": "Model descriptor is referenced by id"
@@ -59,7 +59,7 @@
         "pccx.modelRuntimeCompatibility.v0"
       ],
       "severity": "blocked",
-      "source": "pccx-llm-launcher",
+      "source": "pccx-launcher",
       "suggestedNextAction": "Require pccx-lab/core evidence before enabling runtime integration.",
       "summary": "The runtime descriptor is planned, unavailable, and not configured.",
       "title": "KV260 runtime remains placeholder"
@@ -73,7 +73,7 @@
         "pccx.modelRuntimeCompatibility.v0"
       ],
       "severity": "blocked",
-      "source": "pccx-llm-launcher",
+      "source": "pccx-launcher",
       "suggestedNextAction": "Treat all hardware and performance claims as not measured.",
       "summary": "Compatibility stays provisional until checked evidence exists.",
       "title": "Hardware and measurement evidence are missing"
@@ -87,7 +87,7 @@
         "pccx.diagnosticsHandoff.v0"
       ],
       "severity": "info",
-      "source": "pccx-llm-launcher",
+      "source": "pccx-launcher",
       "suggestedNextAction": "Keep future consumer behavior explicit and opt-in.",
       "summary": "The fixture carries no telemetry, upload, write-back, raw logs, prompts, or private paths.",
       "title": "Read-only privacy boundary is active"
@@ -113,9 +113,9 @@
   "handoffId": "launcher_diagnostics_handoff_gemma3n_e4b_kv260_placeholder",
   "handoffKind": "read_only_handoff",
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#5",
-    "pccxai/pccx-llm-launcher#3",
-    "pccxai/pccx-llm-launcher#12"
+    "pccxai/pccx-launcher#5",
+    "pccxai/pccx-launcher#3",
+    "pccxai/pccx-launcher#12"
   ],
   "launcherStatusRef": {
     "coupling": "data_reference_only",
@@ -154,7 +154,7 @@
   },
   "producer": {
     "execution": "data_only",
-    "id": "pccx-llm-launcher",
+    "id": "pccx-launcher",
     "role": "launcher_generated_summary"
   },
   "runtimeDescriptorRef": {

--- a/contracts/fixtures/launcher-ide-status.placeholder.json
+++ b/contracts/fixtures/launcher-ide-status.placeholder.json
@@ -20,10 +20,10 @@
     "local workflow mode, planned"
   ],
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#4",
-    "pccxai/pccx-llm-launcher#3",
-    "pccxai/pccx-llm-launcher#5",
-    "pccxai/pccx-llm-launcher#12"
+    "pccxai/pccx-launcher#4",
+    "pccxai/pccx-launcher#3",
+    "pccxai/pccx-launcher#5",
+    "pccxai/pccx-launcher#12"
   ],
   "launcherMode": "placeholder",
   "limitations": [

--- a/contracts/fixtures/model-runtime-descriptor.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/model-runtime-descriptor.gemma3n-e4b-kv260-placeholder.json
@@ -31,9 +31,9 @@
   },
   "exampleId": "gemma3n_e4b_kv260_pccx_placeholder",
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#3",
-    "pccxai/pccx-llm-launcher#5",
-    "pccxai/pccx-llm-launcher#12"
+    "pccxai/pccx-launcher#3",
+    "pccxai/pccx-launcher#5",
+    "pccxai/pccx-launcher#12"
   ],
   "launcherIdeStatusReference": {
     "compatibilityState": "provisional",

--- a/contracts/fixtures/runtime-readiness.gemma3n-e4b-kv260.json
+++ b/contracts/fixtures/runtime-readiness.gemma3n-e4b-kv260.json
@@ -94,9 +94,9 @@
   "fixtureVersion": "runtime-readiness.gemma3n-e4b-kv260.2026-05-03",
   "implementationState": "blocked",
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#3",
-    "pccxai/pccx-llm-launcher#5",
-    "pccxai/pccx-llm-launcher#12"
+    "pccxai/pccx-launcher#3",
+    "pccxai/pccx-launcher#5",
+    "pccxai/pccx-launcher#12"
   ],
   "kv260SmokeState": "blocked",
   "lastUpdatedSource": "pccx_evidence_boundary_2026-05-03",

--- a/contracts/launcher_ide_status_contract.py
+++ b/contracts/launcher_ide_status_contract.py
@@ -117,10 +117,10 @@ _CONTRACT = {
         "The contract shape may change before a versioned compatibility commitment.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#4",
-        "pccxai/pccx-llm-launcher#3",
-        "pccxai/pccx-llm-launcher#5",
-        "pccxai/pccx-llm-launcher#12",
+        "pccxai/pccx-launcher#4",
+        "pccxai/pccx-launcher#3",
+        "pccxai/pccx-launcher#5",
+        "pccxai/pccx-launcher#12",
     ],
 }
 

--- a/contracts/model_runtime_descriptor_contract.py
+++ b/contracts/model_runtime_descriptor_contract.py
@@ -396,9 +396,9 @@ def create_gemma3n_e4b_kv260_placeholder_example() -> dict:
             compatibility,
         ),
         "issueRefs": [
-            "pccxai/pccx-llm-launcher#3",
-            "pccxai/pccx-llm-launcher#5",
-            "pccxai/pccx-llm-launcher#12",
+            "pccxai/pccx-launcher#3",
+            "pccxai/pccx-launcher#5",
+            "pccxai/pccx-launcher#12",
         ],
     }
 

--- a/contracts/runtime_readiness_contract.py
+++ b/contracts/runtime_readiness_contract.py
@@ -296,9 +296,9 @@ _GEMMA3N_E4B_KV260_RUNTIME_READINESS = {
         "This is not a release, tag, versioned compatibility commitment, MCP, LSP, IDE, marketplace, or telemetry implementation.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#3",
-        "pccxai/pccx-llm-launcher#5",
-        "pccxai/pccx-llm-launcher#12",
+        "pccxai/pccx-launcher#3",
+        "pccxai/pccx-launcher#5",
+        "pccxai/pccx-launcher#12",
     ],
 }
 

--- a/docs/DIAGNOSTICS_HANDOFF_CONTRACT.md
+++ b/docs/DIAGNOSTICS_HANDOFF_CONTRACT.md
@@ -52,7 +52,7 @@ The handoff records:
 - `limitations`
 - `issueRefs`
 
-The producer is `pccx-llm-launcher`. The consumer is pccx-lab as a
+The producer is `pccx-launcher`. The consumer is pccx-lab as a
 future CLI/core consumer. The current fixture uses placeholder values and
 checked references only.
 

--- a/docs/LOCAL_WORKFLOW_MODE_PLAN.md
+++ b/docs/LOCAL_WORKFLOW_MODE_PLAN.md
@@ -102,6 +102,6 @@ Before adding runtime behavior, the launcher should have:
 ## Issue Alignment
 
 This plan addresses
-[`pccx-llm-launcher#12`](https://github.com/pccxai/pccx-llm-launcher/issues/12)
+[`pccx-launcher#12`](https://github.com/pccxai/pccx-launcher/issues/12)
 by recording the local workflow mode direction while keeping the
 current launcher work data-only and evidence-gated.

--- a/docs/MULTI_MODEL_DEVICE_SUPPORT_PLAN.md
+++ b/docs/MULTI_MODEL_DEVICE_SUPPORT_PLAN.md
@@ -125,6 +125,6 @@ Before adding executable model or device behavior, the launcher should have:
 ## Issue Alignment
 
 This plan addresses
-[`pccx-llm-launcher#13`](https://github.com/pccxai/pccx-llm-launcher/issues/13)
+[`pccx-launcher#13`](https://github.com/pccxai/pccx-launcher/issues/13)
 by recording the multi-model and multi-device support direction while keeping
 the current launcher work descriptor-only and evidence-gated.

--- a/docs/OTHER_EDITOR_BRIDGE_PLAN.md
+++ b/docs/OTHER_EDITOR_BRIDGE_PLAN.md
@@ -94,6 +94,6 @@ Before adding editor-specific code, the launcher should have:
 ## Issue Alignment
 
 This plan addresses
-[`pccx-llm-launcher#11`](https://github.com/pccxai/pccx-llm-launcher/issues/11)
+[`pccx-launcher#11`](https://github.com/pccxai/pccx-launcher/issues/11)
 by recording JetBrains and generic editor direction while keeping the current
 launcher work data-only and pre-compatibility.

--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -2,7 +2,7 @@
 
 ## Origin
 
-`pccx-llm-launcher` was bootstrapped in part from the launcher-era of the
+`pccx-launcher` was bootstrapped in part from the launcher-era of the
 upstream project `hkimw/llm-bottleneck-lab` (formerly `llm-lite`). The
 chosen import point is:
 
@@ -65,7 +65,7 @@ this repository today. Treat them as documentation of past intent.
 
 ## Authoritative inference path
 
-Hardware-side inference readiness for `pccx-llm-launcher` depends on the
+Hardware-side inference readiness for `pccx-launcher` depends on the
 bring-up and verification work that is happening in
 `pccxai/pccx-FPGA-NPU-LLM-kv260`. No release of this repository should
 claim KV260 inference until that repository publishes a verified

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # scripts/check.sh — minimal environment / target-device check for
-# pccx-llm-launcher. This is intentionally a lightweight, honest probe:
+# pccx-launcher. This is intentionally a lightweight, honest probe:
 # it reports what is present, but it does NOT claim that any particular
 # inference path is wired up. The launcher engine itself is not yet
 # imported into this repository.
@@ -46,7 +46,7 @@ else
 fi
 
 HEAD "launcher status"
-NOTE "pccx-llm-launcher does not yet ship a working inference path."
+NOTE "pccx-launcher does not yet ship a working inference path."
 NOTE "KV260 / Gemma 3N E4B support is a target, not a current claim."
 NOTE "Hardware readiness depends on pccxai/pccx-FPGA-NPU-LLM-kv260 bring-up."
 

--- a/scripts/legacy/README.md
+++ b/scripts/legacy/README.md
@@ -13,7 +13,7 @@ hkimw/llm-bottleneck-lab @ 129c524
 That repository has since pivoted to a benchmark / bottleneck-analysis
 focus (`llm-bottleneck-lab`). The launcher-era pieces are preserved here as
 a starting point for the user-facing launcher track that this repo
-(`pccx-llm-launcher`) is meant to grow into.
+(`pccx-launcher`) is meant to grow into.
 
 ## Files
 
@@ -29,7 +29,7 @@ These scripts were authored against a working tree that contained an
 inference engine directory (`x64/gemma3N_E4B/`), a `pynq_env/` virtualenv,
 compiled `.so` shared libraries, and a deprecated native ImGui front-end.
 None of that is present in this repository, and importing it is **not** the
-goal of `pccx-llm-launcher`.
+goal of `pccx-launcher`.
 
 The launcher engine that this repo is meant to drive will instead come from
 the PCCX hardware track once the FPGA / KV260 bring-up evidence is


### PR DESCRIPTION
## Summary

- Run a post-rename consistency pass for Tauri product identifiers and related package metadata.
- Replace remaining `pccx-llm-launcher` product/repo references with `pccx-launcher` in checked docs, contract metadata, fixtures, and launcher status wording.
- Update the README title and opening wording to use the new repo name and state PCCX™ technology / Altifigence™ ownership.

## Files touched

- `README.md`
- `docs/DIAGNOSTICS_HANDOFF_CONTRACT.md`
- `docs/LOCAL_WORKFLOW_MODE_PLAN.md`
- `docs/MULTI_MODEL_DEVICE_SUPPORT_PLAN.md`
- `docs/OTHER_EDITOR_BRIDGE_PLAN.md`
- `docs/PROVENANCE.md`
- `scripts/check.sh`
- `scripts/legacy/README.md`
- `contracts/*.py` issue/product identifier references
- `contracts/fixtures/*.json` checked fixture references

## Rationale

This is a post-rename consistency pass for Tauri product identifiers. The earlier global rename sweep covered broad repo references; this follow-up catches product identifier and package metadata strings that still used the old launcher name. This repository snapshot does not currently contain `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.*`, `package.json`, `pnpm-lock.yaml`, or `package-lock.json`, so no Tauri, package, lockfile, or version files were changed.

## Validation

- `rg -n --hidden -S "pccx-llm-launcher|pccx_llm_launcher|pccx-launcher-staging" -g "!node_modules" -g "!.git"` returned no matches.
- `python3 -m pytest scripts/tests` passed: 249 tests.
- `for f in scripts/tests/*.sh; do bash "$f"; done` passed for all shell tests.
- `bash scripts/check.sh` passed.
- `git diff --check` passed.
- `cargo metadata --no-deps --manifest-path src-tauri/Cargo.toml` skipped because `src-tauri/Cargo.toml` is absent.
- `node -e 'JSON.parse(require("fs").readFileSync("package.json"))'` skipped because `package.json` is absent.
- `tauri info` skipped because the Tauri CLI is not installed and no Tauri config exists in this snapshot.

## Lockfile drift risk

None found in this snapshot: `pnpm-lock.yaml` and `package-lock.json` are absent, so no old-name lockfile references remain and there is no lockfile-driven CI break expected on the next dependency install.
