### PR TITLE
feat: add local desktop synthesis mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,7 @@ jobs:
         run: |
           for f in scripts/check.sh \
                    scripts/check-device-stub.sh \
+                   scripts/local-synth.sh \
                    scripts/install-stub.sh \
                    scripts/launch-stub.sh \
                    scripts/status-stub.sh \
@@ -156,6 +157,8 @@ jobs:
           else
             echo "scripts/check-device-stub.sh not present; skipping"
           fi
+      - name: run scripts/local-synth.sh tests
+        run: bash scripts/tests/local-synth.sh
       - name: run scripts/install-stub.sh (preview only)
         run: |
           if [ -x scripts/install-stub.sh ]; then

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ and verify host-side prerequisites before the real engine lands.
 |---|---|
 | [`scripts/check.sh`](./scripts/check.sh) | Probe host info, tooling availability, edge-device hints. Always exits 0. |
 | [`scripts/check-device-stub.sh`](./scripts/check-device-stub.sh) | Narrowly scoped device-tree / FPGA-node probe (KV260 / Kria detection only). Always exits 0. |
+| [`scripts/local-synth.sh`](./scripts/local-synth.sh) | Local synthesis wrapper for user-installed Vivado or Quartus. Dry-run by default; calls the local tool only with `--run`. |
 | [`scripts/install-stub.sh`](./scripts/install-stub.sh) | Preview of the planned install flow; reports which host runtime pieces are present, lists device-side pieces as future deliverables. Always exits 0. |
 | [`scripts/status-stub.sh`](./scripts/status-stub.sh) | Launcher state summary. Default mode: local scaffold output, always exits 0. With `--include-chat-action-bar`, adds read-only disabled chat action-bar data. With `--include-chat-clipboard-policy`, adds read-only disabled chat clipboard-policy data. With `--include-chat-redaction-policy`, adds read-only disabled chat redaction-policy data. With `--include-chat-attachment-policy`, adds read-only disabled chat attachment-policy data. With `--include-chat-shortcut-map`, adds read-only disabled chat shortcut-map data. With `--include-chat-accessibility`, adds read-only chat accessibility metadata. With `--include-chat-status-summary`, adds read-only aggregate chat status-summary data. With `--include-chat-review-packet`, adds read-only chat review-packet data over existing checked fixture references. With `--include-chat-gap-matrix`, adds read-only chat implementation gap-matrix data over existing checked fixture references. With `--include-chat-evidence-manifest`, adds read-only chat evidence-manifest data over existing checked fixture references. With `--include-chat-message-list`, adds read-only empty chat message-list data. With `--include-chat-response-stream`, adds read-only blocked chat response stream data. With `--include-chat-error-taxonomy`, adds read-only chat error taxonomy data. With `--include-chat-audit-event`, adds read-only blocked chat audit-event metadata. With `--include-chat-surface-layout`, adds read-only chat surface layout data. With `--include-chat-empty-state`, adds read-only display-only chat empty-state data. With `--include-chat-local-only-policy`, adds read-only local-only/cloud-block policy data. With `--include-chat-preferences`, adds read-only chat preferences/settings data. With `--include-chat-session-index`, adds read-only empty chat session index data. With `--include-chat-session-store-policy`, adds read-only disabled chat session-store policy data. With `--include-chat-session-title-policy`, adds read-only placeholder session-title policy data. With `--include-chat-transcript-policy`, adds read-only chat transcript retention/export policy data. With `--include-chat-send-result`, adds read-only blocked chat send-result data. With `--include-chat-composer`, adds read-only chat composer/input-control data. With `--include-chat-model-status`, adds read-only blocked chat model-status display data. With `--include-chat-model-selection-policy`, adds read-only disabled chat model-selection data. With `--include-chat-context-policy`, adds read-only disabled chat context-window/tokenization policy data. With `--include-chat-model-load-request`, adds read-only disabled chat model-load request data. With `--include-chat-session`, adds read-only blocked chat/session and lifecycle summaries. With `--include-chat-readiness`, adds read-only chat readiness checks and recovery actions. With `--include-device-session`, adds a read-only device/session status panel. With `--include-runtime-readiness`, adds a read-only runtime readiness summary. With `--backend pccx-lab`, calls `pccx-lab status --format json` and forwards the run-status envelope (exits non-zero if binary is missing or output is invalid). |
 | [`scripts/device-session-status-stub.sh`](./scripts/device-session-status-stub.sh) | Data-only device/session status JSON for the Gemma 3N E4B + KV260 target. Reports connection, model load, session, diagnostics, readiness, discovery paths, flow steps, and error taxonomy as placeholder / blocked. |
@@ -128,6 +129,8 @@ and verify host-side prerequisites before the real engine lands.
 ```bash
 bash scripts/check.sh
 bash scripts/check-device-stub.sh
+bash scripts/local-synth.sh --detect-only
+bash scripts/local-synth.sh --vendor auto --script path/to/synth.tcl --dry-run
 bash scripts/install-stub.sh
 bash scripts/status-stub.sh
 bash scripts/status-stub.sh --include-chat-model-status
@@ -232,6 +235,14 @@ The pccx-lab status output is an early, pre-compatibility run-status envelope.
 It operates in host-dry-run mode: no real KV260 device probing is
 performed, no model is executed, and no inference is started. This is a
 planned KV260-oriented launcher path, not a readiness claim.
+
+### Local desktop mode
+
+Local desktop mode is documented in
+[docs/LOCAL_DESKTOP_MODE.md](./docs/LOCAL_DESKTOP_MODE.md) and structured under
+[`modules/local-mode/`](./modules/local-mode/). It covers local synthesis,
+BYOL Vivado/Quartus detection, user-owned chat provider credentials, optional
+cloud sync, and DesktopApp / IDE extension boundaries.
 
 ### Launcher / IDE bridge contract (planned)
 

--- a/docs/LOCAL_DESKTOP_MODE.md
+++ b/docs/LOCAL_DESKTOP_MODE.md
@@ -1,0 +1,58 @@
+# PCCX local desktop mode
+
+Local desktop mode lets users run PCCX workflows on their own machine without a
+cloud dependency.
+
+## Scope
+
+- Launcher: local synthesis wrapper, tool detection, desktop state display.
+- CLI: `pccx synth --local` and `pccx deploy --target kv260` consume the same
+  local-mode concepts.
+- IDE: VS Code and JetBrains surfaces call the launcher or CLI boundary with
+  fixed argument arrays.
+- Sync: optional project, library, and build-result backup after entitlement
+  confirmation.
+
+## BYOL and tool detection
+
+BYOL means bring your own local toolchain. The launcher never bundles Vivado or
+Quartus. Detection order is:
+
+1. `PCCX_VIVADO_BIN` or `PCCX_QUARTUS_SH_BIN`.
+2. `vivado` or `quartus_sh` on `PATH`.
+3. A user-selected executable path in the desktop settings UI.
+
+Local synthesis must work offline when the selected tool, project files, and
+synthesis script are already on the machine.
+
+## Chat provider boundary
+
+AI chat uses user-owned Claude, GPT, or Gemini credentials. Credentials stay in
+the user's OS keychain, environment, or provider-specific config, and local-mode
+project records must never serialize secret values. Offline behavior is clear:
+local synthesis remains available, provider chat is unavailable unless a later
+local runtime adapter is selected.
+
+## Sync boundary
+
+Cloud sync is optional. A paid entitlement and explicit user opt-in are both
+required before sync is enabled.
+
+Sync can cover:
+
+- project metadata;
+- reusable libraries;
+- selected synthesis logs and result artifacts.
+
+Sync must not cover:
+
+- provider credentials;
+- private local paths in shared records;
+- hidden agent instructions;
+- raw build caches by default.
+
+## Execution boundary
+
+UI code renders state and sends fixed commands. Adapter code owns process
+execution. The wrapper in `scripts/local-synth.sh` requires a local script path
+and only calls a vendor tool when `--run` is passed.

--- a/modules/local-mode/README.md
+++ b/modules/local-mode/README.md
@@ -1,0 +1,26 @@
+# PCCX local mode module
+
+This module is the desktop and editor boundary for local PCCX use. It keeps
+project metadata, offline state, local build requests, and optional cloud sync
+separate from the launcher UI.
+
+Local mode means:
+
+- synthesis uses the user's installed Vivado or Quartus toolchain;
+- network access is not required for local synthesis;
+- provider chat uses user-owned Claude, GPT, or Gemini credentials outside this
+  repository;
+- project and result sync is optional and gated by an entitlement check.
+
+## Layout
+
+- `interfaces/` defines `LocalProject`, `SyncStatus`, and `LocalBuild`.
+- `core/` owns pure project state, sync decision, and offline detection logic.
+- `adapters/` owns the local toolchain, filesystem, and cloud-sync boundaries.
+- `ui/` maps the same module to DesktopApp and IDE extension surfaces.
+
+## Boundaries
+
+The launcher may render this module directly, but all tool execution stays in an
+adapter. The UI must not build shell strings, read credentials, upload build
+outputs by default, or silently fall back to cloud behavior when offline.

--- a/modules/local-mode/adapters/README.md
+++ b/modules/local-mode/adapters/README.md
@@ -1,0 +1,27 @@
+# Local mode adapters
+
+Adapters are the only layer allowed to touch external systems.
+
+## `local-vivado`
+
+- Detects `PCCX_VIVADO_BIN` first, then `vivado` on `PATH`.
+- Runs a user-selected Tcl script with `vivado -mode batch -source <script>`.
+- Does not download inputs or upload results.
+
+## `local-quartus`
+
+- Detects `PCCX_QUARTUS_SH_BIN` first, then `quartus_sh` on `PATH`.
+- Runs a user-selected Tcl script with `quartus_sh -t <script>`.
+- Does not download inputs or upload results.
+
+## `local-fs`
+
+- Reads and writes local project metadata, build logs, and build artifacts.
+- Must not read credential files or hidden agent instruction files.
+
+## `cloud-sync`
+
+- Syncs project/library metadata and selected build artifacts only after user
+  opt-in and entitlement confirmation.
+- Supports Drive or PCCX cloud storage backends.
+- Must not block local synthesis when offline or not entitled.

--- a/modules/local-mode/core/README.md
+++ b/modules/local-mode/core/README.md
@@ -1,0 +1,26 @@
+# Local mode core
+
+The core layer is pure state and policy. It does not spawn processes, read
+provider credentials, scan the full filesystem, or call network APIs.
+
+Core responsibilities:
+
+- normalize `LocalProject` metadata;
+- decide whether the machine is offline from caller-supplied signals;
+- decide whether sync controls are enabled from entitlement and offline state;
+- produce `LocalBuild` plans for the selected local tool vendor;
+- keep cloud backup optional, never a prerequisite for local synthesis.
+
+Offline rules:
+
+- local synthesis remains available when offline if a local tool and script are
+  present;
+- cloud sync is reported as paused while offline;
+- chat provider calls are unavailable while offline unless the selected provider
+  has a local runtime path in a later reviewed adapter;
+- cached project metadata can be read from local storage.
+
+Sync entitlement rule:
+
+`SyncStatus.enabled` is true only when a paid entitlement is confirmed and the
+user has opted in. Local synthesis and local deploy do not depend on sync.

--- a/modules/local-mode/interfaces/README.md
+++ b/modules/local-mode/interfaces/README.md
@@ -1,0 +1,52 @@
+# Local mode interfaces
+
+These interfaces are the shared contract for Launcher, CLI, and IDE consumers.
+
+```ts
+export type LocalToolVendor = "vivado" | "quartus";
+export type LocalBuildState =
+  | "draft"
+  | "tool_missing"
+  | "ready"
+  | "running"
+  | "succeeded"
+  | "failed";
+
+export interface LocalProject {
+  id: string;
+  root: string;
+  topModule?: string;
+  target?: "kv260" | string;
+  preferredVendor?: LocalToolVendor;
+  syncEnabled: boolean;
+  entitlementRequired: boolean;
+}
+
+export interface SyncStatus {
+  enabled: boolean;
+  entitled: boolean;
+  offline: boolean;
+  provider: "none" | "drive" | "pccx-cloud";
+  lastSuccessfulSyncAt?: string;
+  pendingLocalChanges: number;
+}
+
+export interface LocalBuild {
+  id: string;
+  projectId: string;
+  vendor: LocalToolVendor;
+  toolPath?: string;
+  scriptPath: string;
+  workDir: string;
+  state: LocalBuildState;
+  artifactPaths: string[];
+  logPath?: string;
+}
+```
+
+Interface rules:
+
+- `LocalProject.root`, `scriptPath`, and `workDir` are local paths only.
+- `SyncStatus.enabled` must be false unless entitlement is confirmed.
+- `LocalBuild.toolPath` is discovered from the user's machine or explicit env.
+- Secret values are never serialized into these records.

--- a/modules/local-mode/ui/README.md
+++ b/modules/local-mode/ui/README.md
@@ -1,0 +1,20 @@
+# Local mode UI
+
+The UI layer binds local mode to desktop and editor surfaces without owning
+tool execution.
+
+## DesktopApp
+
+- Shows local tool detection status.
+- Lets the user choose a project root and synthesis script.
+- Calls the local synthesis adapter only after explicit user action.
+- Shows sync status as optional and entitlement-gated.
+- Lets users configure provider chat credentials outside project records.
+
+## IdeExtension
+
+- Presents the same `LocalProject`, `SyncStatus`, and `LocalBuild` data.
+- Offers VS Code and JetBrains command entries that call the CLI or launcher
+  wrapper with fixed argument arrays.
+- Does not build shell strings from editor text.
+- Keeps local synthesis available when cloud sync is paused or offline.

--- a/scripts/local-synth.sh
+++ b/scripts/local-synth.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+
+set -euo pipefail
+
+usage() {
+    cat <<'USAGE'
+Usage:
+  scripts/local-synth.sh --detect-only [--vendor auto|vivado|quartus]
+  scripts/local-synth.sh --script <file.tcl> [--vendor auto|vivado|quartus] [--work-dir <dir>] [--dry-run|--run]
+
+Runs a user-supplied local synthesis script through the user's installed EDA
+toolchain. Dry-run is the default. No network access, downloads, or uploads are
+performed by this wrapper.
+USAGE
+}
+
+VENDOR="auto"
+SCRIPT_FILE=""
+WORK_DIR=""
+MODE="dry-run"
+DETECT_ONLY=0
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --vendor)
+            VENDOR="${2:-}"
+            shift 2
+            ;;
+        --script)
+            SCRIPT_FILE="${2:-}"
+            shift 2
+            ;;
+        --work-dir)
+            WORK_DIR="${2:-}"
+            shift 2
+            ;;
+        --dry-run)
+            MODE="dry-run"
+            shift
+            ;;
+        --run)
+            MODE="run"
+            shift
+            ;;
+        --detect-only)
+            DETECT_ONLY=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            printf '[ERROR] unknown argument: %s\n' "$1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+case "$VENDOR" in
+    auto|vivado|quartus) ;;
+    *)
+        printf '[ERROR] unsupported vendor: %s\n' "$VENDOR" >&2
+        exit 2
+        ;;
+esac
+
+find_executable() {
+    local env_name="$1"
+    local command_name="$2"
+    local override="${!env_name:-}"
+
+    if [ -n "$override" ]; then
+        if [ -x "$override" ]; then
+            printf '%s\n' "$override"
+            return 0
+        fi
+        return 1
+    fi
+
+    command -v "$command_name" 2>/dev/null || return 1
+}
+
+detect_vendor() {
+    local requested="$1"
+    local tool=""
+
+    if [ "$requested" = "vivado" ] || [ "$requested" = "auto" ]; then
+        if tool="$(find_executable PCCX_VIVADO_BIN vivado)"; then
+            printf 'vivado\t%s\n' "$tool"
+            return 0
+        fi
+    fi
+
+    if [ "$requested" = "quartus" ] || [ "$requested" = "auto" ]; then
+        if tool="$(find_executable PCCX_QUARTUS_SH_BIN quartus_sh)"; then
+            printf 'quartus\t%s\n' "$tool"
+            return 0
+        fi
+    fi
+
+    return 1
+}
+
+absolute_path() {
+    local path="$1"
+    local dir=""
+    local base=""
+
+    case "$path" in
+        /*)
+            printf '%s\n' "$path"
+            ;;
+        *)
+            dir="$(dirname "$path")"
+            base="$(basename "$path")"
+            (
+                cd "$dir"
+                printf '%s/%s\n' "$(pwd -P)" "$base"
+            )
+            ;;
+    esac
+}
+
+DETECTED="$(detect_vendor "$VENDOR" || true)"
+if [ -n "$DETECTED" ]; then
+    TOOL_VENDOR="${DETECTED%%	*}"
+    TOOL_PATH="${DETECTED#*	}"
+else
+    TOOL_VENDOR="$VENDOR"
+    [ "$TOOL_VENDOR" = "auto" ] && TOOL_VENDOR="not_found"
+    TOOL_PATH="not_found"
+fi
+
+printf '=== local synthesis wrapper ===\n'
+printf 'mode       : %s\n' "$MODE"
+printf 'vendor     : %s\n' "$TOOL_VENDOR"
+printf 'tool       : %s\n' "$TOOL_PATH"
+printf 'offline    : supported; this wrapper performs no network operation\n'
+
+if [ "$DETECT_ONLY" = "1" ]; then
+    exit 0
+fi
+
+if [ -z "$SCRIPT_FILE" ]; then
+    printf '[ERROR] --script is required unless --detect-only is used\n' >&2
+    exit 2
+fi
+
+if [ ! -f "$SCRIPT_FILE" ]; then
+    printf '[ERROR] synthesis script not found: %s\n' "$SCRIPT_FILE" >&2
+    exit 2
+fi
+
+SCRIPT_ABS="$(absolute_path "$SCRIPT_FILE")"
+if [ -n "$WORK_DIR" ]; then
+    if [ ! -d "$WORK_DIR" ]; then
+        printf '[ERROR] work directory not found: %s\n' "$WORK_DIR" >&2
+        exit 2
+    fi
+    WORK_DIR_ABS="$(absolute_path "$WORK_DIR")"
+else
+    WORK_DIR_ABS="$(pwd -P)"
+fi
+
+printf 'script     : %s\n' "$SCRIPT_ABS"
+printf 'work-dir   : %s\n' "$WORK_DIR_ABS"
+
+if [ "$TOOL_PATH" = "not_found" ]; then
+    printf 'command    : unavailable; install or point PCCX_VIVADO_BIN/PCCX_QUARTUS_SH_BIN to a local tool\n'
+    [ "$MODE" = "run" ] && exit 2
+    exit 0
+fi
+
+if [ "$TOOL_VENDOR" = "vivado" ]; then
+    COMMAND=("$TOOL_PATH" -mode batch -source "$SCRIPT_ABS")
+elif [ "$TOOL_VENDOR" = "quartus" ]; then
+    COMMAND=("$TOOL_PATH" -t "$SCRIPT_ABS")
+else
+    printf '[ERROR] no supported local synthesis tool detected\n' >&2
+    exit 2
+fi
+
+printf 'command    :'
+printf ' %q' "${COMMAND[@]}"
+printf '\n'
+
+if [ "$MODE" = "dry-run" ]; then
+    exit 0
+fi
+
+(
+    cd "$WORK_DIR_ABS"
+    "${COMMAND[@]}"
+)

--- a/scripts/tests/local-synth.sh
+++ b/scripts/tests/local-synth.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+STUB="$ROOT/scripts/local-synth.sh"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+fail() {
+    printf '[FAIL] %s\n' "$*" >&2
+    exit 1
+}
+
+require_contains() {
+    local output="$1"
+    local expected="$2"
+    case "$output" in
+        *"$expected"*) ;;
+        *) fail "missing expected text: $expected" ;;
+    esac
+}
+
+cat >"$TMPDIR/vivado" <<'SH'
+#!/usr/bin/env bash
+printf 'fake-vivado %s\n' "$*"
+SH
+chmod +x "$TMPDIR/vivado"
+
+cat >"$TMPDIR/quartus_sh" <<'SH'
+#!/usr/bin/env bash
+printf 'fake-quartus %s\n' "$*"
+SH
+chmod +x "$TMPDIR/quartus_sh"
+
+cat >"$TMPDIR/build.tcl" <<'TCL'
+puts "local synth fixture"
+TCL
+
+OUTPUT="$(PATH="$TMPDIR:$PATH" bash "$STUB" --detect-only --vendor auto)"
+require_contains "$OUTPUT" "vendor     : vivado"
+require_contains "$OUTPUT" "offline    : supported"
+
+OUTPUT="$(PATH="$TMPDIR:$PATH" bash "$STUB" --vendor vivado --script "$TMPDIR/build.tcl" --dry-run)"
+require_contains "$OUTPUT" "mode       : dry-run"
+require_contains "$OUTPUT" "command    :"
+require_contains "$OUTPUT" "-mode"
+require_contains "$OUTPUT" "-source"
+
+OUTPUT="$(PATH="$TMPDIR:$PATH" bash "$STUB" --vendor quartus --script "$TMPDIR/build.tcl" --run)"
+require_contains "$OUTPUT" "mode       : run"
+require_contains "$OUTPUT" "fake-quartus -t"
+
+if grep -E '\b(curl|wget|ssh|scp|rsync|nc)\b' "$STUB" >/dev/null; then
+    fail "local synth wrapper must not contain network transfer commands"
+fi
+
+printf '[DONE] local synthesis wrapper tests passed\n'


### PR DESCRIPTION
## Summary
- add modules/local-mode boundary docs for local project/build/sync surfaces
- add scripts/local-synth.sh for BYOL Vivado/Quartus detection and dry-run/local execution
- document offline local desktop mode and wire wrapper tests into CI

## Tests
- bash scripts/tests/local-synth.sh
- bash -n scripts/local-synth.sh
- bash -n scripts/tests/local-synth.sh
- git diff --check

No direct push to main.