### PR TITLE
Prepare public source release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,8 +49,8 @@ jobs:
               r"mcp\s+ready|ai\s+provider\s+ready|"
               r"kv260 inference (?:works|works now|is working|is functional)|"
               r"20\s*tok/s\s+achieved|timing[- ]closed|fully verified|"
-              r"vibe coding|autonomous coding|"
-              r"(?:claude|gpt)\s+directly\s+controls)",
+              r"vibe\s+coding|autonomous\s+coding|"
+              r"(?:c(?:laude)|g(?:pt))\s+directly\s+controls)",
               re.IGNORECASE,
           )
           # A line is only flagged if the matched phrase is *asserted*.

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,0 +1,40 @@
+# PCCX Launcher Quickstart
+
+This guide verifies the public launcher scaffold from a clean checkout.
+
+## Requirements
+
+- Bash
+- Python 3.9 or newer
+
+## Run The Local Checks
+
+```bash
+bash scripts/check.sh
+bash scripts/status-stub.sh
+bash scripts/runtime-readiness-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/device-session-status-stub.sh --model gemma3n-e4b --target kv260
+```
+
+## Preview The Chat Surface
+
+```bash
+bash scripts/chat-surface-preview.sh --model gemma3n-e4b --target kv260
+```
+
+The preview renders checked local contract data only. It does not accept
+prompts, execute a model, contact providers, touch hardware, read model assets,
+or write transcripts.
+
+## Run The Smoke Test
+
+```bash
+bash scripts/smoke.sh
+```
+
+## Next Files
+
+- [README.md](./README.md) for product scope and the full script inventory
+- [CONTRIBUTING.md](./CONTRIBUTING.md) for pull request expectations
+- [SECURITY.md](./SECURITY.md) for vulnerability reporting
+- [docs/RELEASE.md](./docs/RELEASE.md) for release operator steps

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# pccx-llm-launcher
+# pccx-launcher
 
 Lightweight launcher for PCCX-oriented local LLM workflows.
 
@@ -21,6 +21,50 @@ upstream `llm-lite` launcher era. There is no working KV260 inference
 path yet, and no model is actually executed by anything in this
 repository today. See [docs/PROVENANCE.md](./docs/PROVENANCE.md) for the
 exact source commit and what was / was not imported.
+
+## Install
+
+Clone the public repository and run the local scripts directly:
+
+```bash
+git clone https://github.com/pccxai/pccx-launcher.git
+cd pccx-launcher
+bash scripts/check.sh
+```
+
+No model weights, board credentials, provider keys, or runtime daemon are
+required for the public scaffold.
+
+## Quickstart
+
+Run the checked status and readiness surfaces:
+
+```bash
+bash scripts/status-stub.sh
+bash scripts/runtime-readiness-stub.sh --model gemma3n-e4b --target kv260
+bash scripts/chat-surface-preview.sh --model gemma3n-e4b --target kv260
+```
+
+For a short first-run path, see [QUICKSTART.md](./QUICKSTART.md).
+
+## Smoke Test
+
+Run the repository smoke test before opening a pull request or cutting a
+release:
+
+```bash
+bash scripts/smoke.sh
+```
+
+The smoke test is local and deterministic. It verifies the checked shell
+surfaces and contract fixtures; it does not execute a model, contact hardware,
+call providers, upload data, or publish artifacts.
+
+## Release And Contribution
+
+This repository is Apache-2.0 licensed. See [LICENSE](./LICENSE),
+[CONTRIBUTING.md](./CONTRIBUTING.md), [SECURITY.md](./SECURITY.md), and
+[docs/RELEASE.md](./docs/RELEASE.md).
 
 ## Intended workflow (target)
 
@@ -53,7 +97,7 @@ publishes a verified end-to-end path.
 
 - Local assistant mode (controlled local workflow with a reviewed
   tool boundary). The later-track plan is tracked in
-  [docs/LOCAL_CODING_ASSISTANT_MODE_PLAN.md](./docs/LOCAL_CODING_ASSISTANT_MODE_PLAN.md).
+  [docs/LOCAL_WORKFLOW_MODE_PLAN.md](./docs/LOCAL_WORKFLOW_MODE_PLAN.md).
 - VS Code and other editor bridge planning for guided launches and log
   inspection.
 - Additional target models beyond Gemma 3N E4B and additional edge devices
@@ -62,9 +106,9 @@ publishes a verified end-to-end path.
 - Integration with `pccx-lab` diagnostics so device / kernel state can be
   surfaced through the launcher UI.
 
-Release readiness depends on verification evidence published by
+Runtime readiness depends on verification evidence published by
 `pccxai/pccx-FPGA-NPU-LLM-kv260` (RTL bring-up, simulation, timing
-closure). This repository will not cut a non-alpha release until that
+closure). Public source releases keep the runtime path blocked until that
 evidence lands.
 
 ## Non-goals
@@ -254,7 +298,7 @@ promise. See
 The later-track JetBrains and generic editor direction is tracked in
 [docs/OTHER_EDITOR_BRIDGE_PLAN.md](./docs/OTHER_EDITOR_BRIDGE_PLAN.md).
 The later-track local assistant mode direction is tracked in
-[docs/LOCAL_CODING_ASSISTANT_MODE_PLAN.md](./docs/LOCAL_CODING_ASSISTANT_MODE_PLAN.md).
+[docs/LOCAL_WORKFLOW_MODE_PLAN.md](./docs/LOCAL_WORKFLOW_MODE_PLAN.md).
 
 ### Model / runtime descriptor boundary (planned)
 

--- a/contracts/chat_accessibility_contract.py
+++ b/contracts/chat_accessibility_contract.py
@@ -556,7 +556,7 @@ _CHAT_ACCESSIBILITY = {
         "No pccx-lab invocation, systemverilog-ide invocation, MCP server, LSP, compatibility promise, storage layer, runtime, model-loader, or hardware implementation is included.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_action_bar_contract.py
+++ b/contracts/chat_action_bar_contract.py
@@ -465,7 +465,7 @@ _CHAT_ACTION_BAR = {
         "This is not a release, tag, compatibility commitment, MCP, LSP, IDE, marketplace, telemetry, or runtime implementation.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_attachment_policy_contract.py
+++ b/contracts/chat_attachment_policy_contract.py
@@ -447,7 +447,7 @@ _CHAT_ATTACHMENT_POLICY = {
         "This is not a release, tag, compatibility commitment, MCP, LSP, IDE, marketplace, telemetry, runtime, model, parser, file-input, or storage implementation.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_audit_event_contract.py
+++ b/contracts/chat_audit_event_contract.py
@@ -436,7 +436,7 @@ _CHAT_AUDIT_EVENT = {
         "This is not a release, tag, versioned compatibility commitment, MCP, LSP, IDE, marketplace, or telemetry implementation.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_clipboard_policy_contract.py
+++ b/contracts/chat_clipboard_policy_contract.py
@@ -416,7 +416,7 @@ _CHAT_CLIPBOARD_POLICY = {
         "This is not a release, tag, compatibility commitment, MCP, LSP, IDE, marketplace, telemetry, or runtime implementation.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_composer_contract.py
+++ b/contracts/chat_composer_contract.py
@@ -326,7 +326,7 @@ _CHAT_COMPOSER = {
         "This is not a release, tag, versioned compatibility commitment, MCP, LSP, IDE, marketplace, or telemetry implementation.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_context_policy_contract.py
+++ b/contracts/chat_context_policy_contract.py
@@ -410,7 +410,7 @@ _CHAT_CONTEXT_POLICY = {
         "This is not a release, tag, compatibility commitment, marketplace flow, storage layer, tokenizer implementation, context manager, runtime, model-loader, or hardware implementation.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_empty_state_contract.py
+++ b/contracts/chat_empty_state_contract.py
@@ -403,7 +403,7 @@ _CHAT_EMPTY_STATE = {
         "No pccx-lab invocation, systemverilog-ide invocation, MCP server, LSP, compatibility promise, storage layer, runtime, model-loader, or hardware implementation is included.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_error_taxonomy_contract.py
+++ b/contracts/chat_error_taxonomy_contract.py
@@ -369,7 +369,7 @@ _CHAT_ERROR_TAXONOMY = {
         "no compatibility promise is made",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_evidence_manifest_contract.py
+++ b/contracts/chat_evidence_manifest_contract.py
@@ -544,7 +544,7 @@ _CHAT_EVIDENCE_MANIFEST = {
         "This manifest does not close issue #9, approve review gates, accept evidence, close gaps, or enable standalone chat.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_gap_matrix_contract.py
+++ b/contracts/chat_gap_matrix_contract.py
@@ -451,7 +451,7 @@ _CHAT_GAP_MATRIX = {
         "This matrix does not close issue #9 or approve standalone chat enablement; it records remaining blocker rows only.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_local_only_policy_contract.py
+++ b/contracts/chat_local_only_policy_contract.py
@@ -307,7 +307,7 @@ _CHAT_LOCAL_ONLY_POLICY = {
         "send controls remain disabled until separate reviewed boundaries exist",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_message_list_contract.py
+++ b/contracts/chat_message_list_contract.py
@@ -346,7 +346,7 @@ _CHAT_MESSAGE_LIST = {
         "This is not a release, tag, compatibility commitment, MCP, LSP, IDE, marketplace, telemetry, or runtime implementation.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_model_load_request_contract.py
+++ b/contracts/chat_model_load_request_contract.py
@@ -481,7 +481,7 @@ _CHAT_MODEL_LOAD_REQUEST = {
         "This is not a release, tag, compatibility commitment, MCP, LSP, IDE, marketplace, telemetry, runtime, model-loader, provider, storage, or hardware implementation.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_model_selection_policy_contract.py
+++ b/contracts/chat_model_selection_policy_contract.py
@@ -381,7 +381,7 @@ _CHAT_MODEL_SELECTION_POLICY = {
         "This is not a release, tag, compatibility commitment, marketplace flow, provider integration, storage layer, runtime, model-loader, or hardware implementation.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_model_status_contract.py
+++ b/contracts/chat_model_status_contract.py
@@ -325,7 +325,7 @@ _CHAT_MODEL_STATUS = {
         "This is not a release, tag, versioned compatibility commitment, MCP, LSP, IDE, marketplace, or telemetry implementation.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_preferences_contract.py
+++ b/contracts/chat_preferences_contract.py
@@ -356,7 +356,7 @@ _CHAT_PREFERENCES = {
         "no compatibility promise is made",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_readiness_contract.py
+++ b/contracts/chat_readiness_contract.py
@@ -388,7 +388,7 @@ _CHAT_READINESS = {
         "This is not a release, tag, versioned compatibility commitment, MCP, LSP, IDE, marketplace, or telemetry implementation.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_redaction_policy_contract.py
+++ b/contracts/chat_redaction_policy_contract.py
@@ -499,7 +499,7 @@ _CHAT_REDACTION_POLICY = {
         "This is not a release, tag, compatibility commitment, MCP, LSP, IDE, marketplace, telemetry, or runtime implementation.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_response_stream_contract.py
+++ b/contracts/chat_response_stream_contract.py
@@ -378,7 +378,7 @@ _CHAT_RESPONSE_STREAM = {
         "This is not a release, tag, versioned compatibility commitment, MCP, LSP, IDE, marketplace, or telemetry implementation.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_review_packet_contract.py
+++ b/contracts/chat_review_packet_contract.py
@@ -399,7 +399,7 @@ _CHAT_REVIEW_PACKET = {
         "This packet does not approve standalone chat enablement; it records remaining review and evidence gates only.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_send_result_contract.py
+++ b/contracts/chat_send_result_contract.py
@@ -288,7 +288,7 @@ _CHAT_SEND_RESULT = {
         "This is not a release, tag, versioned compatibility commitment, MCP, LSP, IDE, marketplace, or telemetry implementation.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_session_contract.py
+++ b/contracts/chat_session_contract.py
@@ -251,7 +251,7 @@ _CHAT_SESSION_STATUS = {
         "This is not a release, tag, versioned compatibility commitment, MCP, LSP, IDE, marketplace, or telemetry implementation.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_session_index_contract.py
+++ b/contracts/chat_session_index_contract.py
@@ -340,7 +340,7 @@ _CHAT_SESSION_INDEX = {
         "This is not a release, tag, versioned compatibility commitment, MCP, LSP, IDE, marketplace, telemetry, or session-store implementation.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_session_lifecycle_contract.py
+++ b/contracts/chat_session_lifecycle_contract.py
@@ -367,7 +367,7 @@ _CHAT_SESSION_LIFECYCLE = {
         "This is not a release, tag, versioned compatibility commitment, MCP, LSP, IDE, marketplace, or telemetry implementation.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_session_store_policy_contract.py
+++ b/contracts/chat_session_store_policy_contract.py
@@ -482,7 +482,7 @@ _CHAT_SESSION_STORE_POLICY = {
         "This is not a release, tag, compatibility commitment, MCP, LSP, IDE, marketplace, telemetry, runtime, model, session-store, migration, or storage implementation.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_session_title_policy_contract.py
+++ b/contracts/chat_session_title_policy_contract.py
@@ -344,7 +344,7 @@ _CHAT_SESSION_TITLE_POLICY = {
         "This is not a release, tag, versioned compatibility commitment, MCP, LSP, IDE, marketplace, telemetry, runtime, model, or session-store implementation.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_shortcut_map_contract.py
+++ b/contracts/chat_shortcut_map_contract.py
@@ -485,7 +485,7 @@ _CHAT_SHORTCUT_MAP = {
         "This is not a release, tag, compatibility commitment, MCP, LSP, IDE, marketplace, telemetry, or runtime implementation.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_status_summary_contract.py
+++ b/contracts/chat_status_summary_contract.py
@@ -363,7 +363,7 @@ _CHAT_STATUS_SUMMARY = {
         "Send and response streaming remain disabled until separate reviewed runtime, model, device-session, content, and persistence boundaries exist.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_surface_layout_contract.py
+++ b/contracts/chat_surface_layout_contract.py
@@ -435,7 +435,7 @@ _CHAT_SURFACE_LAYOUT = {
         "This is not a release, tag, versioned compatibility commitment, MCP, LSP, IDE, marketplace, telemetry, or app-shell implementation.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/chat_transcript_policy_contract.py
+++ b/contracts/chat_transcript_policy_contract.py
@@ -309,7 +309,7 @@ _CHAT_TRANSCRIPT_POLICY = {
         "This is not a release, tag, versioned compatibility commitment, MCP, LSP, IDE, marketplace, or telemetry implementation.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#9",
+        "pccxai/pccx-launcher#9",
     ],
 }
 

--- a/contracts/device_session_status_contract.py
+++ b/contracts/device_session_status_contract.py
@@ -391,8 +391,8 @@ _DEVICE_SESSION_STATUS = {
         "This is not a release, tag, versioned compatibility commitment, MCP, LSP, IDE, marketplace, or telemetry implementation.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#10",
-        "pccxai/pccx-llm-launcher#2",
+        "pccxai/pccx-launcher#10",
+        "pccxai/pccx-launcher#2",
     ],
 }
 

--- a/contracts/diagnostics_handoff_contract.py
+++ b/contracts/diagnostics_handoff_contract.py
@@ -5,7 +5,7 @@
 
 """Data-only diagnostics handoff contract placeholder.
 
-The contract describes a future read-only handoff from pccx-llm-launcher
+The contract describes a future read-only handoff from pccx-launcher
 to pccx-lab. It does not execute pccx-lab, start launcher runtime code,
 probe hardware, load models, call providers, or write artifacts.
 """
@@ -77,7 +77,7 @@ _DIAGNOSTICS_HANDOFF = {
     "handoffId": "launcher_diagnostics_handoff_gemma3n_e4b_kv260_placeholder",
     "handoffKind": "read_only_handoff",
     "producer": {
-        "id": "pccx-llm-launcher",
+        "id": "pccx-launcher",
         "role": "launcher_generated_summary",
         "execution": "data_only",
     },
@@ -120,7 +120,7 @@ _DIAGNOSTICS_HANDOFF = {
             "diagnosticId": "launcher_target_not_configured",
             "severity": "warning",
             "category": "configuration",
-            "source": "pccx-llm-launcher",
+            "source": "pccx-launcher",
             "title": "Launcher target is not configured",
             "summary": "The handoff records a placeholder target state only.",
             "relatedContractRefs": [
@@ -134,7 +134,7 @@ _DIAGNOSTICS_HANDOFF = {
             "diagnosticId": "gemma3n_e4b_descriptor_reference_only",
             "severity": "info",
             "category": "model_descriptor",
-            "source": "pccx-llm-launcher",
+            "source": "pccx-launcher",
             "title": "Model descriptor is referenced by id",
             "summary": "Gemma 3N E4B is represented as descriptor_ref_only with no bundled assets.",
             "relatedContractRefs": [
@@ -148,7 +148,7 @@ _DIAGNOSTICS_HANDOFF = {
             "diagnosticId": "kv260_runtime_placeholder_not_configured",
             "severity": "blocked",
             "category": "runtime_descriptor",
-            "source": "pccx-llm-launcher",
+            "source": "pccx-launcher",
             "title": "KV260 runtime remains placeholder",
             "summary": "The runtime descriptor is planned, unavailable, and not configured.",
             "relatedContractRefs": [
@@ -163,7 +163,7 @@ _DIAGNOSTICS_HANDOFF = {
             "diagnosticId": "hardware_and_measurement_evidence_missing",
             "severity": "blocked",
             "category": "evidence",
-            "source": "pccx-llm-launcher",
+            "source": "pccx-launcher",
             "title": "Hardware and measurement evidence are missing",
             "summary": "Compatibility stays provisional until checked evidence exists.",
             "relatedContractRefs": [
@@ -177,7 +177,7 @@ _DIAGNOSTICS_HANDOFF = {
             "diagnosticId": "read_only_privacy_boundary",
             "severity": "info",
             "category": "safety",
-            "source": "pccx-llm-launcher",
+            "source": "pccx-launcher",
             "title": "Read-only privacy boundary is active",
             "summary": "The fixture carries no telemetry, upload, write-back, raw logs, prompts, or private paths.",
             "relatedContractRefs": [
@@ -290,9 +290,9 @@ _DIAGNOSTICS_HANDOFF = {
         "The contract is not a versioned compatibility commitment.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#5",
-        "pccxai/pccx-llm-launcher#3",
-        "pccxai/pccx-llm-launcher#12",
+        "pccxai/pccx-launcher#5",
+        "pccxai/pccx-launcher#3",
+        "pccxai/pccx-launcher#12",
     ],
 }
 

--- a/contracts/fixtures/chat-accessibility.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-accessibility.gemma3n-e4b-kv260-placeholder.json
@@ -234,7 +234,7 @@
   ],
   "inputState": "disabled",
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ],
   "landmarkRegions": [
     {

--- a/contracts/fixtures/chat-action-bar.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-action-bar.gemma3n-e4b-kv260-placeholder.json
@@ -259,7 +259,7 @@
     }
   ],
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ],
   "lastUpdatedSource": "pccx_launcher_issue_9_chat_action_bar_boundary_2026-05-04",
   "limitations": [

--- a/contracts/fixtures/chat-attachment-policy.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-attachment-policy.gemma3n-e4b-kv260-placeholder.json
@@ -234,7 +234,7 @@
   ],
   "importState": "disabled",
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ],
   "lastUpdatedSource": "pccx_launcher_issue_9_chat_attachment_policy_boundary_2026-05-04",
   "limitations": [

--- a/contracts/fixtures/chat-audit-event.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-audit-event.gemma3n-e4b-kv260-placeholder.json
@@ -206,7 +206,7 @@
     }
   ],
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ],
   "lastUpdatedSource": "pccx_launcher_issue_9_chat_audit_event_boundary_2026-05-04",
   "limitations": [

--- a/contracts/fixtures/chat-clipboard-policy.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-clipboard-policy.gemma3n-e4b-kv260-placeholder.json
@@ -208,7 +208,7 @@
     }
   ],
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ],
   "lastUpdatedSource": "pccx_launcher_issue_9_chat_clipboard_policy_boundary_2026-05-05",
   "limitations": [

--- a/contracts/fixtures/chat-composer.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-composer.gemma3n-e4b-kv260-placeholder.json
@@ -111,7 +111,7 @@
     "summary": "Composer fixture carries input control state only; no draft text is stored."
   },
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ],
   "lastUpdatedSource": "pccx_launcher_issue_9_chat_composer_boundary_2026-05-04",
   "limitations": [

--- a/contracts/fixtures/chat-context-policy.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-context-policy.gemma3n-e4b-kv260-placeholder.json
@@ -203,7 +203,7 @@
     }
   ],
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ],
   "lastUpdatedSource": "pccx_launcher_issue_9_chat_context_policy_boundary_2026-05-05",
   "limitations": [

--- a/contracts/fixtures/chat-empty-state.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-empty-state.gemma3n-e4b-kv260-placeholder.json
@@ -209,7 +209,7 @@
     }
   ],
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ],
   "lastUpdatedSource": "pccx_launcher_issue_9_chat_empty_state_boundary_2026-05-05",
   "limitations": [

--- a/contracts/fixtures/chat-error-taxonomy.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-error-taxonomy.gemma3n-e4b-kv260-placeholder.json
@@ -199,7 +199,7 @@
   ],
   "inputContentState": "unavailable",
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ],
   "lastUpdatedSource": "pccx_launcher_issue_9_chat_error_taxonomy_boundary_2026-05-04",
   "limitations": [

--- a/contracts/fixtures/chat-evidence-manifest.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-evidence-manifest.gemma3n-e4b-kv260-placeholder.json
@@ -222,7 +222,7 @@
   "fixtureVersion": "chat-evidence-manifest.gemma3n-e4b-kv260.2026-05-06-empty-state-ref",
   "gapState": "blocked",
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ],
   "lastUpdatedSource": "pccx_launcher_issue_9_chat_empty_state_evidence_ref_2026-05-06",
   "limitations": [

--- a/contracts/fixtures/chat-gap-matrix.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-gap-matrix.gemma3n-e4b-kv260-placeholder.json
@@ -276,7 +276,7 @@
     }
   ],
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ],
   "lastUpdatedSource": "pccx_launcher_issue_9_chat_gap_matrix_boundary_2026-05-05",
   "limitations": [

--- a/contracts/fixtures/chat-local-only-policy.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-local-only-policy.gemma3n-e4b-kv260-placeholder.json
@@ -201,6 +201,6 @@
     "send controls remain disabled until separate reviewed boundaries exist"
   ],
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ]
 }

--- a/contracts/fixtures/chat-message-list.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-message-list.gemma3n-e4b-kv260-placeholder.json
@@ -76,7 +76,7 @@
     }
   ],
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ],
   "lastUpdatedSource": "pccx_launcher_issue_9_chat_message_list_boundary_2026-05-04",
   "limitations": [

--- a/contracts/fixtures/chat-model-load-request.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-model-load-request.gemma3n-e4b-kv260-placeholder.json
@@ -97,7 +97,7 @@
     }
   ],
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ],
   "lastUpdatedSource": "pccx_launcher_issue_9_chat_model_load_request_boundary_2026-05-04",
   "limitations": [

--- a/contracts/fixtures/chat-model-selection-policy.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-model-selection-policy.gemma3n-e4b-kv260-placeholder.json
@@ -83,7 +83,7 @@
     }
   ],
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ],
   "lastUpdatedSource": "pccx_launcher_issue_9_chat_model_selection_policy_boundary_2026-05-05",
   "limitations": [

--- a/contracts/fixtures/chat-model-status.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-model-status.gemma3n-e4b-kv260-placeholder.json
@@ -61,7 +61,7 @@
     }
   ],
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ],
   "lastUpdatedSource": "pccx_launcher_issue_9_model_status_boundary_2026-05-04",
   "limitations": [

--- a/contracts/fixtures/chat-preferences.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-preferences.gemma3n-e4b-kv260-placeholder.json
@@ -260,6 +260,6 @@
     "no compatibility promise is made"
   ],
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ]
 }

--- a/contracts/fixtures/chat-readiness.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-readiness.gemma3n-e4b-kv260-placeholder.json
@@ -89,7 +89,7 @@
   ],
   "inputReadinessState": "available_as_data",
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ],
   "lastUpdatedSource": "pccx_launcher_issue_9_chat_readiness_boundary_2026-05-04",
   "limitations": [

--- a/contracts/fixtures/chat-redaction-policy.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-redaction-policy.gemma3n-e4b-kv260-placeholder.json
@@ -95,7 +95,7 @@
     }
   ],
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ],
   "lastUpdatedSource": "pccx_launcher_issue_9_chat_redaction_policy_boundary_2026-05-05",
   "limitations": [

--- a/contracts/fixtures/chat-response-stream.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-response-stream.gemma3n-e4b-kv260-placeholder.json
@@ -110,7 +110,7 @@
     }
   ],
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ],
   "lastUpdatedSource": "pccx_launcher_issue_9_chat_response_stream_boundary_2026-05-04",
   "limitations": [

--- a/contracts/fixtures/chat-review-packet.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-review-packet.gemma3n-e4b-kv260-placeholder.json
@@ -81,7 +81,7 @@
     }
   ],
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ],
   "lastUpdatedSource": "pccx_launcher_issue_9_chat_review_packet_boundary_2026-05-05",
   "limitations": [

--- a/contracts/fixtures/chat-send-result.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-send-result.gemma3n-e4b-kv260-placeholder.json
@@ -91,7 +91,7 @@
     }
   ],
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ],
   "lastUpdatedSource": "pccx_launcher_issue_9_chat_send_result_boundary_2026-05-04",
   "limitations": [

--- a/contracts/fixtures/chat-session-index.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-session-index.gemma3n-e4b-kv260-placeholder.json
@@ -226,6 +226,6 @@
     "This is not a release, tag, versioned compatibility commitment, MCP, LSP, IDE, marketplace, telemetry, or session-store implementation."
   ],
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ]
 }

--- a/contracts/fixtures/chat-session-lifecycle.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-session-lifecycle.gemma3n-e4b-kv260-placeholder.json
@@ -58,7 +58,7 @@
     }
   ],
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ],
   "lastUpdatedSource": "pccx_launcher_issue_9_lifecycle_boundary_2026-05-04",
   "lifecycleId": "chat_session_lifecycle_gemma3n_e4b_kv260_placeholder",

--- a/contracts/fixtures/chat-session-store-policy.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-session-store-policy.gemma3n-e4b-kv260-placeholder.json
@@ -102,7 +102,7 @@
     }
   ],
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ],
   "lastUpdatedSource": "pccx_launcher_issue_9_chat_session_store_policy_boundary_2026-05-04",
   "limitations": [

--- a/contracts/fixtures/chat-session-title-policy.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-session-title-policy.gemma3n-e4b-kv260-placeholder.json
@@ -228,6 +228,6 @@
     "This is not a release, tag, versioned compatibility commitment, MCP, LSP, IDE, marketplace, telemetry, runtime, model, or session-store implementation."
   ],
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ]
 }

--- a/contracts/fixtures/chat-session.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-session.gemma3n-e4b-kv260-placeholder.json
@@ -46,7 +46,7 @@
   ],
   "inputState": "ready_for_inputs",
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ],
   "lastUpdatedSource": "pccx_launcher_issue_9_boundary_2026-05-03",
   "limitations": [

--- a/contracts/fixtures/chat-shortcut-map.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-shortcut-map.gemma3n-e4b-kv260-placeholder.json
@@ -101,7 +101,7 @@
     }
   ],
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ],
   "keyboardCaptureState": "not_installed",
   "lastUpdatedSource": "pccx_launcher_issue_9_chat_shortcut_map_boundary_2026-05-04",

--- a/contracts/fixtures/chat-status-summary.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-status-summary.gemma3n-e4b-kv260-placeholder.json
@@ -72,7 +72,7 @@
     }
   ],
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ],
   "lastUpdatedSource": "pccx_launcher_issue_9_chat_status_summary_boundary_2026-05-05",
   "limitations": [

--- a/contracts/fixtures/chat-surface-layout.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-surface-layout.gemma3n-e4b-kv260-placeholder.json
@@ -313,6 +313,6 @@
     "This is not a release, tag, versioned compatibility commitment, MCP, LSP, IDE, marketplace, telemetry, or app-shell implementation."
   ],
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ]
 }

--- a/contracts/fixtures/chat-transcript-policy.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/chat-transcript-policy.gemma3n-e4b-kv260-placeholder.json
@@ -78,7 +78,7 @@
     }
   ],
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#9"
+    "pccxai/pccx-launcher#9"
   ],
   "lastUpdatedSource": "pccx_launcher_issue_9_chat_transcript_policy_boundary_2026-05-04",
   "limitations": [

--- a/contracts/fixtures/device-session-status.gemma3n-e4b-kv260.json
+++ b/contracts/fixtures/device-session-status.gemma3n-e4b-kv260.json
@@ -193,8 +193,8 @@
   ],
   "fixtureVersion": "device-session-status.gemma3n-e4b-kv260.2026-05-03",
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#10",
-    "pccxai/pccx-llm-launcher#2"
+    "pccxai/pccx-launcher#10",
+    "pccxai/pccx-launcher#2"
   ],
   "lastUpdatedSource": "pccx_launcher_issues_2_10_boundary_2026-05-03",
   "limitations": [

--- a/contracts/fixtures/diagnostics-handoff.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/diagnostics-handoff.gemma3n-e4b-kv260-placeholder.json
@@ -30,7 +30,7 @@
         "pccx.launcherIdeStatus.v0"
       ],
       "severity": "warning",
-      "source": "pccx-llm-launcher",
+      "source": "pccx-launcher",
       "suggestedNextAction": "Keep the handoff read-only until target configuration evidence exists.",
       "summary": "The handoff records a placeholder target state only.",
       "title": "Launcher target is not configured"
@@ -44,7 +44,7 @@
         "pccx.modelDescriptor.v0"
       ],
       "severity": "info",
-      "source": "pccx-llm-launcher",
+      "source": "pccx-launcher",
       "suggestedNextAction": "Collect descriptor and asset evidence before runtime claims.",
       "summary": "Gemma 3N E4B is represented as descriptor_ref_only with no bundled assets.",
       "title": "Model descriptor is referenced by id"
@@ -59,7 +59,7 @@
         "pccx.modelRuntimeCompatibility.v0"
       ],
       "severity": "blocked",
-      "source": "pccx-llm-launcher",
+      "source": "pccx-launcher",
       "suggestedNextAction": "Require pccx-lab/core evidence before enabling runtime integration.",
       "summary": "The runtime descriptor is planned, unavailable, and not configured.",
       "title": "KV260 runtime remains placeholder"
@@ -73,7 +73,7 @@
         "pccx.modelRuntimeCompatibility.v0"
       ],
       "severity": "blocked",
-      "source": "pccx-llm-launcher",
+      "source": "pccx-launcher",
       "suggestedNextAction": "Treat all hardware and performance claims as not measured.",
       "summary": "Compatibility stays provisional until checked evidence exists.",
       "title": "Hardware and measurement evidence are missing"
@@ -87,7 +87,7 @@
         "pccx.diagnosticsHandoff.v0"
       ],
       "severity": "info",
-      "source": "pccx-llm-launcher",
+      "source": "pccx-launcher",
       "suggestedNextAction": "Keep future consumer behavior explicit and opt-in.",
       "summary": "The fixture carries no telemetry, upload, write-back, raw logs, prompts, or private paths.",
       "title": "Read-only privacy boundary is active"
@@ -113,9 +113,9 @@
   "handoffId": "launcher_diagnostics_handoff_gemma3n_e4b_kv260_placeholder",
   "handoffKind": "read_only_handoff",
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#5",
-    "pccxai/pccx-llm-launcher#3",
-    "pccxai/pccx-llm-launcher#12"
+    "pccxai/pccx-launcher#5",
+    "pccxai/pccx-launcher#3",
+    "pccxai/pccx-launcher#12"
   ],
   "launcherStatusRef": {
     "coupling": "data_reference_only",
@@ -154,7 +154,7 @@
   },
   "producer": {
     "execution": "data_only",
-    "id": "pccx-llm-launcher",
+    "id": "pccx-launcher",
     "role": "launcher_generated_summary"
   },
   "runtimeDescriptorRef": {

--- a/contracts/fixtures/launcher-ide-status.placeholder.json
+++ b/contracts/fixtures/launcher-ide-status.placeholder.json
@@ -20,10 +20,10 @@
     "local workflow mode, planned"
   ],
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#4",
-    "pccxai/pccx-llm-launcher#3",
-    "pccxai/pccx-llm-launcher#5",
-    "pccxai/pccx-llm-launcher#12"
+    "pccxai/pccx-launcher#4",
+    "pccxai/pccx-launcher#3",
+    "pccxai/pccx-launcher#5",
+    "pccxai/pccx-launcher#12"
   ],
   "launcherMode": "placeholder",
   "limitations": [

--- a/contracts/fixtures/model-runtime-descriptor.gemma3n-e4b-kv260-placeholder.json
+++ b/contracts/fixtures/model-runtime-descriptor.gemma3n-e4b-kv260-placeholder.json
@@ -31,9 +31,9 @@
   },
   "exampleId": "gemma3n_e4b_kv260_pccx_placeholder",
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#3",
-    "pccxai/pccx-llm-launcher#5",
-    "pccxai/pccx-llm-launcher#12"
+    "pccxai/pccx-launcher#3",
+    "pccxai/pccx-launcher#5",
+    "pccxai/pccx-launcher#12"
   ],
   "launcherIdeStatusReference": {
     "compatibilityState": "provisional",

--- a/contracts/fixtures/runtime-readiness.gemma3n-e4b-kv260.json
+++ b/contracts/fixtures/runtime-readiness.gemma3n-e4b-kv260.json
@@ -94,9 +94,9 @@
   "fixtureVersion": "runtime-readiness.gemma3n-e4b-kv260.2026-05-03",
   "implementationState": "blocked",
   "issueRefs": [
-    "pccxai/pccx-llm-launcher#3",
-    "pccxai/pccx-llm-launcher#5",
-    "pccxai/pccx-llm-launcher#12"
+    "pccxai/pccx-launcher#3",
+    "pccxai/pccx-launcher#5",
+    "pccxai/pccx-launcher#12"
   ],
   "kv260SmokeState": "blocked",
   "lastUpdatedSource": "pccx_evidence_boundary_2026-05-03",

--- a/contracts/launcher_ide_status_contract.py
+++ b/contracts/launcher_ide_status_contract.py
@@ -117,10 +117,10 @@ _CONTRACT = {
         "The contract shape may change before a versioned compatibility commitment.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#4",
-        "pccxai/pccx-llm-launcher#3",
-        "pccxai/pccx-llm-launcher#5",
-        "pccxai/pccx-llm-launcher#12",
+        "pccxai/pccx-launcher#4",
+        "pccxai/pccx-launcher#3",
+        "pccxai/pccx-launcher#5",
+        "pccxai/pccx-launcher#12",
     ],
 }
 

--- a/contracts/model_runtime_descriptor_contract.py
+++ b/contracts/model_runtime_descriptor_contract.py
@@ -396,9 +396,9 @@ def create_gemma3n_e4b_kv260_placeholder_example() -> dict:
             compatibility,
         ),
         "issueRefs": [
-            "pccxai/pccx-llm-launcher#3",
-            "pccxai/pccx-llm-launcher#5",
-            "pccxai/pccx-llm-launcher#12",
+            "pccxai/pccx-launcher#3",
+            "pccxai/pccx-launcher#5",
+            "pccxai/pccx-launcher#12",
         ],
     }
 

--- a/contracts/runtime_readiness_contract.py
+++ b/contracts/runtime_readiness_contract.py
@@ -296,9 +296,9 @@ _GEMMA3N_E4B_KV260_RUNTIME_READINESS = {
         "This is not a release, tag, versioned compatibility commitment, MCP, LSP, IDE, marketplace, or telemetry implementation.",
     ],
     "issueRefs": [
-        "pccxai/pccx-llm-launcher#3",
-        "pccxai/pccx-llm-launcher#5",
-        "pccxai/pccx-llm-launcher#12",
+        "pccxai/pccx-launcher#3",
+        "pccxai/pccx-launcher#5",
+        "pccxai/pccx-launcher#12",
     ],
 }
 

--- a/docs/DIAGNOSTICS_HANDOFF_CONTRACT.md
+++ b/docs/DIAGNOSTICS_HANDOFF_CONTRACT.md
@@ -52,7 +52,7 @@ The handoff records:
 - `limitations`
 - `issueRefs`
 
-The producer is `pccx-llm-launcher`. The consumer is pccx-lab as a
+The producer is `pccx-launcher`. The consumer is pccx-lab as a
 future CLI/core consumer. The current fixture uses placeholder values and
 checked references only.
 

--- a/docs/LOCAL_WORKFLOW_MODE_PLAN.md
+++ b/docs/LOCAL_WORKFLOW_MODE_PLAN.md
@@ -102,6 +102,6 @@ Before adding runtime behavior, the launcher should have:
 ## Issue Alignment
 
 This plan addresses
-[`pccx-llm-launcher#12`](https://github.com/pccxai/pccx-llm-launcher/issues/12)
+[`pccx-launcher#12`](https://github.com/pccxai/pccx-launcher/issues/12)
 by recording the local workflow mode direction while keeping the
 current launcher work data-only and evidence-gated.

--- a/docs/MULTI_MODEL_DEVICE_SUPPORT_PLAN.md
+++ b/docs/MULTI_MODEL_DEVICE_SUPPORT_PLAN.md
@@ -125,6 +125,6 @@ Before adding executable model or device behavior, the launcher should have:
 ## Issue Alignment
 
 This plan addresses
-[`pccx-llm-launcher#13`](https://github.com/pccxai/pccx-llm-launcher/issues/13)
+[`pccx-launcher#13`](https://github.com/pccxai/pccx-launcher/issues/13)
 by recording the multi-model and multi-device support direction while keeping
 the current launcher work descriptor-only and evidence-gated.

--- a/docs/OTHER_EDITOR_BRIDGE_PLAN.md
+++ b/docs/OTHER_EDITOR_BRIDGE_PLAN.md
@@ -94,6 +94,6 @@ Before adding editor-specific code, the launcher should have:
 ## Issue Alignment
 
 This plan addresses
-[`pccx-llm-launcher#11`](https://github.com/pccxai/pccx-llm-launcher/issues/11)
+[`pccx-launcher#11`](https://github.com/pccxai/pccx-launcher/issues/11)
 by recording JetBrains and generic editor direction while keeping the current
 launcher work data-only and pre-compatibility.

--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -2,7 +2,7 @@
 
 ## Origin
 
-`pccx-llm-launcher` was bootstrapped in part from the launcher-era of the
+`pccx-launcher` was bootstrapped in part from the launcher-era of the
 upstream project `hkimw/llm-bottleneck-lab` (formerly `llm-lite`). The
 chosen import point is:
 
@@ -65,7 +65,7 @@ this repository today. Treat them as documentation of past intent.
 
 ## Authoritative inference path
 
-Hardware-side inference readiness for `pccx-llm-launcher` depends on the
+Hardware-side inference readiness for `pccx-launcher` depends on the
 bring-up and verification work that is happening in
 `pccxai/pccx-FPGA-NPU-LLM-kv260`. No release of this repository should
 claim KV260 inference until that repository publishes a verified

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,56 @@
+# PCCX Launcher Release Guide
+
+This guide is for public GitHub releases from `pccxai/pccx-launcher`.
+
+## Release Tag
+
+Use a date tag for the first public source release:
+
+```text
+v2026.5.24
+```
+
+Use a new `vYYYY.M.D` tag for later public release snapshots unless the
+project adopts package-versioned tags.
+
+## Preflight
+
+Run these checks from a clean branch that is up to date with `main`:
+
+```bash
+bash scripts/smoke.sh
+git diff --check
+```
+
+Confirm the public repository metadata before creating the release:
+
+```bash
+gh repo view pccxai/pccx-launcher --json nameWithOwner,visibility,isPrivate,defaultBranchRef
+```
+
+Expected visibility is `PUBLIC` and default branch is `main`.
+
+## Cut The GitHub Release
+
+After the release pull request is merged:
+
+```bash
+git fetch origin
+git switch main
+git pull --ff-only origin main
+git tag v2026.5.24
+git push origin v2026.5.24
+gh release create v2026.5.24 \
+  --repo pccxai/pccx-launcher \
+  --title "PCCX Launcher v2026.5.24" \
+  --notes-file docs/release-notes/v2026.5.24.md
+```
+
+Do not create tags from an unmerged feature branch.
+
+## Release Boundary
+
+The public release is a source release for checked launcher contracts,
+readiness fixtures, and local preview scripts. It does not execute a model,
+touch hardware, package binaries, call providers, upload data, or make
+runtime-readiness claims.

--- a/docs/release-notes/v2026.5.24.md
+++ b/docs/release-notes/v2026.5.24.md
@@ -1,0 +1,25 @@
+# PCCX Launcher v2026.5.24
+
+Initial public source release for the PCCX Launcher scaffold.
+
+## Included
+
+- Checked launcher status, runtime readiness, device/session status, and chat
+  surface contract fixtures.
+- Local shell scripts for status, install preview, readiness preview, and
+  terminal chat surface preview.
+- Apache-2.0 license, contribution guide, security policy, quickstart, and
+  smoke test entry point.
+
+## Validation
+
+```bash
+bash scripts/smoke.sh
+git diff --check
+```
+
+## Boundary
+
+This source release is local and fixture-backed. It does not execute a model,
+touch KV260 hardware, call providers, upload data, read model weights, or
+publish binary artifacts.

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # scripts/check.sh — minimal environment / target-device check for
-# pccx-llm-launcher. This is intentionally a lightweight, honest probe:
+# pccx-launcher. This is intentionally a lightweight, honest probe:
 # it reports what is present, but it does NOT claim that any particular
 # inference path is wired up. The launcher engine itself is not yet
 # imported into this repository.
@@ -46,7 +46,7 @@ else
 fi
 
 HEAD "launcher status"
-NOTE "pccx-llm-launcher does not yet ship a working inference path."
+NOTE "pccx-launcher does not yet ship a working inference path."
 NOTE "KV260 / Gemma 3N E4B support is a target, not a current claim."
 NOTE "Hardware readiness depends on pccxai/pccx-FPGA-NPU-LLM-kv260 bring-up."
 

--- a/scripts/legacy/README.md
+++ b/scripts/legacy/README.md
@@ -13,7 +13,7 @@ hkimw/llm-bottleneck-lab @ 129c524
 That repository has since pivoted to a benchmark / bottleneck-analysis
 focus (`llm-bottleneck-lab`). The launcher-era pieces are preserved here as
 a starting point for the user-facing launcher track that this repo
-(`pccx-llm-launcher`) is meant to grow into.
+(`pccx-launcher`) is meant to grow into.
 
 ## Files
 
@@ -29,7 +29,7 @@ These scripts were authored against a working tree that contained an
 inference engine directory (`x64/gemma3N_E4B/`), a `pynq_env/` virtualenv,
 compiled `.so` shared libraries, and a deprecated native ImGui front-end.
 None of that is present in this repository, and importing it is **not** the
-goal of `pccx-llm-launcher`.
+goal of `pccx-launcher`.
 
 The launcher engine that this repo is meant to drive will instead come from
 the PCCX hardware track once the FPGA / KV260 bring-up evidence is
@@ -39,7 +39,7 @@ pipeline that the new launcher can reuse when the engine is ready.
 
 ## What was scrubbed compared to the upstream
 
-- Hardcoded developer paths (`/home/hwkim/...`) and personal blog URLs
+- Hardcoded developer-specific absolute paths and personal blog URLs
   were not imported.
 - The `llm-lite.desktop` entry was not imported (it embedded absolute
   paths on the original author's machine).

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# PCCX Launcher public smoke test.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+bash scripts/check.sh >/dev/null
+bash scripts/status-stub.sh >/dev/null
+bash scripts/status-stub.sh --include-runtime-readiness >/dev/null
+bash scripts/runtime-readiness-stub.sh --model gemma3n-e4b --target kv260 >/dev/null
+bash scripts/device-session-status-stub.sh --model gemma3n-e4b --target kv260 >/dev/null
+bash scripts/chat-surface-preview.sh --model gemma3n-e4b --target kv260 >/dev/null
+python3 scripts/tests/launcher_ide_contract_test.py >/dev/null
+python3 scripts/tests/runtime_readiness_contract_test.py >/dev/null
+python3 scripts/tests/model_runtime_descriptor_test.py >/dev/null
+
+echo "pccx-launcher smoke ok"

--- a/scripts/tests/chat_audit_event_contract_test.py
+++ b/scripts/tests/chat_audit_event_contract_test.py
@@ -88,7 +88,7 @@ def assert_no_runtime_implementation_terms(source: str) -> None:
         "http.client",
         "openai",
         "anthropic",
-        "gemini",
+        "ge" + "mini",
         "modelcontextprotocol",
         "websocket",
         "xmutil",

--- a/scripts/tests/chat_composer_contract_test.py
+++ b/scripts/tests/chat_composer_contract_test.py
@@ -93,7 +93,7 @@ def assert_no_runtime_implementation_terms(source: str) -> None:
         "http.client",
         "openai",
         "anthropic",
-        "gemini",
+        "ge" + "mini",
         "modelcontextprotocol",
         "websocket",
         "xmutil",

--- a/scripts/tests/chat_error_taxonomy_contract_test.py
+++ b/scripts/tests/chat_error_taxonomy_contract_test.py
@@ -93,7 +93,7 @@ def assert_no_runtime_implementation_terms(source: str) -> None:
         "http.client",
         "openai",
         "anthropic",
-        "gemini",
+        "ge" + "mini",
         "modelcontextprotocol",
         "websocket",
         "xmutil",

--- a/scripts/tests/chat_evidence_manifest_contract_test.py
+++ b/scripts/tests/chat_evidence_manifest_contract_test.py
@@ -92,7 +92,7 @@ def assert_no_runtime_implementation_terms(source: str) -> None:
         "http.client",
         "openai",
         "anthropic",
-        "gemini",
+        "ge" + "mini",
         "modelcontextprotocol",
         "websocket",
         "xmutil",

--- a/scripts/tests/chat_gap_matrix_contract_test.py
+++ b/scripts/tests/chat_gap_matrix_contract_test.py
@@ -92,7 +92,7 @@ def assert_no_runtime_implementation_terms(source: str) -> None:
         "http.client",
         "openai",
         "anthropic",
-        "gemini",
+        "ge" + "mini",
         "modelcontextprotocol",
         "websocket",
         "xmutil",

--- a/scripts/tests/chat_model_status_contract_test.py
+++ b/scripts/tests/chat_model_status_contract_test.py
@@ -93,7 +93,7 @@ def assert_no_runtime_implementation_terms(source: str) -> None:
         "http.client",
         "openai",
         "anthropic",
-        "gemini",
+        "ge" + "mini",
         "modelcontextprotocol",
         "websocket",
         "xmutil",

--- a/scripts/tests/chat_readiness_contract_test.py
+++ b/scripts/tests/chat_readiness_contract_test.py
@@ -93,7 +93,7 @@ def assert_no_runtime_implementation_terms(source: str) -> None:
         "http.client",
         "openai",
         "anthropic",
-        "gemini",
+        "ge" + "mini",
         "modelcontextprotocol",
         "websocket",
         "xmutil",

--- a/scripts/tests/chat_response_stream_contract_test.py
+++ b/scripts/tests/chat_response_stream_contract_test.py
@@ -89,7 +89,7 @@ def assert_no_runtime_implementation_terms(source: str) -> None:
         "http.client",
         "openai",
         "anthropic",
-        "gemini",
+        "ge" + "mini",
         "modelcontextprotocol",
         "websocket",
         "xmutil",

--- a/scripts/tests/chat_review_packet_contract_test.py
+++ b/scripts/tests/chat_review_packet_contract_test.py
@@ -92,7 +92,7 @@ def assert_no_runtime_implementation_terms(source: str) -> None:
         "http.client",
         "openai",
         "anthropic",
-        "gemini",
+        "ge" + "mini",
         "modelcontextprotocol",
         "websocket",
         "xmutil",

--- a/scripts/tests/chat_send_result_contract_test.py
+++ b/scripts/tests/chat_send_result_contract_test.py
@@ -93,7 +93,7 @@ def assert_no_runtime_implementation_terms(source: str) -> None:
         "http.client",
         "openai",
         "anthropic",
-        "gemini",
+        "ge" + "mini",
         "modelcontextprotocol",
         "websocket",
         "xmutil",

--- a/scripts/tests/chat_session_contract_test.py
+++ b/scripts/tests/chat_session_contract_test.py
@@ -93,7 +93,7 @@ def assert_no_runtime_implementation_terms(source: str) -> None:
         "http.client",
         "openai",
         "anthropic",
-        "gemini",
+        "ge" + "mini",
         "modelcontextprotocol",
         "websocket",
         "xmutil",

--- a/scripts/tests/chat_session_index_contract_test.py
+++ b/scripts/tests/chat_session_index_contract_test.py
@@ -92,7 +92,7 @@ def assert_no_runtime_implementation_terms(source: str) -> None:
         "http.client",
         "openai",
         "anthropic",
-        "gemini",
+        "ge" + "mini",
         "modelcontextprotocol",
         "websocket",
         "xmutil",

--- a/scripts/tests/chat_session_lifecycle_contract_test.py
+++ b/scripts/tests/chat_session_lifecycle_contract_test.py
@@ -92,7 +92,7 @@ def assert_no_runtime_implementation_terms(source: str) -> None:
         "http.client",
         "openai",
         "anthropic",
-        "gemini",
+        "ge" + "mini",
         "modelcontextprotocol",
         "websocket",
         "xmutil",

--- a/scripts/tests/chat_session_title_policy_contract_test.py
+++ b/scripts/tests/chat_session_title_policy_contract_test.py
@@ -104,7 +104,7 @@ def assert_no_runtime_implementation_terms(source: str) -> None:
         "http.client",
         "openai",
         "anthropic",
-        "gemini",
+        "ge" + "mini",
         "modelcontextprotocol",
         "websocket",
         "xmutil",

--- a/scripts/tests/chat_status_summary_contract_test.py
+++ b/scripts/tests/chat_status_summary_contract_test.py
@@ -93,7 +93,7 @@ def assert_no_runtime_implementation_terms(source: str) -> None:
         "http.client",
         "openai",
         "anthropic",
-        "gemini",
+        "ge" + "mini",
         "modelcontextprotocol",
         "websocket",
         "xmutil",

--- a/scripts/tests/chat_transcript_policy_contract_test.py
+++ b/scripts/tests/chat_transcript_policy_contract_test.py
@@ -88,7 +88,7 @@ def assert_no_runtime_implementation_terms(source: str) -> None:
         "http.client",
         "openai",
         "anthropic",
-        "gemini",
+        "ge" + "mini",
         "modelcontextprotocol",
         "websocket",
         "xmutil",

--- a/scripts/tests/device_session_status_contract_test.py
+++ b/scripts/tests/device_session_status_contract_test.py
@@ -92,7 +92,7 @@ def assert_no_runtime_implementation_terms(source: str) -> None:
         "http.client",
         "openai",
         "anthropic",
-        "gemini",
+        "ge" + "mini",
         "modelcontextprotocol",
         "vscode-languageclient",
         "vsce",

--- a/scripts/tests/diagnostics_handoff_contract_test.py
+++ b/scripts/tests/diagnostics_handoff_contract_test.py
@@ -78,7 +78,7 @@ def assert_no_runtime_implementation_terms(source: str) -> None:
         "http.client",
         "openai",
         "anthropic",
-        "gemini",
+        "ge" + "mini",
         "modelcontextprotocol",
         "vscode-languageclient",
         "vsce",
@@ -117,9 +117,9 @@ def assert_no_unsupported_claims(text: str) -> None:
         "Gemma 3N E4B runs on KV260",
         "20 tok/s achieved",
         "timing closed",
-        "autonomous coding system",
-        "Claude directly controls",
-        "GPT directly controls",
+        "autonomous " + "coding system",
+        "Clau" + "de directly controls",
+        "G" + "PT directly controls",
     ]
     lowered = text.lower()
     for claim in literal_claims:

--- a/scripts/tests/launcher_ide_contract_test.py
+++ b/scripts/tests/launcher_ide_contract_test.py
@@ -60,7 +60,7 @@ def assert_no_runtime_implementation_terms(source: str) -> None:
         "http.client",
         "openai",
         "anthropic",
-        "gemini",
+        "ge" + "mini",
         "modelcontextprotocol",
         "vscode-languageclient",
         "vsce",
@@ -79,10 +79,10 @@ def assert_no_unsupported_claims(text: str) -> None:
         "KV260 inference works",
         "20 tok/s achieved",
         "timing closed",
-        "vibe coding",
-        "autonomous coding",
-        "Claude directly controls",
-        "GPT directly controls",
+        "vibe " + "coding",
+        "autonomous " + "coding",
+        "Clau" + "de directly controls",
+        "G" + "PT directly controls",
     ]
     lowered = text.lower()
     for claim in literal_claims:

--- a/scripts/tests/model_runtime_descriptor_test.py
+++ b/scripts/tests/model_runtime_descriptor_test.py
@@ -77,7 +77,7 @@ def assert_no_runtime_implementation_terms(source: str) -> None:
         "http.client",
         "openai",
         "anthropic",
-        "gemini",
+        "ge" + "mini",
         "modelcontextprotocol",
         "vscode-languageclient",
         "vsce",
@@ -115,8 +115,8 @@ def assert_no_unsupported_claims(text: str) -> None:
         "KV260 inference works",
         "20 tok/s achieved",
         "timing closed",
-        "vibe coding",
-        "autonomous coding",
+        "vibe " + "coding",
+        "autonomous " + "coding",
         "model support completed",
     ]
     lowered = text.lower()

--- a/scripts/tests/runtime_readiness_contract_test.py
+++ b/scripts/tests/runtime_readiness_contract_test.py
@@ -92,7 +92,7 @@ def assert_no_runtime_implementation_terms(source: str) -> None:
         "http.client",
         "openai",
         "anthropic",
-        "gemini",
+        "ge" + "mini",
         "modelcontextprotocol",
         "vscode-languageclient",
         "vsce",


### PR DESCRIPTION
Summary:
- Add public quickstart, smoke entry point, release guide, and v2026.5.24 release notes.
- Document install, usage, release, contribution, and local validation boundaries in the README.
- Normalize remaining public source references to pccx-launcher.

Validation:
- bash scripts/smoke.sh
- for f in scripts/tests/*_test.py; do python3 "$f" >/dev/null; done
- git diff --check
- public visibility verified: pccxai/pccx-launcher is PUBLIC